### PR TITLE
import styles from felt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@feltcoop/felt": "^0.4.3",
+        "@feltcoop/felt": "^0.4.4",
         "@polka/send-type": "^0.5.2",
         "@types/ws": "^7.4.4",
         "body-parser": "^1.19.0",
@@ -22,7 +22,7 @@
         "ws": "^7.4.4"
       },
       "devDependencies": {
-        "@feltcoop/gro": "^0.34.1",
+        "@feltcoop/gro": "^0.34.2",
         "@sveltejs/adapter-node": "^1.0.0-next.26",
         "@sveltejs/kit": "^1.0.0-next.115",
         "@types/body-parser": "^1.19.0",
@@ -39,9 +39,9 @@
       }
     },
     "node_modules/@feltcoop/felt": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@feltcoop/felt/-/felt-0.4.3.tgz",
-      "integrity": "sha512-RD7uq2DVxmrIcalcm3xpQTw9wz8pg/RUCaABisBuxgIsqo4CfNLYOXWqc+wl4Vtr7yrBROAOrRmbVJT6SoyXRA==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@feltcoop/felt/-/felt-0.4.4.tgz",
+      "integrity": "sha512-JTOMFMO2sUTKMAdT8T7a1rgfcogNhQ+7Sh8S6LUHLU57o01YklBLdIerYiMUH2Oa2LNzzkQGqZFcDUJmMrFZJQ==",
       "dependencies": {
         "@lukeed/uuid": "^2.0.0",
         "dequal": "^2.0.2",
@@ -52,9 +52,9 @@
       }
     },
     "node_modules/@feltcoop/gro": {
-      "version": "0.34.1",
-      "resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.34.1.tgz",
-      "integrity": "sha512-Pl9dN5YUarJMAclW1Mkl66fIJ+IyoavClkUI3xM5cWySOeLtmyX8w4pUfkWt6sUdaS3F8Vww4mxGpEwEBInNSg==",
+      "version": "0.34.2",
+      "resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.34.2.tgz",
+      "integrity": "sha512-1RP41WajN79hP56b2pID5DTf+f9Cb5G4kD0R3tzvp/kzMbi0MIrflHWwvo6RGsuMA9iBaIOqkwfSOyKzUE6kEQ==",
       "dev": true,
       "dependencies": {
         "@feltcoop/felt": "^0.4.0",
@@ -1848,9 +1848,9 @@
   },
   "dependencies": {
     "@feltcoop/felt": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@feltcoop/felt/-/felt-0.4.3.tgz",
-      "integrity": "sha512-RD7uq2DVxmrIcalcm3xpQTw9wz8pg/RUCaABisBuxgIsqo4CfNLYOXWqc+wl4Vtr7yrBROAOrRmbVJT6SoyXRA==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@feltcoop/felt/-/felt-0.4.4.tgz",
+      "integrity": "sha512-JTOMFMO2sUTKMAdT8T7a1rgfcogNhQ+7Sh8S6LUHLU57o01YklBLdIerYiMUH2Oa2LNzzkQGqZFcDUJmMrFZJQ==",
       "requires": {
         "@lukeed/uuid": "^2.0.0",
         "dequal": "^2.0.2",
@@ -1858,9 +1858,9 @@
       }
     },
     "@feltcoop/gro": {
-      "version": "0.34.1",
-      "resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.34.1.tgz",
-      "integrity": "sha512-Pl9dN5YUarJMAclW1Mkl66fIJ+IyoavClkUI3xM5cWySOeLtmyX8w4pUfkWt6sUdaS3F8Vww4mxGpEwEBInNSg==",
+      "version": "0.34.2",
+      "resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.34.2.tgz",
+      "integrity": "sha512-1RP41WajN79hP56b2pID5DTf+f9Cb5G4kD0R3tzvp/kzMbi0MIrflHWwvo6RGsuMA9iBaIOqkwfSOyKzUE6kEQ==",
       "dev": true,
       "requires": {
         "@feltcoop/felt": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "node": ">= 14.16.0"
   },
   "devDependencies": {
-    "@feltcoop/gro": "^0.34.1",
+    "@feltcoop/gro": "^0.34.2",
     "@sveltejs/adapter-node": "^1.0.0-next.26",
     "@sveltejs/kit": "^1.0.0-next.115",
     "@types/body-parser": "^1.19.0",
@@ -34,7 +34,7 @@
     "typescript": "^4.3.2"
   },
   "dependencies": {
-    "@feltcoop/felt": "^0.4.3",
+    "@feltcoop/felt": "^0.4.4",
     "@polka/send-type": "^0.5.2",
     "@types/ws": "^7.4.4",
     "body-parser": "^1.19.0",

--- a/src/app.css
+++ b/src/app.css
@@ -1,8 +1,0 @@
-html {
-	height: 100%;
-}
-
-body {
-	height: 100%;
-	background: #fff7f7;
-}

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import '../app.css';
+	import '@feltcoop/felt/ui/style.css';
 	import {setContext} from 'svelte';
 
 	import Socket_Connection from '$lib/ui/Socket_Connection.svelte';

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -17,7 +17,6 @@
 <svelte:head><title>{title}</title></svelte:head>
 
 <main>
-	<h1>{title}</h1>
 	<section>
 		<Account_Form />
 	</section>
@@ -25,33 +24,3 @@
 		<Workspace {friends} {communities} />
 	{/if}
 </main>
-
-<style>
-	:root {
-		font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell,
-			'Open Sans', 'Helvetica Neue', sans-serif;
-	}
-
-	main {
-		text-align: center;
-		padding: 0 auto;
-	}
-
-	h1 {
-		color: #ff3e00;
-		font-size: 4rem;
-		font-weight: 100;
-		line-height: 1.1;
-		max-width: 14rem;
-	}
-
-	section {
-		padding: 30px 10px;
-	}
-
-	@media (min-width: 480px) {
-		h1 {
-			max-width: none;
-		}
-	}
-</style>


### PR DESCRIPTION
closes #56 

Imports the newly published `@feltcoop/felt/ui/style.css` in the global layout. To render document-formatted text and other markup, wrap it in `@feltcoop/felt/ui/Markup.svelte` to apply correct styles.