### PR TITLE
add devmode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@feltcoop/felt": "^0.4.5",
+        "@feltcoop/felt": "^0.5.0",
         "@polka/send-type": "^0.5.2",
         "@types/ws": "^7.4.4",
         "body-parser": "^1.19.0",
@@ -38,9 +38,9 @@
       }
     },
     "node_modules/@feltcoop/felt": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/@feltcoop/felt/-/felt-0.4.5.tgz",
-      "integrity": "sha512-G+P3Ehq/WMjwaD7aX7NcteEw342hfEfJCUTNv8ZvPlVGgzTV3edno96bqzS9SJ7tOvQs1rT8P7qBgjWl7hDiyA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@feltcoop/felt/-/felt-0.5.0.tgz",
+      "integrity": "sha512-GiGZAJJjN5k5BH1yK+1dG41NHHnupFqcKJdUIBxY7+0gfPcvcus2QyO5alTDSsglT9LpxChaXjn2ImLS4HD7nQ==",
       "dependencies": {
         "@lukeed/uuid": "^2.0.0",
         "dequal": "^2.0.2",
@@ -85,6 +85,20 @@
       },
       "engines": {
         "node": ">=14.16.0"
+      }
+    },
+    "node_modules/@feltcoop/gro/node_modules/@feltcoop/felt": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@feltcoop/felt/-/felt-0.4.5.tgz",
+      "integrity": "sha512-G+P3Ehq/WMjwaD7aX7NcteEw342hfEfJCUTNv8ZvPlVGgzTV3edno96bqzS9SJ7tOvQs1rT8P7qBgjWl7hDiyA==",
+      "dev": true,
+      "dependencies": {
+        "@lukeed/uuid": "^2.0.0",
+        "dequal": "^2.0.2",
+        "kleur": "^4.1.4"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
       }
     },
     "node_modules/@lukeed/csprng": {
@@ -1752,9 +1766,9 @@
   },
   "dependencies": {
     "@feltcoop/felt": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/@feltcoop/felt/-/felt-0.4.5.tgz",
-      "integrity": "sha512-G+P3Ehq/WMjwaD7aX7NcteEw342hfEfJCUTNv8ZvPlVGgzTV3edno96bqzS9SJ7tOvQs1rT8P7qBgjWl7hDiyA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@feltcoop/felt/-/felt-0.5.0.tgz",
+      "integrity": "sha512-GiGZAJJjN5k5BH1yK+1dG41NHHnupFqcKJdUIBxY7+0gfPcvcus2QyO5alTDSsglT9LpxChaXjn2ImLS4HD7nQ==",
       "requires": {
         "@lukeed/uuid": "^2.0.0",
         "dequal": "^2.0.2",
@@ -1790,6 +1804,19 @@
         "tslib": "^2.3.0",
         "typescript": "^4.3.5",
         "uvu": "^0.5.1"
+      },
+      "dependencies": {
+        "@feltcoop/felt": {
+          "version": "0.4.5",
+          "resolved": "https://registry.npmjs.org/@feltcoop/felt/-/felt-0.4.5.tgz",
+          "integrity": "sha512-G+P3Ehq/WMjwaD7aX7NcteEw342hfEfJCUTNv8ZvPlVGgzTV3edno96bqzS9SJ7tOvQs1rT8P7qBgjWl7hDiyA==",
+          "dev": true,
+          "requires": {
+            "@lukeed/uuid": "^2.0.0",
+            "dequal": "^2.0.2",
+            "kleur": "^4.1.4"
+          }
+        }
       }
     },
     "@lukeed/csprng": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "typescript": "^4.3.5"
   },
   "dependencies": {
-    "@feltcoop/felt": "^0.4.5",
+    "@feltcoop/felt": "^0.5.0",
     "@polka/send-type": "^0.5.2",
     "@types/ws": "^7.4.4",
     "body-parser": "^1.19.0",

--- a/src/lib/ui/Socket_Connection.svelte
+++ b/src/lib/ui/Socket_Connection.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
 	import {onMount} from 'svelte';
+	import {get_devmode} from '@feltcoop/felt/ui/devmode.js';
 
 	import type {Socket_Store} from '$lib/ui/socket_store.js';
+
+	const devmode = get_devmode();
 
 	let url = `ws://localhost:3002/ws`;
 	export let socket: Socket_Store;
@@ -15,35 +18,37 @@
 	});
 </script>
 
-<div class="socket-connection">
-	{#if $socket.connected}
-		<form>
-			<input bind:value={url} type="text" disabled />
-			<button
-				type="button"
-				on:click={() => socket.disconnect()}
-				disabled={$socket.status === 'pending'}
-			>
-				disconnect
-			</button>
-		</form>
-	{:else}
-		<form>
-			<input bind:value={url} type="text" disabled={$socket.status === 'pending'} />
-			<button
-				type="button"
-				on:click={() => socket.connect(url)}
-				disabled={$socket.status === 'pending'}
-			>
-				connect
-			</button>
-		</form>
-	{/if}
-	<h2>status: <code>'{$socket.status}'</code></h2>
-	{#if $socket.error}
-		<h2 class="error">error: <code>'{$socket.error}'</code></h2>
-	{/if}
-</div>
+{#if $devmode}
+	<div class="socket-connection">
+		{#if $socket.connected}
+			<form>
+				<input bind:value={url} type="text" disabled />
+				<button
+					type="button"
+					on:click={() => socket.disconnect()}
+					disabled={$socket.status === 'pending'}
+				>
+					disconnect
+				</button>
+			</form>
+		{:else}
+			<form>
+				<input bind:value={url} type="text" disabled={$socket.status === 'pending'} />
+				<button
+					type="button"
+					on:click={() => socket.connect(url)}
+					disabled={$socket.status === 'pending'}
+				>
+					connect
+				</button>
+			</form>
+		{/if}
+		<h2>status: <code>'{$socket.status}'</code></h2>
+		{#if $socket.error}
+			<h2 class="error">error: <code>'{$socket.error}'</code></h2>
+		{/if}
+	</div>
+{/if}
 
 <style>
 	.socket-connection {

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import '@feltcoop/felt/ui/style.css';
 	import {setContext} from 'svelte';
+	import {set_devmode} from '@feltcoop/felt/ui/devmode.js';
+	import Devmode from '@feltcoop/felt/ui/Devmode.svelte';
 
 	import '$lib/ui/style.css';
 	import Socket_Connection from '$lib/ui/Socket_Connection.svelte';
@@ -8,6 +10,8 @@
 
 	const socket = create_socket_store();
 	setContext('socket', socket);
+
+	const devmode = set_devmode();
 </script>
 
 <svelte:head>
@@ -19,3 +23,5 @@
 <Socket_Connection {socket} />
 
 <slot />
+
+<Devmode {devmode} />

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -19,9 +19,6 @@ export default {
 					// 'ws://localhost:3000': 'ws://localhost:3001/',
 				},
 			},
-			ssr: {
-				noExternal: ['@feltcoop/felt'],
-			},
 			optimizeDeps: {
 				exclude: ['@feltcoop/felt'],
 			},

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -19,6 +19,12 @@ export default {
 					// 'ws://localhost:3000': 'ws://localhost:3001/',
 				},
 			},
+			ssr: {
+				noExternal: ['@feltcoop/felt'],
+			},
+			optimizeDeps: {
+				exclude: ['@feltcoop/felt'],
+			},
 		},
 	},
 };


### PR DESCRIPTION
Adds the `devmode` top-level component and context store. To use it from anywhere in the component tree during component initialization:

```ts
import {get_devmode} from '@feltcoop/felt/ui/devmode.js';
const devmode = get_devmode(); // reads from context
$devmode; // writable store
```

Also had to add the `optimizeDeps` Vite config option to fix bundling, but unlike the SSR error we don't need the `ssr` config. Without the `optimizeDeps` override, it fails to prebundle properly, messing up Svelte's initialization. The newly imported Felt code uses Svelte's context helpers, so that's the root cause of this specific issue.