### PR TITLE
fix a type

### DIFF
--- a/src/spaces/space.ts
+++ b/src/spaces/space.ts
@@ -1,6 +1,10 @@
+import type {PartialOnly} from '@feltcoop/gro';
+
 export interface Space {
-	space_id?: number;
+	space_id: number;
 	url: string;
 	media_type: string;
 	content: string;
 }
+
+export type SpacePartial = PartialOnly<Space, 'space_id'>;

--- a/src/spaces/space.ts
+++ b/src/spaces/space.ts
@@ -1,10 +1,6 @@
-import type {OmitStrict} from '@feltcoop/gro';
-
 export interface Space {
 	space_id: number;
 	url: string;
 	media_type: string;
 	content: string;
 }
-
-export type SpacePartial = OmitStrict<Space, 'space_id'>;

--- a/src/spaces/space.ts
+++ b/src/spaces/space.ts
@@ -1,4 +1,4 @@
-import type {PartialOnly} from '@feltcoop/gro';
+import type {OmitStrict} from '@feltcoop/gro';
 
 export interface Space {
 	space_id: number;
@@ -7,4 +7,4 @@ export interface Space {
 	content: string;
 }
 
-export type SpacePartial = PartialOnly<Space, 'space_id'>;
+export type SpacePartial = OmitStrict<Space, 'space_id'>;


### PR DESCRIPTION
I think this is a better pattern for now, fixes an error in a Svelte component.

`SpacePartial` should be used in places where we don't yet have the id.

It could probably use a better name, but the idea is that we have a separate document type in some circumstances.