### PR TITLE
Added some front end logic to fix state errors with new accounts

### DIFF
--- a/src/lib/ChatRoom.svelte
+++ b/src/lib/ChatRoom.svelte
@@ -57,14 +57,14 @@
 </script>
 
 <div class="chatRoom">
-	<input type="text" placeholder="> chat" on:keydown={onKeyDown} bind:value={text} />
 	<PostList posts={$posts} />
+	<input type="text" placeholder="> chat" on:keydown={onKeyDown} bind:value={text} />
 </div>
 
 <style>
 	.chatRoom {
 		display: flex;
 		flex-direction: column;
-		align-items: center;
+		align-items: left;
 	}
 </style>

--- a/src/lib/CommunityNav.svelte
+++ b/src/lib/CommunityNav.svelte
@@ -8,9 +8,9 @@
 	export let selectedCommunity: Community;
 	export let selectCommunity: (community: Community) => void;
 
-	$: invitableFriends = friends.filter(
-		(x) => !selectedCommunity.members.some((y) => x.account_id == y.account_id),
-	);
+	$: invitableFriends = selectedCommunity
+		? friends.filter((x) => !selectedCommunity.members.some((y) => x.account_id == y.account_id))
+		: [];
 
 	let newName = '';
 
@@ -89,29 +89,31 @@
 		</Modal>
 
 		<!--TODO: Make an IconButton component in felt and use it here-->
-		|
-		<Modal let:open={openModal} let:close={closeModal}>
-			<span slot="trigger">
-				<button
-					aria-label="Invite users to {selectedCommunity.name}"
-					type="button"
-					class="button-emoji"
-					on:click={() => openModal()}>✉️</button
-				>
-			</span>
-			<div slot="header">
-				<h1>Invite users to {selectedCommunity.name}</h1>
-			</div>
-			<div slot="content">
-				{#each invitableFriends as friend (friend.account_id)}
-					<p>
-						<button type="button" class="button-join" on:click={() => inviteFriend(friend)}>
-							{friend.name}
-						</button>
-					</p>
-				{/each}
-			</div>
-		</Modal>
+		{#if selectedCommunity}
+			|
+			<Modal let:open={openModal} let:close={closeModal}>
+				<span slot="trigger">
+					<button
+						aria-label="Invite users to {selectedCommunity.name}"
+						type="button"
+						class="button-emoji"
+						on:click={() => openModal()}>✉️</button
+					>
+				</span>
+				<div slot="header">
+					<h1>Invite users to {selectedCommunity.name}</h1>
+				</div>
+				<div slot="content">
+					{#each invitableFriends as friend (friend.account_id)}
+						<p>
+							<button type="button" class="button-join" on:click={() => inviteFriend(friend)}>
+								{friend.name}
+							</button>
+						</p>
+					{/each}
+				</div>
+			</Modal>
+		{/if}
 	</div>
 	{#each communities as community (community.community_id)}
 		<button type="button" class="button-nav" on:click={() => selectCommunity(community)}>
@@ -147,5 +149,6 @@
 		width: 85px;
 		height: 100%;
 		position: fixed;
+		background: #3bbb3b;
 	}
 </style>

--- a/src/lib/SpaceNav.svelte
+++ b/src/lib/SpaceNav.svelte
@@ -64,15 +64,6 @@
 				</p>
 			</div>
 		</Modal>
-
-		<!--TODO: Make an IconButton component in felt and use it here-->
-		|
-		<button
-			aria-label="Search Spaces"
-			type="button"
-			class="button-emoji"
-			on:click={() => console.log('search')}>🔍</button
-		>
 	</div>
 	{#each spaces as space (space.space_id)}
 		<button type="button" class="button-nav" on:click={() => selectSpace(space)}>{space.url}</button

--- a/src/lib/Workspace.svelte
+++ b/src/lib/Workspace.svelte
@@ -8,20 +8,16 @@
 
 	export let friends: Member[];
 	export let communities: Community[];
-	let selectedCommunity = communities ? communities[0] : {};
-	let selectedCommunitySpaces = selectedCommunity ? selectedCommunity.spaces : [];
+	let selectedCommunity = communities[0] || null;
+	$: selectedCommunitySpaces = selectedCommunity?.spaces || null;
 	const selectCommunity = (community: Community) => {
 		selectedCommunity = community;
-		selectedCommunitySpaces = community.spaces;
 	};
 	let selectedSpace = selectedCommunity ? selectedCommunity.spaces[0] : null;
 	const selectSpace = (space: Space) => {
 		selectedSpace = space;
 		console.log(`[ss] ${selectedSpace.url}`);
 	};
-	if (selectedSpace) {
-		console.log('selectedSpace', selectedSpace);
-	}
 </script>
 
 <div class="workspace">

--- a/src/lib/Workspace.svelte
+++ b/src/lib/Workspace.svelte
@@ -8,15 +8,20 @@
 
 	export let friends: Member[];
 	export let communities: Community[];
-	let selectedCommunity = communities[0];
+	let selectedCommunity = communities ? communities[0] : {};
+	let selectedCommunitySpaces = selectedCommunity ? selectedCommunity.spaces : [];
 	const selectCommunity = (community: Community) => {
 		selectedCommunity = community;
+		selectedCommunitySpaces = community.spaces;
 	};
-	let selectedSpace = selectedCommunity.spaces[0];
+	let selectedSpace = selectedCommunity ? selectedCommunity.spaces[0] : null;
 	const selectSpace = (space: Space) => {
 		selectedSpace = space;
 		console.log(`[ss] ${selectedSpace.url}`);
 	};
+	if (selectedSpace) {
+		console.log('selectedSpace', selectedSpace);
+	}
 </script>
 
 <div class="workspace">
@@ -24,15 +29,19 @@
 		<CommunityNav {friends} {communities} {selectedCommunity} {selectCommunity} />
 	</section>
 	<section class="spacenav">
-		<SpaceNav
-			community={selectedCommunity}
-			spaces={selectedCommunity.spaces}
-			{selectedSpace}
-			{selectSpace}
-		/>
+		{#if selectedCommunity}
+			<SpaceNav
+				community={selectedCommunity}
+				spaces={selectedCommunitySpaces}
+				{selectedSpace}
+				{selectSpace}
+			/>
+		{/if}
 	</section>
 	<div class="viewfinder">
-		<ChatRoom space={selectedSpace} />
+		{#if selectedSpace}
+			<ChatRoom space={selectedSpace} />
+		{/if}
 	</div>
 </div>
 


### PR DESCRIPTION
This PR fixes an issue where new accounts were bugging out due to missing communities & spaces. This adds some more front end validation to help render the screen for when accounts have no community, or when a community has no spaces.

I also tweaked the styling to make the community nav stand out, & put the chat input box at the bottom of it's component.