### PR TITLE
fix socket disconnect

### DIFF
--- a/src/lib/ui/Main_Nav.svelte
+++ b/src/lib/ui/Main_Nav.svelte
@@ -3,7 +3,6 @@
 	import Space_Nav from '$lib/ui/Space_Nav.svelte';
 	import Socket_Connection from '$lib/ui/Socket_Connection.svelte';
 	import Account_Form from '$lib/ui/Account_Form.svelte';
-	import {get_socket} from '$lib/ui/socket';
 	import {get_data} from '$lib/ui/data';
 	import {get_ui} from '$lib/ui/ui';
 
@@ -27,12 +26,10 @@
 	// $: console.log('[Main_Nav] communities', communities);
 	// $: console.log('[Main_Nav] selected_community', selected_community);
 	// $: console.log('[Main_Nav] selected_space', selected_space);
-
-	const socket = get_socket();
 </script>
 
 <div class="main-nav">
-	<Socket_Connection {socket} />
+	<Socket_Connection />
 	<Account_Form />
 	<div class="explorer">
 		{#if selected_community}

--- a/src/lib/ui/Socket_Connection.svelte
+++ b/src/lib/ui/Socket_Connection.svelte
@@ -2,12 +2,13 @@
 	import {onMount} from 'svelte';
 	import {get_devmode} from '@feltcoop/felt/ui/devmode.js';
 
-	import type {Socket_Store} from '$lib/ui/socket.js';
+	import {get_socket} from '$lib/ui/socket';
+
+	const socket = get_socket();
 
 	const devmode = get_devmode();
 
 	let url = `ws://localhost:3002/ws`;
-	export let socket: Socket_Store;
 
 	onMount(() => {
 		const {hostname} = window.location;
@@ -15,6 +16,9 @@
 		url = `ws://${hostname}:3002/ws`;
 		console.log('created socket store', socket, url);
 		socket.connect(url); // TODO should be reactive to `url` changes
+		return () => {
+			socket.disconnect();
+		};
 	});
 </script>
 

--- a/src/lib/ui/socket.ts
+++ b/src/lib/ui/socket.ts
@@ -91,6 +91,7 @@ export const to_socket_store = () => {
 		subscribe,
 		disconnect: (code = 1000) => {
 			update(($socket) => {
+				// TODO this is buggy if `connect` is still pending
 				console.log('[socket] disconnect', code, $socket);
 				if (!$socket.connected || !$socket.ws || $socket.status !== 'success') {
 					throw Error('Socket cannot disconnect because it is not connected'); // TODO return errors instead?

--- a/src/lib/ui/socket.ts
+++ b/src/lib/ui/socket.ts
@@ -1,6 +1,7 @@
 import type {Async_Status} from '@feltcoop/felt';
 import type {Json} from '@feltcoop/felt/util/json.js';
 import {writable} from 'svelte/store';
+import type {Readable} from 'svelte/store';
 import {setContext, getContext} from 'svelte';
 
 import {messages} from '$lib/ui/messages_store';
@@ -29,8 +30,12 @@ export interface Socket_State {
 	send_count: number;
 }
 
-// TODO is this the preferred type definition?
-export type Socket_Store = ReturnType<typeof to_socket_store>;
+export interface Socket_Store {
+	subscribe: Readable<Socket_State>['subscribe'];
+	disconnect: (code?: number) => void;
+	connect: (url: string) => void;
+	send: (data: Json) => void;
+}
 
 export const to_socket_store = () => {
 	const {subscribe, update} = writable<Socket_State>(to_default_socket_state(), () => {
@@ -43,32 +48,6 @@ export const to_socket_store = () => {
 	const unsubscribe = subscribe((value) => {
 		console.log('[socket] store subscriber', value);
 	});
-
-	const disconnect = (code = 1000): void => {
-		update(($socket) => {
-			console.log('[socket] disconnect', code, $socket.url);
-			if (!$socket.ws) return $socket;
-			$socket.ws.close(code);
-			return {...$socket, status: 'pending', connected: false, ws: null, url: null};
-		});
-	};
-
-	const connect = (url: string): void => {
-		console.log('[socket] connect', url);
-		update(($socket) => {
-			if ($socket.connected || $socket.ws || $socket.status !== 'initial') {
-				throw Error('socket already connected'); // TODO return errors instead?
-			}
-			return {
-				...$socket,
-				url,
-				connected: false,
-				status: 'pending',
-				ws: create_web_socket(url),
-				error: null,
-			};
-		});
-	};
 
 	const create_web_socket = (url: string): WebSocket => {
 		const ws = new WebSocket(url);
@@ -108,16 +87,45 @@ export const to_socket_store = () => {
 		return ws;
 	};
 
-	const send = (data: Json) => {
-		console.log('[ws] sending ', data);
-		update(($socket) => {
-			if (!$socket.ws) return $socket;
-			$socket.ws.send(JSON.stringify(data));
-			return {...$socket, send_count: $socket.send_count + 1};
-		});
+	const store: Socket_Store = {
+		subscribe,
+		disconnect: (code = 1000) => {
+			update(($socket) => {
+				console.log('[socket] disconnect', code, $socket);
+				if (!$socket.connected || !$socket.ws || $socket.status !== 'success') {
+					throw Error('Socket cannot disconnect because it is not connected'); // TODO return errors instead?
+				}
+				$socket.ws.close(code);
+				return {...$socket, status: 'pending', connected: false, ws: null, url: null};
+			});
+		},
+		connect: (url) => {
+			update(($socket) => {
+				console.log('[socket] connect', $socket);
+				if ($socket.connected || $socket.ws || $socket.status !== 'initial') {
+					throw Error('Socket cannot connect because it is already connected'); // TODO return errors instead?
+				}
+				return {
+					...$socket,
+					url,
+					connected: false,
+					status: 'pending',
+					ws: create_web_socket(url),
+					error: null,
+				};
+			});
+		},
+		send: (data) => {
+			update(($socket) => {
+				console.log('[ws] send', data, $socket);
+				if (!$socket.ws) return $socket;
+				$socket.ws.send(JSON.stringify(data));
+				return {...$socket, send_count: $socket.send_count + 1};
+			});
+		},
 	};
 
-	return {subscribe, disconnect, connect, send};
+	return store;
 };
 
 const to_default_socket_state = (): Socket_State => ({


### PR DESCRIPTION
Fixes the socket disconnect issue, so when the user logs out it'll disconnect. It's being encapsulated in the `Socket_Connection.svelte` component, so mounting/unmounting that component controls the socket lifecycle. I don't love the flexibility this gives us with putting the socket in context and having it tied to the component lifecycle, but it's fine for now. There's a source of truth issue here with the socket url that I don't know how to fix. We know we need multiple concurrent sockets to various servers, so I suspect we'll want to rework this to be more data-driven from the top.

Also refactors the `Socket_Store` to match the pattern elsewhere, giving us better types.