### PR TITLE
add global app.css

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -1,0 +1,8 @@
+html {
+	height: 100%;
+}
+
+body {
+	height: 100%;
+	background: #fff7f7;
+}

--- a/src/routes/$layout.svelte
+++ b/src/routes/$layout.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import '../app.css';
 	import SocketConnection from '$lib/SocketConnection.svelte';
 	import {createSocketStore} from '$lib/socketStore';
 	import {setContext} from 'svelte';


### PR DESCRIPTION
This adds `src/app.css` and imports it from `src/routes/$layout.svelte`, which is the pattern the SvelteKit default now uses to get a global CSS file loaded on every page. We want to keep it small, but this is the place to put our global (static) styles. We'll eventually move this code into `@feltcoop/felt`, but it helps flesh out our requirements.

Now when we add component styles, like to buttons, we can decide whether they're global design system rules, or specific to the component.