### PR TITLE
add postgres and simple examples

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,13 +2,13 @@
 
 name: Build
 
-# Controls when the action will run. 
+# Controls when the action will run.
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -19,6 +19,22 @@ jobs:
   build:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
+
+    services:
+      # Postgres config taken from GitHub Actions help docs:
+      # https://help.github.com/en/actions/configuring-and-managing-workflows/creating-postgresql-service-containers
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_DB: felt
+          POSTGRES_PASSWORD: password
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -33,4 +49,4 @@ jobs:
       - name: Build & test the project
         run: |
           npx gro build
-          npx gro check        
+          npx gro check

--- a/package-lock.json
+++ b/package-lock.json
@@ -887,6 +887,11 @@
         "source-map": "^0.6.1"
       }
     },
+    "postgres": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/postgres/-/postgres-1.0.2.tgz",
+      "integrity": "sha512-zeLgt42KSUNgX/uvo+gbVxTAYwgSY6MIKuU/a8YWuObX4rtGuKrVWopvEAqIAPSO0FeHS1TsSKnqPjoufPy8NA=="
+    },
     "prettier": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "body-parser": "^1.19.0",
     "cookie-session": "^1.4.0",
     "polka": "^1.0.0-next.13",
+    "postgres": "^1.0.2",
     "sirv": "^1.0.11"
   },
   "prettier": {

--- a/src/db/Database.ts
+++ b/src/db/Database.ts
@@ -1,12 +1,11 @@
 import type {Result} from '@feltcoop/gro';
 import {unwrap} from '@feltcoop/gro';
 import {readFileSync, writeFileSync} from 'fs';
-import postgres from 'postgres';
 
 import type {UserSession} from '../session/clientSession.js';
 import type {User} from '../vocab/user/user.js';
 import type {Entity} from '../vocab/entity/entity.js';
-import type {PostgresOptions, PostgresSql} from './postgres.js';
+import type {PostgresSql} from './postgres.js';
 
 interface Data {
 	users: User[];
@@ -46,15 +45,15 @@ const getInitialData = (): Data => ({
 });
 
 export interface Options {
-	postgresOptions: string | PostgresOptions;
+	sql: PostgresSql;
 }
 
 export class Database {
 	sql: PostgresSql;
 
-	constructor({postgresOptions}: Options) {
+	constructor({sql}: Options) {
 		console.log('[db] create');
-		this.sql = postgres(postgresOptions);
+		this.sql = sql;
 	}
 	async init(): Promise<void> {
 		console.log('[db] init');

--- a/src/db/Database.ts
+++ b/src/db/Database.ts
@@ -61,7 +61,7 @@ export class Database {
 
 		// example: create table
 		const createAccountsTableResult = await sql`
-			CREATE TABLE IF NOT EXISTS accounts ( 
+			create table if not exists accounts (
 				name text,
 				password text
 			)

--- a/src/db/Database.ts
+++ b/src/db/Database.ts
@@ -46,16 +46,15 @@ const getInitialData = (): Data => ({
 });
 
 export interface Options {
-	postgresUrl?: string;
-	postgresOptions?: PostgresOptions;
+	postgresOptions: string | PostgresOptions;
 }
 
 export class Database {
 	sql: PostgresSql;
 
-	constructor({postgresUrl, postgresOptions}: Options = {}) {
+	constructor({postgresOptions}: Options) {
 		console.log('[db] create');
-		this.sql = postgresUrl ? postgres(postgresUrl, postgresOptions) : postgres(postgresOptions);
+		this.sql = postgres(postgresOptions);
 	}
 	async init(): Promise<void> {
 		console.log('[db] init');
@@ -120,6 +119,7 @@ export class Database {
 	}
 	async destroy(): Promise<void> {
 		console.log('[db] destroy');
+		await this.sql.end();
 	}
 	// TODO declaring like this is weird, should be static, but not sure what interface is best
 	repos = {

--- a/src/db/Database.ts
+++ b/src/db/Database.ts
@@ -55,68 +55,12 @@ export class Database {
 		console.log('[db] create');
 		this.sql = sql;
 	}
-	async init(): Promise<void> {
-		console.log('[db] init');
-		const {sql} = this;
 
-		// example: create table
-		const createAccountsTableResult = await sql`
-			create table if not exists accounts (
-				name text,
-				password text
-			)
-		`;
-		if (createAccountsTableResult.count) {
-			console.log('[db] createAccountsTableResult', createAccountsTableResult);
-		}
-
-		// example: select
-		interface AccountDoc {
-			name: string;
-			password: string;
-		}
-		const accountDocs: AccountDoc[] = await sql`
-			select name, password from accounts
-		`;
-		console.log('[db] accountDocs', accountDocs);
-
-		// example: insert literal values
-		const account1Doc = accountDocs.find((d) => d.name === 'account1');
-		if (!account1Doc) {
-			const account1InitialData = {name: 'account1', password: 'HASHVALUE1'};
-			const createAccount1Result = await sql`
-				insert into accounts (
-					name, password
-				) values (
-					${account1InitialData.name}, ${account1InitialData.password}
-				)
-			`;
-			console.log('[db] createAccount1Result', createAccount1Result);
-		}
-
-		// example: insert with dynamic query helper
-		const account2Doc = accountDocs.find((d) => d.name === 'account2');
-		if (!account2Doc) {
-			const account2: AccountDoc = {name: 'account2', password: 'HASHVALUE2'};
-			const account2Result = await sql`
-				insert into accounts ${sql(account2, 'name', 'password')}
-			`;
-			console.log('[db] createAccount2Result', account2Result);
-		}
-
-		// example: select after inserting
-		// don't double print:
-		if (!accountDocs.length) {
-			const accountDocs: AccountDoc[] = await sql`
-				select name, password from accounts
-			`;
-			console.log('[db] accountDocs', accountDocs);
-		}
-	}
 	async destroy(): Promise<void> {
 		console.log('[db] destroy');
 		await this.sql.end();
 	}
+
 	// TODO declaring like this is weird, should be static, but not sure what interface is best
 	repos = {
 		session: {

--- a/src/db/Database.ts
+++ b/src/db/Database.ts
@@ -107,10 +107,6 @@ export class Database {
 		// example: select after inserting
 		// don't double print:
 		if (!accountDocs.length) {
-			interface AccountDoc {
-				name: string;
-				password: string;
-			}
 			const accountDocs: AccountDoc[] = await sql`
 				select name, password from accounts
 			`;

--- a/src/db/Database.ts
+++ b/src/db/Database.ts
@@ -104,8 +104,9 @@ export class Database {
 			console.log('[db] createAccount2Result', account2Result);
 		}
 
+		// example: select after inserting
+		// don't double print:
 		if (!accountDocs.length) {
-			// example: select after inserting
 			interface AccountDoc {
 				name: string;
 				password: string;

--- a/src/db/README.md
+++ b/src/db/README.md
@@ -7,6 +7,11 @@
 
 ## postgres
 
+The Felt server has a dependency on[PostgreSQL](https://www.postgresql.org).
+Please see its website for setup instructions.
+
+> TODO what minimum supported version?
+
 Felt's database driver is [`postgres`](https://github.com/porsager/postgres).
 See its docs to learn more.
 

--- a/src/db/README.md
+++ b/src/db/README.md
@@ -1,0 +1,25 @@
+# felt-server/db
+
+## tech
+
+- [PostgreSQL](https://www.postgresql.org)
+- [`postgres`](https://github.com/porsager/postgres)
+
+## postgres
+
+Felt's database driver is [`postgres`](https://github.com/porsager/postgres).
+See its docs to learn more.
+
+At the moment, the [`ApiServer`](../server/ApiServer.ts)
+tries to connect to the database `'felt'` as `'postgres'` with password `'password'`.
+It uses the following environment variables if they're defined:
+
+```
+host = PGHOST
+port = PGPORT
+database = PGDATABASE
+username = PGUSERNAME or PGUSER
+password = PGPASSWORD
+idle_timeout = PGIDLE_TIMEOUT
+connect_timeout = PGCONNECT_TIMEOUT
+```

--- a/src/db/README.md
+++ b/src/db/README.md
@@ -10,7 +10,7 @@
 Felt's database driver is [`postgres`](https://github.com/porsager/postgres).
 See its docs to learn more.
 
-At the moment, the [`ApiServer`](../server/ApiServer.ts)
+At the moment, the [`server`](../server/server.ts)
 tries to connect to the database `'felt'` as `'postgres'` with password `'password'`.
 It uses the following environment variables if they're defined:
 

--- a/src/db/README.md
+++ b/src/db/README.md
@@ -10,9 +10,9 @@
 Felt's database driver is [`postgres`](https://github.com/porsager/postgres).
 See its docs to learn more.
 
-At the moment, the [`server`](../server/server.ts)
-tries to connect to the database `'felt'` as `'postgres'` with password `'password'`.
-It uses the following environment variables if they're defined:
+At the moment, the server [defaults to connecting](../db/postgres.ts)
+to the database `'felt'` as `'postgres'` with password `'password'`.
+It prioritizes the following environment variables if they're defined:
 
 ```
 host = PGHOST

--- a/src/db/README.md
+++ b/src/db/README.md
@@ -11,7 +11,7 @@ The Felt server has a dependency on [PostgreSQL](https://www.postgresql.org) 13.
 You can find [setup instructions](https://www.postgresql.org/download/) on their website.
 
 Felt's database driver is [`postgres`](https://github.com/porsager/postgres).
-See its [README](https://github.com/porsager/postgres) to learn more.
+See its [README](https://github.com/porsager/postgres#readme) to learn more.
 
 At the moment, the server [defaults to connecting](../db/postgres.ts)
 to the database with the following values,

--- a/src/db/README.md
+++ b/src/db/README.md
@@ -20,11 +20,11 @@ to the database with the following values,
 prioritizing environment variables if they're defined:
 
 ```
-host = PGHOST
-port = PGPORT
 database = PGDATABASE or 'felt'
 username = PGUSERNAME or PGUSER or 'postgres'
 password = PGPASSWORD or 'password'
+host = PGHOST
+port = PGPORT
 idle_timeout = PGIDLE_TIMEOUT
 connect_timeout = PGCONNECT_TIMEOUT
 ```

--- a/src/db/README.md
+++ b/src/db/README.md
@@ -13,7 +13,7 @@ You can find [setup instructions](https://www.postgresql.org/download/) on their
 Felt's database driver is [`postgres`](https://github.com/porsager/postgres).
 See its [README](https://github.com/porsager/postgres#readme) to learn more.
 
-At the moment, the server [defaults to connecting](../db/postgres.ts)
+At the moment, the server [defaults to connecting](./postgres.ts)
 to the database with the following values,
 prioritizing environment variables if they're defined:
 

--- a/src/db/README.md
+++ b/src/db/README.md
@@ -16,15 +16,15 @@ Felt's database driver is [`postgres`](https://github.com/porsager/postgres).
 See its docs to learn more.
 
 At the moment, the server [defaults to connecting](../db/postgres.ts)
-to the database `'felt'` as `'postgres'` with password `'password'`.
-It prioritizes the following environment variables if they're defined:
+to the database with the following values,
+prioritizing environment variables if they're defined:
 
 ```
 host = PGHOST
 port = PGPORT
-database = PGDATABASE
-username = PGUSERNAME or PGUSER
-password = PGPASSWORD
+database = PGDATABASE or 'felt'
+username = PGUSERNAME or PGUSER or 'postgres'
+password = PGPASSWORD or 'password'
 idle_timeout = PGIDLE_TIMEOUT
 connect_timeout = PGCONNECT_TIMEOUT
 ```

--- a/src/db/README.md
+++ b/src/db/README.md
@@ -7,7 +7,7 @@
 
 ## postgres
 
-The Felt server has a dependency on[PostgreSQL](https://www.postgresql.org).
+The Felt server has a dependency on [PostgreSQL](https://www.postgresql.org).
 Please see its website for setup instructions.
 
 > TODO what minimum supported version?

--- a/src/db/README.md
+++ b/src/db/README.md
@@ -7,10 +7,8 @@
 
 ## postgres
 
-The Felt server has a dependency on [PostgreSQL](https://www.postgresql.org).
+The Felt server has a dependency on [PostgreSQL](https://www.postgresql.org) 13.2+.
 You can find [setup instructions](https://www.postgresql.org/download/) on their website.
-
-> TODO what minimum supported version?
 
 Felt's database driver is [`postgres`](https://github.com/porsager/postgres).
 See its docs to learn more.

--- a/src/db/README.md
+++ b/src/db/README.md
@@ -11,7 +11,7 @@ The Felt server has a dependency on [PostgreSQL](https://www.postgresql.org) 13.
 You can find [setup instructions](https://www.postgresql.org/download/) on their website.
 
 Felt's database driver is [`postgres`](https://github.com/porsager/postgres).
-See its docs to learn more.
+See its [README](https://github.com/porsager/postgres) to learn more.
 
 At the moment, the server [defaults to connecting](../db/postgres.ts)
 to the database with the following values,

--- a/src/db/README.md
+++ b/src/db/README.md
@@ -8,7 +8,7 @@
 ## postgres
 
 The Felt server has a dependency on [PostgreSQL](https://www.postgresql.org).
-Please see its website for setup instructions.
+You can find [setup instructions](https://www.postgresql.org/download/) on their website.
 
 > TODO what minimum supported version?
 

--- a/src/db/README.md
+++ b/src/db/README.md
@@ -28,3 +28,5 @@ password = PGPASSWORD
 idle_timeout = PGIDLE_TIMEOUT
 connect_timeout = PGCONNECT_TIMEOUT
 ```
+
+> TODO figure out config, maybe through `src/gro.config.ts`

--- a/src/db/db.ts
+++ b/src/db/db.ts
@@ -1,4 +1,0 @@
-import {Database} from './Database.js';
-
-// TODO doing this because of `src/hooks.ts` - not sure I like it
-export const db = new Database();

--- a/src/db/postgres-types.d.ts
+++ b/src/db/postgres-types.d.ts
@@ -14,7 +14,7 @@ declare module 'postgres' {
 	 * @returns An utility function to make queries to the server
 	 */
 	declare function postgres<T extends JSToPostgresTypeMap>(
-		options?: postgres.Options<T>,
+		options?: string | postgres.Options<T>,
 	): postgres.Sql<JSToPostgresTypeMap extends T ? {} : T>;
 	/**
 	 * Establish a connection to a PostgreSQL server.

--- a/src/db/postgres-types.d.ts
+++ b/src/db/postgres-types.d.ts
@@ -1,0 +1,442 @@
+/*
+
+public domain (The Unlicense)
+https://github.com/porsager/postgres
+
+I am stumped - are these published?
+https://github.com/porsager/postgres/blob/master/types/index.d.ts
+
+*/
+declare module 'postgres' {
+	/**
+	 * Establish a connection to a PostgreSQL server.
+	 * @param options Connection options - default to the same as psql
+	 * @returns An utility function to make queries to the server
+	 */
+	declare function postgres<T extends JSToPostgresTypeMap>(
+		options?: postgres.Options<T>,
+	): postgres.Sql<JSToPostgresTypeMap extends T ? {} : T>;
+	/**
+	 * Establish a connection to a PostgreSQL server.
+	 * @param url Connection string used for authentication
+	 * @param options Connection options - default to the same as psql
+	 * @returns An utility function to make queries to the server
+	 */
+	declare function postgres<T extends JSToPostgresTypeMap>(
+		url: string,
+		options?: postgres.Options<T>,
+	): postgres.Sql<JSToPostgresTypeMap extends T ? {} : T>;
+
+	/**
+	 * Connection options of Postgres.
+	 */
+	interface BaseOptions<T extends JSToPostgresTypeMap> {
+		/** Postgres ip address or domain name */
+		host: string | string[];
+		/** Postgres server port */
+		port: number | number[];
+		/** Name of database to connect to */
+		database: string;
+		/** Username of database user */
+		user: string;
+		/** True; or options for tls.connect */
+		ssl: 'require' | 'prefer' | boolean | object;
+		/** Max number of connections */
+		max: number;
+		/** Idle connection timeout in seconds */
+		idle_timeout: number | undefined;
+		/** Connect timeout in seconds */
+		connect_timeout: number;
+		/** Array of custom types; see more below */
+		types: PostgresTypeList<T>;
+		/** Disable prepared mode */
+		no_prepare: boolean;
+		/** Defaults to console.log */
+		onnotice: (notice: postgres.Notice) => void;
+		/** (key; value) when server param change */
+		onparameter: (key: string, value: any) => void;
+		/** Is called with (connection; query; parameters) */
+		debug: boolean | ((connection: number, query: string, parameters: any[]) => void);
+		/** Transform hooks */
+		transform: {
+			/** Transforms incoming column names */
+			column?: (column: string) => string;
+			/** Transforms incoming row values */
+			value?: (value: any) => any;
+			/** Transforms entire rows */
+			row?: (row: postgres.Row) => any;
+		};
+		/** Connection parameters */
+		connection: Partial<postgres.ConnectionParameters>;
+	}
+
+	type PostgresTypeList<T> = {
+		[name in keyof T]: T[name] extends (...args: any) => unknown
+			? postgres.PostgresType<T[name]>
+			: postgres.PostgresType;
+	};
+
+	interface JSToPostgresTypeMap {
+		[name: string]: unknown;
+	}
+
+	declare class PostgresError extends Error {
+		name: 'PostgresError';
+		severity_local: string;
+		severity: string;
+		code: string;
+		position: string;
+		file: string;
+		line: string;
+		routine: string;
+
+		detail?: string;
+		hint?: string;
+		internal_position?: string;
+		internal_query?: string;
+		where?: string;
+		schema_name?: string;
+		table_name?: string;
+		column_name?: string;
+		data?: string;
+		type_name?: string;
+		constraint_name?: string;
+
+		// Disable user-side creation of PostgresError
+		private constructor();
+	}
+
+	type UnwrapPromiseArray<T> = T extends any[]
+		? {
+				[k in keyof T]: T[k] extends Promise<infer R> ? R : T[k];
+		  }
+		: T;
+
+	type PostgresErrorType = PostgresError;
+
+	declare namespace postgres {
+		type PostgresError = PostgresErrorType;
+
+		/**
+		 * Convert a string to Pascal case.
+		 * @param str THe string to convert
+		 * @returns The new string in Pascal case
+		 */
+		function toPascal(str: string): string;
+		/**
+		 * Convert a string to Camel case.
+		 * @param str THe string to convert
+		 * @returns The new string in Camel case
+		 */
+		function toCamel(str: string): string;
+		/**
+		 * Convert a string to Kebab case.
+		 * @param str THe string to convert
+		 * @returns The new string in Kebab case
+		 */
+		function toKebab(str: string): string;
+
+		const BigInt: PostgresType<(number: bigint) => string>;
+
+		interface ConnectionParameters {
+			/** Default application_name */
+			application_name: string;
+			/** Other connection parameters */
+			[name: string]: any;
+		}
+
+		interface Options<T extends JSToPostgresTypeMap> extends Partial<BaseOptions<T>> {
+			/** @inheritdoc */
+			host?: string;
+			/** @inheritdoc */
+			port?: number;
+			/** unix socket path (usually '/tmp') */
+			path?: string | (() => string);
+			/** Password of database user (an alias for `password`) */
+			pass?: Options<T>['password'];
+			/** Password of database user */
+			password?: string | (() => string | Promise<string>);
+			/** Name of database to connect to (an alias for `database`) */
+			db?: Options<T>['database'];
+			/** Username of database user (an alias for `username`) */
+			username?: Options<T>['user'];
+			/** Postgres ip address or domain name (an alias for `host`) */
+			hostname?: Options<T>['host'];
+		}
+
+		interface ParsedOptions<T extends JSToPostgresTypeMap> extends BaseOptions<T> {
+			/** @inheritdoc */
+			host: string[];
+			/** @inheritdoc */
+			port: number[];
+			/** @inheritdoc */
+			pass: null;
+			serializers: {[oid: number]: T[keyof T]};
+			parsers: {[oid: number]: T[keyof T]};
+		}
+
+		interface Notice {
+			[field: string]: string;
+		}
+
+		interface PostgresType<T extends (...args: any) => any = (...args: any) => any> {
+			to: number;
+			from: number[];
+			serialize: T;
+			parse: (raw: ReturnType<T>) => unknown;
+		}
+
+		interface Parameter<T = SerializableParameter> {
+			/**
+			 * PostgreSQL OID of the type
+			 */
+			type: number;
+			/**
+			 * Serialized value
+			 */
+			value: string | null;
+			/**
+			 * Raw value to serialize
+			 */
+			raw: T | null;
+		}
+
+		interface ArrayParameter<T extends SerializableParameter[] = SerializableParameter[]>
+			extends Parameter<T | T[]> {
+			array: true;
+		}
+
+		interface ConnectionError extends globalThis.Error {
+			code:
+				| never
+				| 'CONNECTION_DESTROYED'
+				| 'CONNECT_TIMEOUT'
+				| 'CONNECTION_CLOSED'
+				| 'CONNECTION_ENDED';
+			errno: this['code'];
+			address: string;
+			port?: number;
+		}
+
+		interface NotSupportedError extends globalThis.Error {
+			code: 'MESSAGE_NOT_SUPPORTED';
+			name:
+				| never
+				| 'CopyInResponse'
+				| 'CopyOutResponse'
+				| 'ParameterDescription'
+				| 'FunctionCallResponse'
+				| 'NegotiateProtocolVersion'
+				| 'CopyBothResponse';
+		}
+
+		interface GenericError extends globalThis.Error {
+			code:
+				| never
+				| 'NOT_TAGGED_CALL'
+				| 'UNDEFINED_VALUE'
+				| 'MAX_PARAMETERS_EXCEEDED'
+				| 'SASL_SIGNATURE_MISMATCH';
+			message: string;
+		}
+
+		interface AuthNotImplementedError extends globalThis.Error {
+			code: 'AUTH_TYPE_NOT_IMPLEMENTED';
+			type:
+				| number
+				| 'KerberosV5'
+				| 'CleartextPassword'
+				| 'MD5Password'
+				| 'SCMCredential'
+				| 'GSS'
+				| 'GSSContinue'
+				| 'SSPI'
+				| 'SASL'
+				| 'SASLContinue'
+				| 'SASLFinal';
+			message: string;
+		}
+
+		type Error =
+			| never
+			| PostgresError
+			| ConnectionError
+			| NotSupportedError
+			| GenericError
+			| AuthNotImplementedError;
+
+		type Serializable = null | boolean | number | string | Date | Uint8Array;
+
+		type SerializableParameter =
+			| Serializable
+			| Helper<any>
+			| Parameter<any>
+			| ArrayParameter
+			| SerializableParameter[];
+
+		type HelperSerializable =
+			| {[index: string]: SerializableParameter}
+			| {[index: string]: SerializableParameter}[];
+
+		type SerializableKeys<T> = keyof T extends infer R
+			? R extends keyof T
+				? T[R] extends SerializableParameter
+					? R
+					: never
+				: keyof T
+			: keyof T;
+
+		interface Row {
+			[column: string]: any;
+		}
+
+		interface UnlabeledRow<T = any> {
+			'?column?': T;
+		}
+
+		type MaybeRow = Row | undefined;
+
+		type TransformRow<T> = T extends Serializable ? {'?column?': T} : T;
+
+		type AsRowList<T extends readonly any[]> = {[k in keyof T]: TransformRow<T[k]>};
+
+		interface Column<T extends string> {
+			name: T;
+			type: number;
+			parser(raw: string): string;
+		}
+
+		type ColumnList<T> = (T extends string ? Column<T> : never)[];
+
+		interface State {
+			state: 'I';
+			pid: number;
+			secret: number;
+		}
+
+		interface ResultMeta<T extends number | null> {
+			count: T; // For tuples
+			command: string;
+			state: State;
+		}
+
+		interface ResultQueryMeta<T extends number | null, U> extends ResultMeta<T> {
+			columns: ColumnList<U>;
+		}
+
+		type ExecutionResult<T> = [] & ResultQueryMeta<number, keyof NonNullable<T>>;
+		type RowList<T extends MaybeRow[]> = T &
+			Iterable<NonNullable<T[number]>> &
+			ResultQueryMeta<T['length'], keyof T[number]>;
+
+		interface PendingQuery<TRow extends MaybeRow[]> extends Promise<RowList<TRow>> {
+			stream(
+				cb: (row: NonNullable<TRow[number]>, result: ExecutionResult<TRow[number]>) => void,
+			): Promise<ExecutionResult<TRow[number]>>;
+			cursor(cb: (row: NonNullable<TRow[number]>) => void): Promise<ExecutionResult<TRow[number]>>;
+			cursor(
+				size: 1,
+				cb: (row: NonNullable<TRow[number]>) => void,
+			): Promise<ExecutionResult<TRow[number]>>;
+			cursor(
+				size: number,
+				cb: (rows: NonNullable<TRow[number]>[]) => void,
+			): Promise<ExecutionResult<TRow[number]>>;
+		}
+
+		interface PendingRequest extends Promise<[] & ResultMeta<null>> {}
+
+		interface ListenRequest extends Promise<ListenMeta> {}
+		interface ListenMeta extends ResultMeta<null> {
+			unlisten(): Promise<void>;
+		}
+
+		interface Helper<T, U extends any[] = T[]> {
+			first: T;
+			rest: U;
+		}
+
+		interface Sql<TTypes extends JSToPostgresTypeMap> {
+			/**
+			 * Execute the SQL query passed as a template string. Can only be used as template string tag.
+			 * @param template The template generated from the template string
+			 * @param args Interpoled values of the template string
+			 * @returns A promise resolving to the result of your query
+			 */
+			<T extends any[] = Row[]>(
+				template: TemplateStringsArray,
+				...args: SerializableParameter[]
+			): PendingQuery<AsRowList<T>>;
+
+			/**
+			 * Escape column names
+			 * @param columns Columns to escape
+			 * @returns A formated representation of the column names
+			 */
+			(columns: string[]): Helper<string>;
+			(...columns: string[]): Helper<string>;
+
+			/**
+			 * Extract properties from an object or from an array of objects
+			 * @param objOrArray An object or an array of objects to extract properties from
+			 * @param keys Keys to extract from the object or from objets inside the array
+			 * @returns A formated representation of the parameter
+			 */
+			<
+				T extends object | readonly object[],
+				U extends SerializableKeys<T extends readonly object[] ? T[number] : T>
+			>(
+				objOrArray: T,
+				...keys: U[]
+			): Helper<T, U[]>;
+
+			END: {}; // FIXME unique symbol ?
+			PostgresError: typeof PostgresError;
+
+			array<T extends SerializableParameter[] = SerializableParameter[]>(
+				value: T,
+			): ArrayParameter<T>;
+			begin<T>(cb: (sql: TransactionSql<TTypes>) => T | Promise<T>): Promise<UnwrapPromiseArray<T>>;
+			begin<T>(
+				options: string,
+				cb: (sql: TransactionSql<TTypes>) => T | Promise<T>,
+			): Promise<UnwrapPromiseArray<T>>;
+			end(options?: {timeout?: number}): Promise<void>;
+			file<T extends any[] = Row[]>(
+				path: string,
+				options?: {cache?: boolean},
+			): PendingQuery<AsRowList<T>>;
+			file<T extends any[] = Row[]>(
+				path: string,
+				args: SerializableParameter[],
+				options?: {cache?: boolean},
+			): PendingQuery<AsRowList<T>>;
+			json(value: any): Parameter;
+			listen(channel: string, cb: (value?: string) => void): ListenRequest;
+			notify(channel: string, payload: string): PendingRequest;
+			options: ParsedOptions<TTypes>;
+			parameters: ConnectionParameters;
+			types: {
+				[name in keyof TTypes]: TTypes[name] extends (...args: any) => any
+					? (...args: Parameters<TTypes[name]>) => postgres.Parameter<ReturnType<TTypes[name]>>
+					: (...args: any) => postgres.Parameter<any>;
+			};
+			unsafe<T extends any[] = Row[]>(
+				query: string,
+				parameters?: SerializableParameter[],
+			): PendingQuery<AsRowList<T>>;
+		}
+
+		interface TransactionSql<TTypes extends JSToPostgresTypeMap> extends Sql<TTypes> {
+			savepoint<T>(
+				cb: (sql: TransactionSql<TTypes>) => T | Promise<T>,
+			): Promise<UnwrapPromiseArray<T>>;
+			savepoint<T>(
+				name: string,
+				cb: (sql: TransactionSql<TTypes>) => T | Promise<T>,
+			): Promise<UnwrapPromiseArray<T>>;
+		}
+	}
+
+	export = postgres;
+}

--- a/src/db/postgres.ts
+++ b/src/db/postgres.ts
@@ -1,4 +1,5 @@
 import type {Sql, Options} from 'postgres';
+import {numberFromEnv, stringFromEnv} from '@feltcoop/gro/dist/utils/env.js';
 
 export type PostgresSql = Sql<PostgresTypeMap>;
 
@@ -6,3 +7,13 @@ export type PostgresOptions = Options<PostgresTypeMap>;
 
 // TODO use this to pass through custom types
 export type PostgresTypeMap = Record<string, unknown>;
+
+export const toDefaultPostgresOptions = (): PostgresOptions => ({
+	host: stringFromEnv('PGHOST'),
+	port: numberFromEnv('PGPORT', 5432),
+	database: stringFromEnv('PGDATABASE', 'felt'),
+	username: stringFromEnv('PGUSERNAME', stringFromEnv('PGUSER', 'postgres')),
+	password: stringFromEnv('PGPASSWORD', 'password'),
+	idle_timeout: numberFromEnv('PGIDLE_TIMEOUT'),
+	connect_timeout: numberFromEnv('PGCONNECT_TIMEOUT'),
+});

--- a/src/db/postgres.ts
+++ b/src/db/postgres.ts
@@ -1,3 +1,10 @@
+import type {Sql, Options} from 'postgres';
+
+export type PostgresSql = Sql<PostgresTypeMap>;
+export type PostgresOptions = Options<PostgresTypeMap>;
+// TODO use this somehow - will need refactoring
+export type PostgresTypeMap = Record<string, unknown>;
+
 /* 
 
 public domain (The Unlicense)
@@ -43,10 +50,3 @@ idle_timeout 	PGIDLE_TIMEOUT
 connect_timeout 	PGCONNECT_TIMEOUT
 
 */
-
-import type {Sql, Options} from 'postgres';
-
-export type PostgresSql = Sql<PostgresTypeMap>;
-export type PostgresOptions = Options<PostgresTypeMap>;
-// TODO use this somehow - will need refactoring
-export type PostgresTypeMap = Record<string, unknown>;

--- a/src/db/postgres.ts
+++ b/src/db/postgres.ts
@@ -1,52 +1,8 @@
 import type {Sql, Options} from 'postgres';
 
 export type PostgresSql = Sql<PostgresTypeMap>;
+
 export type PostgresOptions = Options<PostgresTypeMap>;
-// TODO use this somehow - will need refactoring
+
+// TODO use this to pass through custom types
 export type PostgresTypeMap = Record<string, unknown>;
-
-/* 
-
-public domain (The Unlicense)
-https://github.com/porsager/postgres
-
-supported options:
-
-host            : '',         // Postgres ip address[s] or domain name[s]
-port            : 5432,       // Postgres server port[s]
-path            : '',         // unix socket path (usually '/tmp')
-database        : '',         // Name of database to connect to
-username        : '',         // Username of database user
-password        : '',         // Password of database user
-ssl             : false,      // true, prefer, require, tls.connect options
-max             : 10,         // Max number of connections
-idle_timeout    : 0,          // Idle connection timeout in seconds
-connect_timeout : 30,         // Connect timeout in seconds
-no_prepare      : false,      // No automatic creation of prepared statements
-types           : [],         // Array of custom types, see more below
-onnotice        : fn          // Defaults to console.log
-onparameter     : fn          // (key, value) when server param change
-debug           : fn          // Is called with (connection, query, params)
-transform       : {
-  column            : fn, // Transforms incoming column names
-  value             : fn, // Transforms incoming row values
-  row               : fn  // Transforms entire rows
-},
-connection      : {
-  application_name  : 'postgres.js', // Default application_name
-  ...                                // Other connection parameters
-},
-target_session_attrs : null   // Use 'read-write' with multiple hosts to 
-                              // ensure only connecting to primary
-
-supported env vars mapped to options:
-
-host 	PGHOST
-port 	PGPORT
-database 	PGDATABASE
-username 	PGUSERNAME or PGUSER
-password 	PGPASSWORD
-idle_timeout 	PGIDLE_TIMEOUT
-connect_timeout 	PGCONNECT_TIMEOUT
-
-*/

--- a/src/db/postgres.ts
+++ b/src/db/postgres.ts
@@ -1,0 +1,52 @@
+/* 
+
+public domain (The Unlicense)
+https://github.com/porsager/postgres
+
+supported options:
+
+host            : '',         // Postgres ip address[s] or domain name[s]
+port            : 5432,       // Postgres server port[s]
+path            : '',         // unix socket path (usually '/tmp')
+database        : '',         // Name of database to connect to
+username        : '',         // Username of database user
+password        : '',         // Password of database user
+ssl             : false,      // true, prefer, require, tls.connect options
+max             : 10,         // Max number of connections
+idle_timeout    : 0,          // Idle connection timeout in seconds
+connect_timeout : 30,         // Connect timeout in seconds
+no_prepare      : false,      // No automatic creation of prepared statements
+types           : [],         // Array of custom types, see more below
+onnotice        : fn          // Defaults to console.log
+onparameter     : fn          // (key, value) when server param change
+debug           : fn          // Is called with (connection, query, params)
+transform       : {
+  column            : fn, // Transforms incoming column names
+  value             : fn, // Transforms incoming row values
+  row               : fn  // Transforms entire rows
+},
+connection      : {
+  application_name  : 'postgres.js', // Default application_name
+  ...                                // Other connection parameters
+},
+target_session_attrs : null   // Use 'read-write' with multiple hosts to 
+                              // ensure only connecting to primary
+
+supported env vars mapped to options:
+
+host 	PGHOST
+port 	PGPORT
+database 	PGDATABASE
+username 	PGUSERNAME or PGUSER
+password 	PGPASSWORD
+idle_timeout 	PGIDLE_TIMEOUT
+connect_timeout 	PGCONNECT_TIMEOUT
+
+*/
+
+import type {Sql, Options} from 'postgres';
+
+export type PostgresSql = Sql<PostgresTypeMap>;
+export type PostgresOptions = Options<PostgresTypeMap>;
+// TODO use this somehow - will need refactoring
+export type PostgresTypeMap = Record<string, unknown>;

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -1,0 +1,62 @@
+import type {ApiServer} from 'src/server/ApiServer';
+
+export const seed = async (server: ApiServer): Promise<void> => {
+	const {db} = server;
+	const {sql} = db;
+
+	console.log('[seed] adding initial dataset to database');
+
+	// example: create table
+	const createAccountsTableResult = await sql`
+  create table if not exists accounts (
+    name text,
+    password text
+  )
+`;
+	if (createAccountsTableResult.count) {
+		console.log('[db] createAccountsTableResult', createAccountsTableResult);
+	}
+
+	// example: select
+	interface AccountDoc {
+		name: string;
+		password: string;
+	}
+	const accountDocs: AccountDoc[] = await sql`
+  select name, password from accounts
+`;
+	console.log('[db] accountDocs', accountDocs);
+
+	// example: insert literal values
+	const account1Doc = accountDocs.find((d) => d.name === 'account1');
+	if (!account1Doc) {
+		const account1InitialData = {name: 'account1', password: 'HASHVALUE1'};
+		const createAccount1Result = await sql`
+    insert into accounts (
+      name, password
+    ) values (
+      ${account1InitialData.name}, ${account1InitialData.password}
+    )
+  `;
+		console.log('[db] createAccount1Result', createAccount1Result);
+	}
+
+	// example: insert with dynamic query helper
+	const account2Doc = accountDocs.find((d) => d.name === 'account2');
+	if (!account2Doc) {
+		const account2: AccountDoc = {name: 'account2', password: 'HASHVALUE2'};
+		const account2Result = await sql`
+    insert into accounts ${sql(account2, 'name', 'password')}
+  `;
+		console.log('[db] createAccount2Result', account2Result);
+	}
+
+	// example: select after inserting
+	// don't double print:
+	if (!accountDocs.length) {
+		const accountDocs: AccountDoc[] = await sql`
+    select name, password from accounts
+  `;
+		console.log('[db] accountDocs', accountDocs);
+	}
+};

--- a/src/server/ApiServer.test.ts
+++ b/src/server/ApiServer.test.ts
@@ -1,7 +1,10 @@
+import polka from 'polka';
 import {suite} from 'uvu';
 import * as t from 'uvu/assert';
 
 import {ApiServer} from './ApiServer.js';
+import {Database} from '../db/Database.js';
+import {toDefaultPostgresOptions} from '../db/postgres.js';
 
 const TEST_PORT = 3003; // TODO
 
@@ -9,8 +12,12 @@ const TEST_PORT = 3003; // TODO
 const test_ApiServer = suite('ApiServer');
 
 test_ApiServer('init and destroy', async () => {
-	const server = new ApiServer({port: TEST_PORT});
-	t.is(server.config.port, TEST_PORT);
+	const server = new ApiServer({
+		app: polka(),
+		db: new Database({postgresOptions: toDefaultPostgresOptions()}),
+		port: TEST_PORT,
+	});
+	t.is(server.options.port, TEST_PORT);
 	await server.init();
 	// TODO make API requests, and look into before/after
 	await server.destroy();

--- a/src/server/ApiServer.test.ts
+++ b/src/server/ApiServer.test.ts
@@ -1,6 +1,7 @@
 import polka from 'polka';
 import {suite} from 'uvu';
 import * as t from 'uvu/assert';
+import postgres from 'postgres';
 
 import {ApiServer} from './ApiServer.js';
 import {Database} from '../db/Database.js';
@@ -14,7 +15,7 @@ const test_ApiServer = suite('ApiServer');
 test_ApiServer('init and destroy', async () => {
 	const server = new ApiServer({
 		app: polka(),
-		db: new Database({postgresOptions: toDefaultPostgresOptions()}),
+		db: new Database({sql: postgres(toDefaultPostgresOptions())}),
 		port: TEST_PORT,
 	});
 	t.is(server.options.port, TEST_PORT);

--- a/src/server/ApiServer.test.ts
+++ b/src/server/ApiServer.test.ts
@@ -18,7 +18,7 @@ test_ApiServer('init and destroy', async () => {
 		db: new Database({sql: postgres(toDefaultPostgresOptions())}),
 		port: TEST_PORT,
 	});
-	t.is(server.options.port, TEST_PORT);
+	t.is(server.port, TEST_PORT);
 	await server.init();
 	// TODO make API requests, and look into before/after
 	await server.destroy();

--- a/src/server/ApiServer.ts
+++ b/src/server/ApiServer.ts
@@ -113,7 +113,7 @@ export class ApiServer {
 				assets_handler,
 				prerendered_handler,
 				async (req, res, next) => {
-					const parsed = new URL(req.url || '', `http://localhost`);
+					const parsed = new URL(req.url || '', 'http://localhost');
 					if (this.isApiServerPathname(parsed.pathname)) return next();
 					const rendered = await render({
 						method: req.method,

--- a/src/server/ApiServer.ts
+++ b/src/server/ApiServer.ts
@@ -67,7 +67,8 @@ export class ApiServer {
 
 	constructor(public readonly config: ApiServerConfig) {
 		this.app = polka(config.polka);
-		// TODO refactor this config, properly source the values upstream
+		// TODO refactor this config, properly source the values upstream,
+		// probably make `db` and `polka` options (not their configs)
 		this.db = new Database({
 			postgresOptions: {
 				host: stringFromEnv('PGHOST'),

--- a/src/server/ApiServer.ts
+++ b/src/server/ApiServer.ts
@@ -23,13 +23,13 @@ import {
 	API_SERVER_DEFAULT_PORT_PROD,
 } from '@feltcoop/gro/dist/config/defaultBuildConfig.js';
 import {SVELTE_KIT_DIST_PATH} from '@feltcoop/gro/dist/paths.js';
-import {numberFromEnv} from '@feltcoop/gro/dist/utils/env.js';
+import {numberFromEnv, stringFromEnv} from '@feltcoop/gro/dist/utils/env.js';
 
 import {toAttachSessionUserMiddleware} from '../session/attachSessionUserMiddleware.js';
 import {toLoginMiddleware} from '../session/loginMiddleware.js';
 import {toLogoutMiddleware} from '../session/logoutMiddleware.js';
 import type {User} from '../vocab/user/user.js';
-import {db} from '../db/db.js';
+import {Database} from '../db/Database.js';
 
 const log = new Logger([blue('[ApiServer]')]);
 
@@ -63,10 +63,22 @@ export interface RenderSvelteKit {
 
 export class ApiServer {
 	readonly app: ServerApp;
-	readonly db = db;
+	readonly db: Database;
 
 	constructor(public readonly config: ApiServerConfig) {
 		this.app = polka(config.polka);
+		// TODO refactor this config, properly source the values
+		this.db = new Database({
+			postgresOptions: {
+				host: stringFromEnv('PGHOST'),
+				port: numberFromEnv('PGPORT', 5432),
+				database: stringFromEnv('PGDATABASE', 'felt'),
+				username: stringFromEnv('PGUSERNAME', stringFromEnv('PGUSER', 'postgres')),
+				password: stringFromEnv('PGPASSWORD', 'password'),
+				idle_timeout: numberFromEnv('PGIDLE_TIMEOUT'),
+				connect_timeout: numberFromEnv('PGCONNECT_TIMEOUT'),
+			},
+		});
 		log.info('created');
 	}
 

--- a/src/server/ApiServer.ts
+++ b/src/server/ApiServer.ts
@@ -67,7 +67,7 @@ export class ApiServer {
 
 	constructor(public readonly config: ApiServerConfig) {
 		this.app = polka(config.polka);
-		// TODO refactor this config, properly source the values
+		// TODO refactor this config, properly source the values upstream
 		this.db = new Database({
 			postgresOptions: {
 				host: stringFromEnv('PGHOST'),

--- a/src/server/ApiServer.ts
+++ b/src/server/ApiServer.ts
@@ -43,17 +43,15 @@ const dev = process.env.NODE_ENV !== 'production';
 const TODO_SERVER_COOKIE_KEYS = ['TODO', 'KEY_2_TODO', 'KEY_3_TODO'];
 
 export interface Options {
-	port?: number;
 	app: Polka<Request>;
 	db: Database;
+	port?: number;
 	loadRender?: () => Promise<RenderSvelteKit | null>;
 }
 
 export interface RenderSvelteKit {
 	<TContext>(request: SvelteKitRequest<TContext>): SvelteKitResponse | Promise<SvelteKitResponse>;
 }
-
-// TODO review all of this before deploying to production
 
 export class ApiServer {
 	readonly app: Polka<Request>;

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -3,6 +3,7 @@ import {SVELTE_KIT_DIST_PATH} from '@feltcoop/gro/dist/paths.js';
 import {ApiServer} from './ApiServer.js';
 import type {ApiServerConfig} from './ApiServer.js';
 
+// TODO refactor
 const config: ApiServerConfig = {
 	loadRender: async () => {
 		let importPath = `../${SVELTE_KIT_DIST_PATH}/` + 'app.js'; // don't want Rollup to bundle this

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1,10 +1,23 @@
+import polka from 'polka';
 import {SVELTE_KIT_DIST_PATH} from '@feltcoop/gro/dist/paths.js';
+import {numberFromEnv, stringFromEnv} from '@feltcoop/gro/dist/utils/env.js';
 
 import {ApiServer} from './ApiServer.js';
-import type {ApiServerConfig} from './ApiServer.js';
+import {Database} from '../db/Database.js';
 
-// TODO refactor
-const config: ApiServerConfig = {
+export const server = new ApiServer({
+	app: polka(),
+	db: new Database({
+		postgresOptions: {
+			host: stringFromEnv('PGHOST'),
+			port: numberFromEnv('PGPORT', 5432),
+			database: stringFromEnv('PGDATABASE', 'felt'),
+			username: stringFromEnv('PGUSERNAME', stringFromEnv('PGUSER', 'postgres')),
+			password: stringFromEnv('PGPASSWORD', 'password'),
+			idle_timeout: numberFromEnv('PGIDLE_TIMEOUT'),
+			connect_timeout: numberFromEnv('PGCONNECT_TIMEOUT'),
+		},
+	}),
 	loadRender: async () => {
 		let importPath = `../${SVELTE_KIT_DIST_PATH}/` + 'app.js'; // don't want Rollup to bundle this
 		try {
@@ -14,9 +27,7 @@ const config: ApiServerConfig = {
 			return null;
 		}
 	},
-};
-
-export const server = new ApiServer(config);
+});
 
 server.init().catch((err) => {
 	console.error('server.init() failed', err);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1,4 +1,5 @@
 import polka from 'polka';
+import postgres from 'postgres';
 import {SVELTE_KIT_DIST_PATH} from '@feltcoop/gro/dist/paths.js';
 
 import {ApiServer} from './ApiServer.js';
@@ -7,7 +8,7 @@ import {toDefaultPostgresOptions} from '../db/postgres.js';
 
 export const server = new ApiServer({
 	app: polka(),
-	db: new Database({postgresOptions: toDefaultPostgresOptions()}),
+	db: new Database({sql: postgres(toDefaultPostgresOptions())}),
 	loadRender: async () => {
 		let importPath = `../${SVELTE_KIT_DIST_PATH}/` + 'app.js'; // don't want Rollup to bundle this
 		try {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -5,6 +5,7 @@ import {SVELTE_KIT_DIST_PATH} from '@feltcoop/gro/dist/paths.js';
 import {ApiServer} from './ApiServer.js';
 import {Database} from '../db/Database.js';
 import {toDefaultPostgresOptions} from '../db/postgres.js';
+import {seed} from '../db/seed.js';
 
 export const server = new ApiServer({
 	app: polka(),
@@ -20,7 +21,12 @@ export const server = new ApiServer({
 	},
 });
 
-server.init().catch((err) => {
-	console.error('server.init() failed', err);
-	throw err;
-});
+server
+	.init()
+	.then(async () => {
+		await seed(server);
+	})
+	.catch((err) => {
+		console.error('server.init() failed', err);
+		throw err;
+	});

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1,23 +1,13 @@
 import polka from 'polka';
 import {SVELTE_KIT_DIST_PATH} from '@feltcoop/gro/dist/paths.js';
-import {numberFromEnv, stringFromEnv} from '@feltcoop/gro/dist/utils/env.js';
 
 import {ApiServer} from './ApiServer.js';
 import {Database} from '../db/Database.js';
+import {toDefaultPostgresOptions} from '../db/postgres.js';
 
 export const server = new ApiServer({
 	app: polka(),
-	db: new Database({
-		postgresOptions: {
-			host: stringFromEnv('PGHOST'),
-			port: numberFromEnv('PGPORT', 5432),
-			database: stringFromEnv('PGDATABASE', 'felt'),
-			username: stringFromEnv('PGUSERNAME', stringFromEnv('PGUSER', 'postgres')),
-			password: stringFromEnv('PGPASSWORD', 'password'),
-			idle_timeout: numberFromEnv('PGIDLE_TIMEOUT'),
-			connect_timeout: numberFromEnv('PGCONNECT_TIMEOUT'),
-		},
-	}),
+	db: new Database({postgresOptions: toDefaultPostgresOptions()}),
 	loadRender: async () => {
 		let importPath = `../${SVELTE_KIT_DIST_PATH}/` + 'app.js'; // don't want Rollup to bundle this
 		try {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "target": "es2020",
     "module": "es2020",
     "strict": true,
-    "importsNotUsedAsValues": "remove",
+    "importsNotUsedAsValues": "error",
     "isolatedModules": true,
     "sourceMap": true,
     "esModuleInterop": true,


### PR DESCRIPTION
This adds the dependency [`postgres`](https://github.com/porsager/postgres/) to drive the database. It includes some simple examples in a temporary location and some initial documentation in a readme.

- [x] basics
- [x] get CI working with Postgres!
- [x] move the examples to `src/db/seed.ts`

In a followup PR we could implement the methods in `src/db/Database.ts` using its `sql` property, and refactor into nice repos files or something, e.g. `src/account/repo.ts` alongside a `src/account/model.ts`. (possibly namespaced off of the root at `src/vocab/account/*` or something)