### PR TITLE
add instructions to setup postgres defaults

### DIFF
--- a/src/db/README.md
+++ b/src/db/README.md
@@ -27,6 +27,17 @@ idle_timeout = PGIDLE_TIMEOUT
 connect_timeout = PGCONNECT_TIMEOUT
 ```
 
+To set up the database with the expected defaults:
+
+```bash
+sudo -u postgres psql
+# in psql:
+# postgres=#
+create database felt; # notice the semicolon
+\password
+<enter "password">
+```
+
 > TODO figure out config, maybe through `src/gro.config.ts`
 
 ## database tasks


### PR DESCRIPTION
This documents the steps needed to get a fresh Postgres installation ready with `felt-server`'s default values. It's copy-paste from our private notes.