### PR TITLE
Add spaces to context

### DIFF
--- a/src/communities/community.ts
+++ b/src/communities/community.ts
@@ -1,4 +1,7 @@
+import type {Space} from '../spaces/space.js';
+
 export interface Community {
 	community_id?: number;
 	name: string;
+	spaces: Space[];
 }

--- a/src/db/Database.ts
+++ b/src/db/Database.ts
@@ -110,9 +110,17 @@ export class Database {
 				};
 			},
 			filterByAccount: async (accountId: number): Promise<Result<{value: Community[]}>> => {
-				console.log(`[db] preparring to query for communities account: ${accountId}`);
-				const data = await this.sql<Community[]>`
-				SELECT c.community_id, c.name FROM communities c JOIN account_communities ac ON c.community_id=ac.community_id AND ac.account_id= ${accountId}
+				console.log(`[db] preparring to query for communities & spaces account: ${accountId}`);
+				const data = await this.sql<Community[]>`		
+  					select c.community_id, c.name,
+    				(
+      				select array_to_json(array_agg(row_to_json(d)))
+      				from (
+        				SELECT s.space_id, s.url, s.media_type, s.content FROM spaces s JOIN community_spaces cs ON s.space_id=cs.space_id AND cs.community_id=c.community_id      				
+      				) d
+    				) as spaces
+  				from communities c JOIN account_communities ac
+  				ON c.community_id=ac.community_id AND ac.account_id=${accountId}				
 				`;
 				console.log('[db] community data', data);
 				return {ok: true, value: data};

--- a/src/db/Database.ts
+++ b/src/db/Database.ts
@@ -114,7 +114,7 @@ export class Database {
 				const data = await this.sql<Community[]>`		
   					select c.community_id, c.name,
     				(
-      				select array_to_json(array_agg(row_to_json(d)))
+      				select array_to_json(coalesce(array_agg(row_to_json(d)), '{}'))
       				from (
         				SELECT s.space_id, s.url, s.media_type, s.content FROM spaces s JOIN community_spaces cs ON s.space_id=cs.space_id AND cs.community_id=c.community_id      				
       				) d

--- a/src/lib/CommunityNav.svelte
+++ b/src/lib/CommunityNav.svelte
@@ -2,10 +2,11 @@
 	import type {Community} from '../communities/community.js';
 
 	export let communities: Community[];
-	export let communityFocus: Community;
-	const changeFocus = async (index: number) => {
-		$: communityFocus = communities[index];
-	};
+	export let selectedCommunity: Community;
+	//export const selectCommunity;
+	let selectedCommunityIndex: number | null = null;
+	$: selectedCommunity = selectedCommunityIndex ?? communities[selectedCommunityIndex];
+	const changeFocus = (index: number) => selectedCommunityIndex = index;	
 </script>
 
 <div class="sidenav">

--- a/src/lib/CommunityNav.svelte
+++ b/src/lib/CommunityNav.svelte
@@ -5,13 +5,12 @@
 	export let selectedCommunity: Community;
 	export let selectCommunity: (community: Community) => void;
 	let selectedCommunityIndex: number | null = null;
-	$: selectedCommunity = selectedCommunityIndex ?? communities[selectedCommunityIndex];
-	const changeFocus = (index: number) => selectCommunity(communities[index]);
+	$: selectedCommunity = selectedCommunityIndex ?? communities[selectedCommunityIndex];	
 </script>
 
 <div class="sidenav">
 	{#each communities as community, i}
-		<button type="button" on:click={() => changeFocus(i)}>{community.name} </button>
+		<button type="button" on:click={() => selectCommunity(communities[i])}>{community.name} </button>
 	{/each}
 </div>
 

--- a/src/lib/CommunityNav.svelte
+++ b/src/lib/CommunityNav.svelte
@@ -2,14 +2,15 @@
 	import type {Community} from '../communities/community.js';
 
 	export let communities: Community[];
-	const submitName = async (name: string) => {
-		console.log(name);
+	export let communityFocus: Community;
+	const changeFocus = async (index: number) => {
+		$: communityFocus = communities[index];
 	};
 </script>
 
 <div class="sidenav">
-	{#each communities as {name} (name)}
-		<button type="button" on:click={() => submitName(name)}>{name} </button>
+	{#each communities as community, i}
+		<button type="button" on:click={() => changeFocus(i)}>{community.name} </button>
 	{/each}
 </div>
 
@@ -18,9 +19,10 @@
 		border: 1px outset grey;
 		background-color: lightGreen;
 		height: 75px;
-		width: 90%;
+		width: 75px;
 		cursor: pointer;
 		margin: 5%;
+		word-wrap: break-word;
 	}
 
 	button:active {
@@ -28,9 +30,8 @@
 	}
 
 	.sidenav {
-		width: 5%;
+		width: 85px;
 		height: 100%;
-		border: 2px outset black;
 		position: fixed;
 	}
 </style>

--- a/src/lib/CommunityNav.svelte
+++ b/src/lib/CommunityNav.svelte
@@ -3,10 +3,11 @@
 
 	export let communities: Community[];
 	export let selectedCommunity: Community;
-	//export const selectCommunity;
+	export let selectCommunity: (community: Community) => void;
 	let selectedCommunityIndex: number | null = null;
-	$: selectedCommunity = selectedCommunityIndex ?? communities[selectedCommunityIndex];
-	const changeFocus = (index: number) => selectedCommunityIndex = index;	
+	$: selectedCommunity = selectedCommunityIndex ?? communities[selectedCommunityIndex];	
+	const changeFocus = (index: number) => selectCommunity(communities[index]);	
+	
 </script>
 
 <div class="sidenav">

--- a/src/lib/CommunityNav.svelte
+++ b/src/lib/CommunityNav.svelte
@@ -5,12 +5,14 @@
 	export let selectedCommunity: Community;
 	export let selectCommunity: (community: Community) => void;
 	let selectedCommunityIndex: number | null = null;
-	$: selectedCommunity = selectedCommunityIndex ?? communities[selectedCommunityIndex];	
+	$: selectedCommunity = selectedCommunityIndex ?? communities[selectedCommunityIndex];
 </script>
 
 <div class="sidenav">
 	{#each communities as community, i}
-		<button type="button" on:click={() => selectCommunity(communities[i])}>{community.name} </button>
+		<button type="button" on:click={() => selectCommunity(communities[i])}
+			>{community.name}
+		</button>
 	{/each}
 </div>
 

--- a/src/lib/CommunityNav.svelte
+++ b/src/lib/CommunityNav.svelte
@@ -5,9 +5,8 @@
 	export let selectedCommunity: Community;
 	export let selectCommunity: (community: Community) => void;
 	let selectedCommunityIndex: number | null = null;
-	$: selectedCommunity = selectedCommunityIndex ?? communities[selectedCommunityIndex];	
-	const changeFocus = (index: number) => selectCommunity(communities[index]);	
-	
+	$: selectedCommunity = selectedCommunityIndex ?? communities[selectedCommunityIndex];
+	const changeFocus = (index: number) => selectCommunity(communities[index]);
 </script>
 
 <div class="sidenav">

--- a/src/lib/CommunityNav.svelte
+++ b/src/lib/CommunityNav.svelte
@@ -4,15 +4,11 @@
 	export let communities: Community[];
 	export let selectedCommunity: Community;
 	export let selectCommunity: (community: Community) => void;
-	let selectedCommunityIndex: number | null = null;
-	$: selectedCommunity = selectedCommunityIndex ?? communities[selectedCommunityIndex];
 </script>
 
 <div class="sidenav">
-	{#each communities as community, i}
-		<button type="button" on:click={() => selectCommunity(communities[i])}
-			>{community.name}
-		</button>
+	{#each communities as community (community.community_id)}
+		<button type="button" on:click={() => selectCommunity(community)}>{community.name} </button>
 	{/each}
 </div>
 

--- a/src/lib/SideNav.svelte
+++ b/src/lib/SideNav.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import type {Community} from '../communities/community.js';
 
-	//TODO there is an issue with the communities prop not properly clearing/updating on login/logout
 	export let communities: Community[];
 	const submitName = async (name: string) => {
 		console.log(name);

--- a/src/lib/SpaceNav.svelte
+++ b/src/lib/SpaceNav.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+	import type {Space} from '../spaces/space.js';
+
+	export let spaces: Space[];
+	const submitName = async (url: string) => {
+		console.log(url);
+	};
+</script>
+
+<div class="sidenav">
+	{#each spaces as {url} (url)}
+		<button type="button" on:click={() => submitName(url)}>{url} </button>
+	{/each}
+</div>
+
+<style>
+	button {
+		border: 1px outset grey;
+		background-color: lightGreen;
+		height: 75px;
+		width: 75px;
+		cursor: pointer;
+		margin: 5%;
+		word-wrap: break-word;
+	}
+
+	button:active {
+		background-color: grey;
+	}
+
+	.sidenav {
+		width: 85px;
+		height: 100%;
+		position: fixed;
+	}
+</style>

--- a/src/lib/SpaceNav.svelte
+++ b/src/lib/SpaceNav.svelte
@@ -8,9 +8,11 @@
 </script>
 
 <div class="sidenav">
-	{#each spaces as {url} (url)}
-		<button type="button" on:click={() => submitName(url)}>{url} </button>
-	{/each}
+	{#if spaces}
+		{#each spaces as {url} (url)}
+			<button type="button" on:click={() => submitName(url)}>{url} </button>
+		{/each}
+	{/if}
 </div>
 
 <style>

--- a/src/lib/SpaceNav.svelte
+++ b/src/lib/SpaceNav.svelte
@@ -8,11 +8,9 @@
 </script>
 
 <div class="sidenav">
-	{#if spaces}
-		{#each spaces as {url} (url)}
-			<button type="button" on:click={() => submitName(url)}>{url} </button>
-		{/each}
-	{/if}
+	{#each spaces as {url} (url)}
+		<button type="button" on:click={() => submitName(url)}>{url} </button>
+	{/each}
 </div>
 
 <style>

--- a/src/lib/Workspace.svelte
+++ b/src/lib/Workspace.svelte
@@ -3,15 +3,14 @@
 	import SpaceNav from '$lib/SpaceNav.svelte';
 	import type {Community} from 'src/communities/community.js';
 
-	export let communities: Community[];
-	let communityFocus: Community;
-	$: communityFocus = communities[0];
-	$: console.log(`the current community spaces are ${communityFocus.spaces}`);
+	export let communities: Community[];	
+	let selectedCommunity = communities[0];
+  const selectCommunity = (community: Community) => {selectedCommunity = community;};
 </script>
 
 <div class="workspace">
-	<section class="communitynav"><CommunityNav {communities} {communityFocus} /></section>
-	<section class="spacenav"><SpaceNav spaces={communityFocus.spaces} /></section>
+	<section class="communitynav"><CommunityNav {communities} {selectedCommunity}/></section>
+	<section class="spacenav"><SpaceNav spaces={selectedCommunity.spaces} /></section>
 	<div class="viewfinder">"hello this is where a chat box would go"</div>
 </div>
 

--- a/src/lib/Workspace.svelte
+++ b/src/lib/Workspace.svelte
@@ -4,9 +4,9 @@
 	import type {Community} from 'src/communities/community.js';
 
 	export let communities: Community[];
-	$: selectedCommunity = communities[0];
+	let selectedCommunity = communities[0];
 	const selectCommunity = (community: Community) => {
-		$: selectedCommunity = community;
+		selectedCommunity = community;
 	};
 </script>
 

--- a/src/lib/Workspace.svelte
+++ b/src/lib/Workspace.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+	import CommunityNav from '$lib/CommunityNav.svelte';
+	import SpaceNav from '$lib/SpaceNav.svelte';
+	import type {Community} from 'src/communities/community.js';
+
+	export let communities: Community[];
+	let communityFocus: Community;
+	$: communityFocus = communities[0];
+	$: console.log(`the current community spaces are ${communityFocus.spaces}`);
+</script>
+
+<div class="workspace">
+	<section class="communitynav"><CommunityNav {communities} {communityFocus} /></section>
+	<section class="spacenav"><SpaceNav spaces={communityFocus.spaces} /></section>
+	<div class="viewfinder">"hello this is where a chat box would go"</div>
+</div>
+
+<style>
+	.workspace {
+		height: 100%;
+		display: flex;
+	}
+
+	section {
+		height: 100%;
+		flex: 1;
+		border: 1px solid #ccc;
+	}
+
+	.viewfinder {
+		height: 100%;
+		border: 1px solid #ccc;
+		width: 80%;
+	}
+</style>

--- a/src/lib/Workspace.svelte
+++ b/src/lib/Workspace.svelte
@@ -3,13 +3,17 @@
 	import SpaceNav from '$lib/SpaceNav.svelte';
 	import type {Community} from 'src/communities/community.js';
 
-	export let communities: Community[];	
+	export let communities: Community[];
 	$: selectedCommunity = communities[0];
-  const selectCommunity = (community: Community) => {$: selectedCommunity = community;};  
+	const selectCommunity = (community: Community) => {
+		$: selectedCommunity = community;
+	};
 </script>
 
 <div class="workspace">
-	<section class="communitynav"><CommunityNav {communities} {selectedCommunity} {selectCommunity}/></section>
+	<section class="communitynav">
+		<CommunityNav {communities} {selectedCommunity} {selectCommunity} />
+	</section>
 	<section class="spacenav"><SpaceNav spaces={selectedCommunity.spaces} /></section>
 	<div class="viewfinder">"hello this is where a chat box would go"</div>
 </div>

--- a/src/lib/Workspace.svelte
+++ b/src/lib/Workspace.svelte
@@ -4,12 +4,12 @@
 	import type {Community} from 'src/communities/community.js';
 
 	export let communities: Community[];	
-	let selectedCommunity = communities[0];
-  const selectCommunity = (community: Community) => {selectedCommunity = community;};
+	$: selectedCommunity = communities[0];
+  const selectCommunity = (community: Community) => {$: selectedCommunity = community;};  
 </script>
 
 <div class="workspace">
-	<section class="communitynav"><CommunityNav {communities} {selectedCommunity}/></section>
+	<section class="communitynav"><CommunityNav {communities} {selectedCommunity} {selectCommunity}/></section>
 	<section class="spacenav"><SpaceNav spaces={selectedCommunity.spaces} /></section>
 	<div class="viewfinder">"hello this is where a chat box would go"</div>
 </div>

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -16,7 +16,7 @@
 
 <main>
 	{#if communities}
-	<Workspace {communities} />
+		<Workspace {communities} />
 	{/if}
 	<h1>{title}</h1>
 	<section>

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -15,7 +15,9 @@
 <svelte:head><title>{title}</title></svelte:head>
 
 <main>
+	{#if communities}
 	<Workspace {communities} />
+	{/if}
 	<h1>{title}</h1>
 	<section>
 		<AccountForm />
@@ -31,10 +33,6 @@
 	main {
 		text-align: center;
 		padding: 0 auto;
-	}
-
-	body {
-		width: 0px;
 	}
 
 	h1 {

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -1,9 +1,7 @@
 <script lang="ts">
 	import {session} from '$app/stores.js';
-	import Counter from '$lib/Counter.svelte';
-	import Echo from '$lib/Echo.svelte';
 	import AccountForm from '$lib/AccountForm.svelte';
-	import SideNav from '$lib/SideNav.svelte';
+	import Workspace from '$lib/Workspace.svelte';
 	import type {ClientAccount} from 'src/session/clientSession.js';
 	import type {Community} from 'src/communities/community.js';
 
@@ -17,16 +15,8 @@
 <svelte:head><title>{title}</title></svelte:head>
 
 <main>
-	{#if communities}
-		<SideNav {communities} />
-	{/if}
+	<Workspace {communities} />
 	<h1>{title}</h1>
-	<section>
-		<Counter />
-	</section>
-	<section>
-		<Echo />
-	</section>
 	<section>
 		<AccountForm />
 	</section>
@@ -40,9 +30,11 @@
 
 	main {
 		text-align: center;
-		padding: 1em;
-		margin: 0 auto;
 		padding: 0 auto;
+	}
+
+	body {
+		width: 0px;
 	}
 
 	h1 {
@@ -50,7 +42,6 @@
 		font-size: 4rem;
 		font-weight: 100;
 		line-height: 1.1;
-		margin: 4rem auto;
 		max-width: 14rem;
 	}
 


### PR DESCRIPTION
This PR adds `spaces` as an attribute of a community, pushes it up with an account's context, and then renders it.

@ryanatkn I think I'm barking up the wrong tree as far as reactivity goes. I was trying to get the selected community back up into the workspace and down into the `SpacesNav` but it clearly isn't working.

All the front end architecture is WIP, so open to any suggestions or paths forward there.