### PR TITLE
add space type rendering for notes and iframes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@feltcoop/felt": "^0.6.0",
+        "@feltcoop/felt": "^0.7.0",
         "@polka/send-type": "^0.5.2",
         "@types/ws": "^7.4.4",
         "body-parser": "^1.19.0",
@@ -39,16 +39,16 @@
       }
     },
     "node_modules/@feltcoop/felt": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@feltcoop/felt/-/felt-0.6.0.tgz",
-      "integrity": "sha512-C68nk64bpGozMV0byMm/VkrEdOUcS7uyw5XpCF4cTADFXxwiqzBolh8kCeMTq8hSHLF2eCxhnbfqyp7HKvgqWw==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@feltcoop/felt/-/felt-0.7.0.tgz",
+      "integrity": "sha512-eCc4IIZW7HTa0O31c0GJDCUQXUBrn88+pskk+DQQlIHOzfzhVsf3OasMGiuluwb8dOhKrbRyZ62PAWwldbPDPg==",
       "dependencies": {
         "@lukeed/uuid": "^2.0.0",
         "dequal": "^2.0.2",
         "kleur": "^4.1.4"
       },
       "engines": {
-        "node": ">= 14.16.0"
+        "node": ">=16.6.0"
       },
       "peerDependencies": {
         "@sveltejs/kit": "^1.0.0-next.136",
@@ -1769,9 +1769,9 @@
   },
   "dependencies": {
     "@feltcoop/felt": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@feltcoop/felt/-/felt-0.6.0.tgz",
-      "integrity": "sha512-C68nk64bpGozMV0byMm/VkrEdOUcS7uyw5XpCF4cTADFXxwiqzBolh8kCeMTq8hSHLF2eCxhnbfqyp7HKvgqWw==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@feltcoop/felt/-/felt-0.7.0.tgz",
+      "integrity": "sha512-eCc4IIZW7HTa0O31c0GJDCUQXUBrn88+pskk+DQQlIHOzfzhVsf3OasMGiuluwb8dOhKrbRyZ62PAWwldbPDPg==",
       "requires": {
         "@lukeed/uuid": "^2.0.0",
         "dequal": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "typescript": "^4.3.5"
   },
   "dependencies": {
-    "@feltcoop/felt": "^0.6.0",
+    "@feltcoop/felt": "^0.7.0",
     "@polka/send-type": "^0.5.2",
     "@types/ws": "^7.4.4",
     "body-parser": "^1.19.0",

--- a/src/lib/db/Database.ts
+++ b/src/lib/db/Database.ts
@@ -218,19 +218,19 @@ export class Database {
 					this.repos.spaces.insert(community_id, {
 						name: 'chat',
 						url: '/chat',
-						media_type: 'application/json',
+						media_type: 'application/fuz+json',
 						content: '{"type": "Chat", "props": {"data": "/chat/posts"}}',
 					}),
 					this.repos.spaces.insert(community_id, {
 						name: 'board',
 						url: '/board',
-						media_type: 'application/json',
+						media_type: 'application/fuz+json',
 						content: '{"type": "Board", "props": {"data": "/board/posts"}}',
 					}),
 					this.repos.spaces.insert(community_id, {
 						name: 'voice',
 						url: '/voice',
-						media_type: 'application/json',
+						media_type: 'application/fuz+json',
 						content: '{"type": "Voice", "props": {"data": "/voice/stream"}}',
 					}),
 				]);

--- a/src/lib/db/seed.ts
+++ b/src/lib/db/seed.ts
@@ -289,7 +289,7 @@ export const seed = async (db: Database): Promise<void> => {
 			name: 'felt library',
 			url: '/felt-library',
 			media_type: 'application/fuz+json',
-			content: '{"type": "Iframe", "props": {"url": "https://www.felt.dev/sketch/library"}}',
+			content: '{"type": "Iframe", "props": {"url": "https://www.dealt.dev/tar"}}',
 		};
 		const space5_result = await sql`
 			insert into spaces ${sql(space5, 'url', 'media_type', 'content')}

--- a/src/lib/db/seed.ts
+++ b/src/lib/db/seed.ts
@@ -286,8 +286,8 @@ export const seed = async (db: Database): Promise<void> => {
 	const space5 = space_docs.find((d) => d.space_id === 5);
 	if (!space5) {
 		const space5: Space_Params = {
-			name: 'felt library',
-			url: '/felt-library',
+			name: 'dealt: tar',
+			url: '/tar',
 			media_type: 'application/fuz+json',
 			content: '{"type": "Iframe", "props": {"url": "https://www.dealt.dev/tar"}}',
 		};

--- a/src/lib/db/seed.ts
+++ b/src/lib/db/seed.ts
@@ -232,8 +232,8 @@ export const seed = async (db: Database): Promise<void> => {
 		const space1: Space_Params = {
 			name: 'general',
 			url: '/general',
-			media_type: 'application/json',
-			content: '{"type": "Chat_Room", "props": {"data": "/general/posts"}}',
+			media_type: 'application/fuz+json',
+			content: '{"type": "Chat", "props": {"data": "/general/posts"}}',
 		};
 		const space1_result = await sql`
 			insert into spaces ${sql(space1, 'url', 'media_type', 'content')}
@@ -246,8 +246,8 @@ export const seed = async (db: Database): Promise<void> => {
 		const space2: Space_Params = {
 			name: 'general/cute',
 			url: '/general/cute',
-			media_type: 'application/json',
-			content: '{"type": "Chat_Room", "props": {"data": "/general/cute/posts"}}',
+			media_type: 'application/fuz+json',
+			content: '{"type": "Chat", "props": {"data": "/general/cute/posts"}}',
 		};
 		const space2_result = await sql`
 			insert into spaces ${sql(space2, 'url', 'media_type', 'content')}
@@ -260,13 +260,41 @@ export const seed = async (db: Database): Promise<void> => {
 		const space3: Space_Params = {
 			name: 'dm/a',
 			url: '/dm/a',
-			media_type: 'application/json',
-			content: '{"type": "DirectMessage", "props": {"data": "/dm/a/posts"}}',
+			media_type: 'application/fuz+json',
+			content: '{"type": "Chat", "props": {"data": "/dm/a/posts"}}',
 		};
 		const space3_result = await sql`
 			insert into spaces ${sql(space3, 'url', 'media_type', 'content')}
 		`;
 		console.log('[db] create_space3_result', space3_result);
+	}
+
+	const space4 = space_docs.find((d) => d.space_id === 4);
+	if (!space4) {
+		const space4: Space_Params = {
+			name: 'notes',
+			url: '/notes',
+			media_type: 'application/fuz+json',
+			content: '{"type": "Notes", "props": {"data": "/notes"}}',
+		};
+		const space4_result = await sql`
+			insert into spaces ${sql(space4, 'url', 'media_type', 'content')}
+		`;
+		console.log('[db] create_space4_result', space4_result);
+	}
+
+	const space5 = space_docs.find((d) => d.space_id === 5);
+	if (!space5) {
+		const space5: Space_Params = {
+			name: 'felt library',
+			url: '/felt-library',
+			media_type: 'application/fuz+json',
+			content: '{"type": "Iframe", "props": {"url": "https://www.felt.dev/sketch/library"}}',
+		};
+		const space5_result = await sql`
+			insert into spaces ${sql(space5, 'url', 'media_type', 'content')}
+		`;
+		console.log('[db] create_space5_result', space5_result);
 	}
 
 	const community_spaces1_doc = community_spaces_docs.find(
@@ -300,6 +328,28 @@ export const seed = async (db: Database): Promise<void> => {
 			insert into community_spaces ${sql(community_spaces3, 'space_id', 'community_id')}
 		`;
 		console.log('[db] community_spaces3_result', community_spaces3_result);
+	}
+
+	const community_spaces4_doc = community_spaces_docs.find(
+		(d) => d.space_id === 4 && d.community_id === 1,
+	);
+	if (!community_spaces4_doc) {
+		const community_spaces4: Community_Spaces_Params = {space_id: 4, community_id: 1};
+		const community_spaces4_result = await sql`
+			insert into community_spaces ${sql(community_spaces4, 'space_id', 'community_id')}
+		`;
+		console.log('[db] community_spaces4_result', community_spaces4_result);
+	}
+
+	const community_spaces5_doc = community_spaces_docs.find(
+		(d) => d.space_id === 5 && d.community_id === 1,
+	);
+	if (!community_spaces5_doc) {
+		const community_spaces5: Community_Spaces_Params = {space_id: 5, community_id: 1};
+		const community_spaces5_result = await sql`
+			insert into community_spaces ${sql(community_spaces5, 'space_id', 'community_id')}
+		`;
+		console.log('[db] community_spaces5_result', community_spaces5_result);
 	}
 
 	const post1 = post_docs.find((d) => d.post_id === 1);

--- a/src/lib/spaces/space_middleware.ts
+++ b/src/lib/spaces/space_middleware.ts
@@ -1,7 +1,7 @@
 import send from '@polka/send-type';
 
 import type {Api_Server, Middleware} from '$lib/server/Api_Server.js';
-import type {Space_Params} from './space';
+import type {Space_Params} from '$lib/spaces/space';
 
 //Returns a single space object
 export const to_space_middleware = (server: Api_Server): Middleware => {

--- a/src/lib/ui/Chat.svelte
+++ b/src/lib/ui/Chat.svelte
@@ -54,11 +54,11 @@
 		overflow: hidden; /* make the content scroll */
 	}
 	.posts {
+		overflow: auto;
 		flex: 1;
 		display: flex;
-		flex-direction: column;
-		justify-content: flex-end;
-		overflow: auto;
+		/* makes scrolling start at the bottom */
+		flex-direction: column-reverse;
 	}
 	input {
 		border-left: none;

--- a/src/lib/ui/Chat.svelte
+++ b/src/lib/ui/Chat.svelte
@@ -1,14 +1,13 @@
 <script lang="ts">
 	import {browser} from '$app/env';
-	import type {Json} from '@feltcoop/felt/util/json.js';
 
 	import type {Space} from '$lib/spaces/space.js';
 	import type {Member} from '$lib/members/member.js';
 	import Post_List from '$lib/ui/Post_List.svelte';
 	import {posts} from '$lib/ui/post_store';
-	import {get_socket} from '$lib/ui/socket';
+	import {get_api} from '$lib/ui/api';
 
-	const socket = get_socket();
+	const api = get_api();
 
 	export let space: Space;
 	export let members_by_id: Map<number, Member>;
@@ -16,8 +15,9 @@
 	let text = '';
 
 	$: browser && load_posts(space.space_id);
-	$: console.log(`[chat_room] fetching posts for ${space.space_id}`);
+	$: console.log(`[Chat] fetching posts for ${space.space_id}`);
 
+	// TODO refactor
 	const load_posts = async (space_id: number) => {
 		const res = await fetch(`/api/v1/spaces/${space_id}/posts`);
 		if (res.ok) {
@@ -28,29 +28,8 @@
 
 	const create_post = async () => {
 		if (!text) return;
-		const res = await fetch(`/api/v1/spaces/${space.space_id}/posts`, {
-			method: 'POST',
-			headers: {'Content-Type': 'application/json'},
-			body: JSON.stringify({content: text}),
-		});
-		if (res.ok) {
-			console.log('post sent, broadcasting to server');
-			const data = await res.json();
-			broadcast_post(data);
-		} else {
-			console.error('error sending post');
-		}
+		await api.create_post(space, text);
 		text = '';
-	};
-
-	const broadcast_post = async (data: Json) => {
-		if (!$socket.connected) {
-			console.error('expected socket to be connected to chat');
-			return;
-		}
-		// TODO the type of message created here does *not* include fields like `id`, `attributed_to`, etc - these are added by the server
-		// TODO this should create a client-side tracking object that we can monitor, cancel, organize, etc
-		socket.send(data);
 	};
 
 	const on_keydown = async (e: KeyboardEvent) => {
@@ -72,17 +51,20 @@
 		display: flex;
 		flex-direction: column;
 		flex: 1;
+		overflow: hidden; /* make the content scroll */
 	}
 	.posts {
 		flex: 1;
 		display: flex;
 		flex-direction: column;
 		justify-content: flex-end;
+		overflow: auto;
 	}
 	input {
 		border-left: none;
 		border-right: none;
 		border-bottom: none;
 		border-radius: 0;
+		margin: 0; /* TODO remove in felt@0.6.1 */
 	}
 </style>

--- a/src/lib/ui/Chat.svelte
+++ b/src/lib/ui/Chat.svelte
@@ -65,6 +65,5 @@
 		border-right: none;
 		border-bottom: none;
 		border-radius: 0;
-		margin: 0; /* TODO remove in felt@0.6.1 */
 	}
 </style>

--- a/src/lib/ui/Community_Nav.svelte
+++ b/src/lib/ui/Community_Nav.svelte
@@ -48,7 +48,7 @@
 	}
 
 	button {
-		width: var(--icon_size_lg);
-		height: var(--icon_size_lg);
+		width: var(--icon_size_md);
+		height: var(--icon_size_md);
 	}
 </style>

--- a/src/lib/ui/Iframe.svelte
+++ b/src/lib/ui/Iframe.svelte
@@ -1,16 +1,35 @@
 <script lang="ts">
 	import type {Space} from '$lib/spaces/space.js';
+	import Pending_Animation_Overlay from '$lib/ui/Pending_Animation_Overlay.svelte';
 
 	export let space: Space;
 	export let url: string; // TODO type
+
+	let loaded = false;
 </script>
 
 <!-- TODO figure out sandboxing -- allow-same-origin? -->
-<iframe sandbox="allow-scripts allow-pointer-lock" frameborder="0" title={space.name} src={url} />
+
+<div class="iframe-wrapper">
+	<iframe
+		sandbox="allow-scripts allow-pointer-lock"
+		frameborder="0"
+		title={space.name}
+		src={url}
+		on:load={() => (loaded = true)}
+	/>
+	{#if !loaded}
+		<Pending_Animation_Overlay />
+	{/if}
+</div>
 
 <style>
-	iframe {
+	.iframe-wrapper {
+		flex: 1;
 		display: flex;
+		position: relative; /* for the absolute positioned pending animation */
+	}
+	iframe {
 		flex: 1;
 	}
 </style>

--- a/src/lib/ui/Iframe.svelte
+++ b/src/lib/ui/Iframe.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import type {Space} from '$lib/spaces/space.js';
+
+	export let space: Space;
+	export let url: string; // TODO type
+</script>
+
+<!-- TODO figure out sandboxing -- allow-same-origin? -->
+<iframe sandbox="allow-scripts allow-pointer-lock" frameborder="0" title={space.name} src={url} />
+
+<style>
+	iframe {
+		display: flex;
+		flex: 1;
+	}
+</style>

--- a/src/lib/ui/Note_List.svelte
+++ b/src/lib/ui/Note_List.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	import type {Post} from '$lib/posts/post.js';
+	import Note_List_Item from '$lib/ui/Note_List_Item.svelte';
+
+	export let posts: Post[];
+
+	$: notes = posts.slice().reverse(); // TODO definitely not this
+</script>
+
+<ul>
+	{#each notes as post (post.post_id)}
+		<Note_List_Item {post} />
+	{/each}
+</ul>

--- a/src/lib/ui/Note_List.svelte
+++ b/src/lib/ui/Note_List.svelte
@@ -12,3 +12,11 @@
 		<Note_List_Item {post} />
 	{/each}
 </ul>
+
+<style>
+	ul {
+		display: flex;
+		flex-wrap: wrap;
+		flex-direction: row;
+	}
+</style>

--- a/src/lib/ui/Note_List_Item.svelte
+++ b/src/lib/ui/Note_List_Item.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import type {Post} from '$lib/posts/post.js';
+
+	export let post: Post;
+</script>
+
+<li>
+	{post.content}
+</li>
+
+<style>
+	li {
+		padding: var(--spacing_sm);
+		border-bottom: var(--border);
+	}
+</style>

--- a/src/lib/ui/Note_List_Item.svelte
+++ b/src/lib/ui/Note_List_Item.svelte
@@ -11,6 +11,10 @@
 <style>
 	li {
 		padding: var(--spacing_sm);
-		border-bottom: var(--border);
+		border: var(--border);
+		max-width: var(--column_width_min);
+		margin: 10px;
+		padding: 10px;
+		background-color: var(--input_bg_color);
 	}
 </style>

--- a/src/lib/ui/Notes.svelte
+++ b/src/lib/ui/Notes.svelte
@@ -56,7 +56,6 @@
 		border-right: none;
 		border-top: none;
 		border-radius: 0;
-		margin: 0; /* TODO remove in felt@6.1.0 */
 	}
 	.posts {
 		flex: 1;

--- a/src/lib/ui/Notes.svelte
+++ b/src/lib/ui/Notes.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+	import {browser} from '$app/env';
+
+	import type {Space} from '$lib/spaces/space.js';
+	import Note_List from '$lib/ui/Note_List.svelte';
+	import {posts} from '$lib/ui/post_store';
+	import {get_api} from '$lib/ui/api';
+
+	const api = get_api();
+
+	export let space: Space;
+
+	let text = '';
+
+	$: browser && load_posts(space.space_id);
+	$: console.log(`[Notes] fetching posts for ${space.space_id}`);
+
+	// TODO refactor
+	const load_posts = async (space_id: number) => {
+		const res = await fetch(`/api/v1/spaces/${space_id}/posts`);
+		if (res.ok) {
+			const data = await res.json();
+			posts.set(data.posts);
+		}
+	};
+
+	const create_post = async () => {
+		if (!text) return;
+		await api.create_post(space, text);
+		text = '';
+	};
+
+	const on_keydown = async (e: KeyboardEvent) => {
+		if (e.key === 'Enter') {
+			await create_post();
+		}
+	};
+</script>
+
+<div class="notes">
+	<textarea type="text" placeholder="> note" on:keydown={on_keydown} bind:value={text} />
+	<div class="posts">
+		<Note_List posts={$posts} />
+	</div>
+</div>
+
+<style>
+	.notes {
+		display: flex;
+		flex-direction: column;
+		flex: 1;
+		overflow: hidden; /* make the content scroll */
+	}
+	textarea {
+		border-left: none;
+		border-right: none;
+		border-top: none;
+		border-radius: 0;
+		margin: 0; /* TODO remove in felt@6.1.0 */
+	}
+	.posts {
+		flex: 1;
+		display: flex;
+		flex-direction: column;
+		overflow: auto;
+	}
+</style>

--- a/src/lib/ui/Pending_Animation_Overlay.svelte
+++ b/src/lib/ui/Pending_Animation_Overlay.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import Pending_Animation from '@feltcoop/felt/ui/Pending_Animation.svelte';
+</script>
+
+<div class="pending-animation-overlay">
+	<Pending_Animation />
+</div>
+
+<style>
+	.pending-animation-overlay {
+		position: absolute;
+		left: 0;
+		top: 0;
+		width: 100%;
+		height: 100%;
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		font-size: var(--font_size_xl7);
+	}
+</style>

--- a/src/lib/ui/Pending_Animation_Overlay.svelte
+++ b/src/lib/ui/Pending_Animation_Overlay.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	// TODO extract to Felt
 	import Pending_Animation from '@feltcoop/felt/ui/Pending_Animation.svelte';
 </script>
 

--- a/src/lib/ui/Post_List.svelte
+++ b/src/lib/ui/Post_List.svelte
@@ -14,6 +14,7 @@
 	};
 </script>
 
+<!-- TODO possibly remove the `ul` wrapper and change the `li`s to `div`s -->
 <ul>
 	{#each posts as post (post.post_id)}
 		<Post_List_Item {post} member={to_member(post.actor_id)} />

--- a/src/lib/ui/Space_Input.svelte
+++ b/src/lib/ui/Space_Input.svelte
@@ -26,7 +26,7 @@
 			community.community_id,
 			new_name,
 			url,
-//TODO : add space type picker
+			//TODO : add space type picker
 			'application/fuz+json',
 			`{"type": "Chat", "props": {"data": "${url}/posts"}}`,
 		);

--- a/src/lib/ui/Space_Input.svelte
+++ b/src/lib/ui/Space_Input.svelte
@@ -26,6 +26,7 @@
 			community.community_id,
 			new_name,
 			url,
+//TODO : add space type picker
 			'application/fuz+json',
 			`{"type": "Chat", "props": {"data": "${url}/posts"}}`,
 		);

--- a/src/lib/ui/Space_Input.svelte
+++ b/src/lib/ui/Space_Input.svelte
@@ -26,8 +26,8 @@
 			community.community_id,
 			new_name,
 			url,
-			'application/json',
-			`{"type": "Chat_Room", "props": {"data": "${url}/posts"}}`,
+			'application/fuz+json',
+			`{"type": "Chat", "props": {"data": "${url}/posts"}}`,
 		);
 		new_name = '';
 	};

--- a/src/lib/ui/Space_View.svelte
+++ b/src/lib/ui/Space_View.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+	import Chat from '$lib/ui/Chat.svelte';
+	import Notes from '$lib/ui/Notes.svelte';
+	import type {Space} from '$lib/spaces/space';
+	import Iframe from '$lib/ui/Iframe.svelte';
+	import type {Member} from '$lib/members/member';
+
+	export let space: Space;
+	export let members_by_id: Map<number, Member>;
+
+	// TODO types
+	const to_space_data = (space: Space): any => {
+		switch (space.media_type) {
+			case 'application/fuz+json': {
+				return JSON.parse(space.content);
+			}
+			default: {
+				return space.content;
+			}
+		}
+	};
+
+	$: space_data = to_space_data(space);
+	$: console.log('space_data', space_data);
+</script>
+
+<!-- TODO make this a lookup by type and handle generically -->
+{#if space_data.type === 'Chat'}
+	<Chat {space} {members_by_id} />
+{:else if space_data.type === 'Notes'}
+	<Notes {space} />
+{:else if space_data.type === 'Iframe'}
+	<Iframe {space} {...space_data.props} />
+{:else}
+	unknown space type: {space_data.type}
+{/if}

--- a/src/lib/ui/Workspace.svelte
+++ b/src/lib/ui/Workspace.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-	import Chat_Room from '$lib/ui/Chat_Room.svelte';
 	import Space_Input from '$lib/ui/Space_Input.svelte';
+	import Space_View from '$lib/ui/Space_View.svelte';
 	import Workspace_Header from '$lib/ui/Workspace_Header.svelte';
 	import {get_data} from '$lib/ui/data';
 	import {get_ui} from '$lib/ui/ui';
@@ -20,15 +20,12 @@
 		  )
 		: null;
 	$: members_by_id = selected_community?.members_by_id;
-
-	// $: console.log('[Workspace] selected_community', selected_community);
-	// $: console.log('[Workspace] selected_space', selected_space);
 </script>
 
 <div class="workspace">
 	<Workspace_Header space={selected_space} />
 	{#if selected_space && members_by_id}
-		<Chat_Room space={selected_space} {members_by_id} />
+		<Space_View space={selected_space} {members_by_id} />
 	{:else if selected_community}
 		<Space_Input community={selected_community}>Create a new space</Space_Input>
 	{/if}

--- a/src/lib/ui/style.css
+++ b/src/lib/ui/style.css
@@ -4,13 +4,7 @@
 	--bg_saturation: 23%;
 	--bg_lightness: 96%;
 	--bg_color_lightness: 91%; /* TODO ? */
-	/* TODO upgrade felt@0.6.1 and delete these */
-	--icon_size_xl: 6.4rem;
-	--icon_size_lg: 4.8rem;
-	--icon_size_md: 3.2rem;
-	--icon_size_sm: 2.4rem;
-	--icon_size_xs: 1.8rem;
-	--navbar_size: var(--icon_size_lg);
+	--navbar_size: var(--icon_size_md);
 }
 
 body {

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -19,7 +19,7 @@
 	$: data.update_session($session);
 	const ui = set_ui();
 	$: ui.update_data($data); // TODO this or make it an arg to the ui store?
-	set_api(to_api_store(ui, data));
+	set_api(to_api_store(ui, data, socket));
 
 	onMount(() => {
 		const socket_url = dev ? `ws://localhost:3001/ws` : `wss://staging.felt.dev/ws`;


### PR DESCRIPTION
- renders spaces based on their `media_type`
- renames `Chat` from `Chat_Room`
- adds a `Notes` component and seeds one
- adds an `Iframe` component and seeds one
- upgrades Felt

I originally tried to iframe Felt's library, but it loads, renders, and then errors with `The operation is insecure.`. Quick search didn't yield a workaround; not sure how to proceed right now, so I changed it to load dealt.dev/tar. Might be a sandbox attribute or something in SvelteKit? Based on the error, my guess is it's related to how SvelteKit is doing routing but I'm alright with iframing something else for now.