### PR TITLE
rename sessionUserMiddleware

### DIFF
--- a/src/server/ApiServer.ts
+++ b/src/server/ApiServer.ts
@@ -18,7 +18,7 @@ import {
 } from '@feltcoop/gro/dist/config/defaultBuildConfig.js';
 import {toEnvNumber} from '@feltcoop/gro/dist/utils/env.js';
 
-import {toAttachSessionUserMiddleware} from '../session/attachSessionUserMiddleware.js';
+import {toSessionUserMiddleware} from '../session/sessionUserMiddleware.js';
 import {toLoginMiddleware} from '../session/loginMiddleware.js';
 import {toLogoutMiddleware} from '../session/logoutMiddleware.js';
 import type {User} from '../vocab/user/user.js';
@@ -90,7 +90,7 @@ export class ApiServer {
 					name: 'session_id',
 				}),
 			)
-			.use(toAttachSessionUserMiddleware(this))
+			.use(toSessionUserMiddleware(this))
 			// API
 			.post('/api/v1/echo', (req, res) => {
 				log.info('echo', req.body);

--- a/src/session/sessionUserMiddleware.ts
+++ b/src/session/sessionUserMiddleware.ts
@@ -2,13 +2,13 @@ import send from '@polka/send-type';
 
 import type {ApiServer, Middleware} from '../server/ApiServer.js';
 
-export const toAttachSessionUserMiddleware = (server: ApiServer): Middleware => {
+export const toSessionUserMiddleware = (server: ApiServer): Middleware => {
 	return async (req, res, next) => {
 		if (!req.session.name) {
 			return next();
 		}
 
-		console.log('[attachSessionUserMiddleware]', req.session.name); // TODO logging
+		console.log('[sessionUserMiddleware]', req.session.name); // TODO logging
 		const findUserResult = await server.db.repos.users.findByName(req.session.name);
 		if (findUserResult.ok) {
 			req.user = findUserResult.value;


### PR DESCRIPTION
This just simplifies the name of the `attachSessionUserMiddleware` to remove the word "attach". Seems plenty descriptive without it.