### PR TITLE
refactor socket to not be dependent on ui component

### DIFF
--- a/src/lib/ui/Main_Nav.svelte
+++ b/src/lib/ui/Main_Nav.svelte
@@ -46,7 +46,6 @@
 		>
 			{$data.account.name}
 		</button>
-		<Socket_Connection />
 	</div>
 	{#if $ui.main_nav_view === 'explorer'}
 		<div class="explorer">
@@ -62,6 +61,7 @@
 		</div>
 	{:else if $ui.main_nav_view === 'account'}
 		<Account_Form />
+		<Socket_Connection />
 	{/if}
 </div>
 

--- a/src/lib/ui/Socket_Connection.svelte
+++ b/src/lib/ui/Socket_Connection.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-	import {dev} from '$app/env';
-	import {onMount} from 'svelte';
 	import {get_devmode} from '@feltcoop/felt/ui/devmode.js';
 
 	import {get_socket} from '$lib/ui/socket';
@@ -8,27 +6,16 @@
 	const socket = get_socket();
 	const devmode = get_devmode();
 
-	$: url = '';
-
-	onMount(() => {
-		if (dev) {
-			url = `ws://localhost:3000/ws`;
-		} else {
-			url = `wss://staging.felt.dev/ws`;
-		}
-		console.log('created socket store', socket, url);
-		socket.connect(url); // TODO should be reactive to `url` changes
-		return () => {
-			socket.disconnect();
-		};
-	});
+	let new_url = $socket.url || '';
+	const reset_url = () => (new_url = $socket.url || '');
+	$: if ($socket.connected) reset_url();
 </script>
 
 {#if $devmode}
 	<div class="socket-connection">
 		{#if $socket.connected}
 			<form>
-				<input bind:value={url} type="text" disabled />
+				<input bind:value={new_url} type="text" disabled />
 				<button
 					type="button"
 					on:click={() => socket.disconnect()}
@@ -39,10 +26,10 @@
 			</form>
 		{:else}
 			<form>
-				<input bind:value={url} type="text" disabled={$socket.status === 'pending'} />
+				<input bind:value={new_url} type="text" disabled={$socket.status === 'pending'} />
 				<button
 					type="button"
-					on:click={() => socket.connect(url)}
+					on:click={() => socket.connect(new_url)}
 					disabled={$socket.status === 'pending'}
 				>
 					connect

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -20,22 +20,10 @@
 	const ui = set_ui();
 	$: ui.update_data($data); // TODO this or make it an arg to the ui store?
 	set_api(to_api_store(ui, data));
-	// TODO consider higher order components instead of linking stores together like this,
-	// 	continuing component-level composition:
-	// 	<Ui>
-	// 		<Data>
-	// 			<Api>
-	// 				<Main_Nav />
-	// 			</Api>
-	// 		</Data>
-	// 	</Ui>
-
-	console.log('$data', $data);
 
 	onMount(() => {
-		const url = dev ? `ws://localhost:3001/ws` : `wss://staging.felt.dev/ws`;
-		console.log('created socket store', $socket, url);
-		socket.connect(url); // TODO should be reactive to `url` changes
+		const socket_url = dev ? `ws://localhost:3001/ws` : `wss://staging.felt.dev/ws`;
+		socket.connect(socket_url);
 		return () => {
 			socket.disconnect();
 		};

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -3,7 +3,9 @@
 	import '@feltcoop/felt/ui/style.css';
 	import {set_devmode} from '@feltcoop/felt/ui/devmode.js';
 	import Devmode from '@feltcoop/felt/ui/Devmode.svelte';
+	import {onMount} from 'svelte';
 	import {session} from '$app/stores';
+	import {dev} from '$app/env';
 
 	import {set_socket} from '$lib/ui/socket';
 	import Main_Nav from '$lib/ui/Main_Nav.svelte';
@@ -12,7 +14,7 @@
 	import {set_api, to_api_store} from '$lib/ui/api';
 
 	const devmode = set_devmode();
-	set_socket();
+	const socket = set_socket();
 	const data = set_data($session);
 	$: data.update_session($session);
 	const ui = set_ui();
@@ -29,6 +31,15 @@
 	// 	</Ui>
 
 	console.log('$data', $data);
+
+	onMount(() => {
+		const url = dev ? `ws://localhost:3001/ws` : `wss://staging.felt.dev/ws`;
+		console.log('created socket store', $socket, url);
+		socket.connect(url); // TODO should be reactive to `url` changes
+		return () => {
+			socket.disconnect();
+		};
+	});
 </script>
 
 <svelte:head>


### PR DESCRIPTION
Currently the socket is disconnected when the `Socket_Connection` component is unmounted. This change decouples the socket connection from its controls, hoisting the connection logic to the top-level layout, making the `Socket_Connection` UI optional. Without this change, the socket disconnects when the luggage goes into the closet!