### PR TITLE
improve mobile view

### DIFF
--- a/src/lib/ui/Chat.svelte
+++ b/src/lib/ui/Chat.svelte
@@ -5,9 +5,9 @@
 	import type {Member} from '$lib/members/member.js';
 	import Post_List from '$lib/ui/Post_List.svelte';
 	import {posts} from '$lib/ui/post_store';
-	import {get_api} from '$lib/ui/api';
+	import {get_app} from '$lib/ui/app';
 
-	const api = get_api();
+	const {api} = get_app();
 
 	export let space: Space;
 	export let members_by_id: Map<number, Member>;

--- a/src/lib/ui/Community_Input.svelte
+++ b/src/lib/ui/Community_Input.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 	import Modal from '$lib/ui/Modal.svelte';
 	import Markup from '@feltcoop/felt/ui/Markup.svelte';
-	import {get_api} from '$lib/ui/api';
 	import {autofocus} from '$lib/ui/actions';
+	import {get_app} from '$lib/ui/app';
 
-	const api = get_api();
+	const {api} = get_app();
 
 	let new_name = '';
 

--- a/src/lib/ui/Community_Nav.svelte
+++ b/src/lib/ui/Community_Nav.svelte
@@ -2,9 +2,9 @@
 	import type {Community} from '$lib/communities/community.js';
 	import type {Member} from '$lib/members/member.js';
 	import Community_Input from '$lib/ui/Community_Input.svelte';
-	import {get_api} from '$lib/ui/api';
+	import {get_app} from '$lib/ui/app';
 
-	const api = get_api();
+	const {api} = get_app();
 
 	export let members: Member[];
 	export let communities: Community[];

--- a/src/lib/ui/Main_Nav.svelte
+++ b/src/lib/ui/Main_Nav.svelte
@@ -9,6 +9,11 @@
 
 	const {data, ui, api} = get_app();
 
+	// TODO share these vars with CSS
+	const MAIN_NAV_WIDTH = 320; // TODO this is the same as `column_width_min`
+	const NAV_TRANSITION_IN_DURATION = 410;
+	const BG_TRANSITION_IN_DURATION = 237;
+
 	$: members = $data.members;
 	$: communities = $data.communities;
 
@@ -30,10 +35,10 @@
 
 <div
 	class="main-nav-bg"
-	in:fade={{duration: 237}}
+	in:fade={{duration: BG_TRANSITION_IN_DURATION}}
 	on:click={() => ($ui.expand_main_nav ? api.toggle_main_nav() : null)}
 />
-<div class="main-nav" in:fly={{x: -320, duration: 410}}>
+<div class="main-nav" in:fly={{x: -MAIN_NAV_WIDTH, duration: NAV_TRANSITION_IN_DURATION}}>
 	<div class="header">
 		<button class="icon-button" on:click={() => api.toggle_main_nav()}> ☰ </button>
 		<button
@@ -91,7 +96,8 @@
 		/* TODO from felt */
 		background-color: rgba(0, 0, 0, 0.6);
 	}
-	@media (max-width: 800px) {
+	/* `50rem` in media queries is the same as `800px`, which is `--column_width` */
+	@media (max-width: 50rem) {
 		.main-nav {
 			z-index: 1;
 			position: fixed;
@@ -99,7 +105,7 @@
 			top: 0;
 		}
 		.main-nav-bg {
-			display: flex;
+			display: block;
 		}
 	}
 	.header {

--- a/src/lib/ui/Main_Nav.svelte
+++ b/src/lib/ui/Main_Nav.svelte
@@ -1,13 +1,17 @@
 <script lang="ts">
+	import {fly, fade} from 'svelte/transition';
+
 	import Community_Nav from '$lib/ui/Community_Nav.svelte';
 	import Space_Nav from '$lib/ui/Space_Nav.svelte';
 	import Socket_Connection from '$lib/ui/Socket_Connection.svelte';
 	import Account_Form from '$lib/ui/Account_Form.svelte';
 	import {get_data} from '$lib/ui/data';
 	import {get_ui} from '$lib/ui/ui';
+	import {get_api} from '$lib/ui/api';
 
 	const data = get_data();
 	const ui = get_ui();
+	const api = get_api();
 
 	$: members = $data.members;
 	$: communities = $data.communities;
@@ -28,8 +32,14 @@
 	// $: console.log('[Main_Nav] selected_space', selected_space);
 </script>
 
-<div class="main-nav">
+<div
+	class="main-nav-bg"
+	in:fade={{duration: 237}}
+	on:click={() => ($ui.expand_main_nav ? api.toggle_main_nav() : null)}
+/>
+<div class="main-nav" in:fly={{x: -320, duration: 410}}>
 	<div class="header">
+		<button class="icon-button" on:click={() => api.toggle_main_nav()}> ☰ </button>
 		<button
 			on:click={() => ui.set_main_nav_view('explorer')}
 			class:selected={$ui.main_nav_view === 'explorer'}
@@ -73,6 +83,28 @@
 		flex-shrink: 0;
 		border-left: var(--border);
 		border-right: var(--border);
+		background-color: var(--bg);
+	}
+	.main-nav-bg {
+		display: none;
+		position: fixed;
+		width: 100%;
+		height: 100%;
+		left: 0;
+		top: 0;
+		/* TODO from felt */
+		background-color: rgba(0, 0, 0, 0.6);
+	}
+	@media (max-width: 800px) {
+		.main-nav {
+			z-index: 1;
+			position: fixed;
+			left: 0;
+			top: 0;
+		}
+		.main-nav-bg {
+			display: flex;
+		}
 	}
 	.header {
 		display: flex;

--- a/src/lib/ui/Main_Nav.svelte
+++ b/src/lib/ui/Main_Nav.svelte
@@ -9,7 +9,7 @@
 
 	const {data, ui, api} = get_app();
 
-	// TODO share these vars with CSS
+	// TODO upstream these vars to Felt and share with CSS
 	const MAIN_NAV_WIDTH = 320; // TODO this is the same as `column_width_min`
 	const NAV_TRANSITION_IN_DURATION = 410;
 	const BG_TRANSITION_IN_DURATION = 237;

--- a/src/lib/ui/Main_Nav.svelte
+++ b/src/lib/ui/Main_Nav.svelte
@@ -5,13 +5,9 @@
 	import Space_Nav from '$lib/ui/Space_Nav.svelte';
 	import Socket_Connection from '$lib/ui/Socket_Connection.svelte';
 	import Account_Form from '$lib/ui/Account_Form.svelte';
-	import {get_data} from '$lib/ui/data';
-	import {get_ui} from '$lib/ui/ui';
-	import {get_api} from '$lib/ui/api';
+	import {get_app} from '$lib/ui/app';
 
-	const data = get_data();
-	const ui = get_ui();
-	const api = get_api();
+	const {data, ui, api} = get_app();
 
 	$: members = $data.members;
 	$: communities = $data.communities;

--- a/src/lib/ui/Main_Nav.svelte
+++ b/src/lib/ui/Main_Nav.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-	import {fly, fade} from 'svelte/transition';
-
 	import Community_Nav from '$lib/ui/Community_Nav.svelte';
 	import Space_Nav from '$lib/ui/Space_Nav.svelte';
 	import Socket_Connection from '$lib/ui/Socket_Connection.svelte';
@@ -8,11 +6,6 @@
 	import {get_app} from '$lib/ui/app';
 
 	const {data, ui, api} = get_app();
-
-	// TODO upstream these vars to Felt and share with CSS
-	const MAIN_NAV_WIDTH = 320; // TODO this is the same as `column_width_min`
-	const NAV_TRANSITION_IN_DURATION = 410;
-	const BG_TRANSITION_IN_DURATION = 237;
 
 	$: members = $data.members;
 	$: communities = $data.communities;
@@ -35,10 +28,10 @@
 
 <div
 	class="main-nav-bg"
-	in:fade={{duration: BG_TRANSITION_IN_DURATION}}
+	class:expanded={$ui.expand_main_nav}
 	on:click={() => ($ui.expand_main_nav ? api.toggle_main_nav() : null)}
 />
-<div class="main-nav" in:fly={{x: -MAIN_NAV_WIDTH, duration: NAV_TRANSITION_IN_DURATION}}>
+<div class="main-nav" class:expanded={$ui.expand_main_nav}>
 	<div class="header">
 		<button class="icon-button" on:click={() => api.toggle_main_nav()}> ☰ </button>
 		<button
@@ -76,6 +69,8 @@
 
 <style>
 	.main-nav {
+		position: relative;
+		z-index: 1;
 		height: 100%;
 		width: var(--column_width_min);
 		overflow: auto;
@@ -86,7 +81,11 @@
 		border-right: var(--border);
 		background-color: var(--bg);
 	}
+	.main-nav.expanded {
+		animation: fly-in var(--transition_duration_md) ease-out;
+	}
 	.main-nav-bg {
+		z-index: 1;
 		display: none;
 		position: fixed;
 		width: 100%;
@@ -106,6 +105,9 @@
 		}
 		.main-nav-bg {
 			display: block;
+		}
+		.main-nav-bg.expanded {
+			animation: fade-in var(--transition_duration_sm) linear;
 		}
 	}
 	.header {

--- a/src/lib/ui/Member_Input.svelte
+++ b/src/lib/ui/Member_Input.svelte
@@ -3,9 +3,9 @@
 	import Modal from '$lib/ui/Modal.svelte';
 	import Markup from '@feltcoop/felt/ui/Markup.svelte';
 	import type {Member} from '$lib/members/member.js';
-	import {get_api} from '$lib/ui/api';
+	import {get_app} from '$lib/ui/app';
 
-	const api = get_api();
+	const {api} = get_app();
 
 	export let members: Member[];
 	export let community: Community;

--- a/src/lib/ui/Notes.svelte
+++ b/src/lib/ui/Notes.svelte
@@ -4,9 +4,9 @@
 	import type {Space} from '$lib/spaces/space.js';
 	import Note_List from '$lib/ui/Note_List.svelte';
 	import {posts} from '$lib/ui/post_store';
-	import {get_api} from '$lib/ui/api';
+	import {get_app} from '$lib/ui/app';
 
-	const api = get_api();
+	const {api} = get_app();
 
 	export let space: Space;
 

--- a/src/lib/ui/Socket_Connection.svelte
+++ b/src/lib/ui/Socket_Connection.svelte
@@ -1,10 +1,7 @@
 <script lang="ts">
-	import {get_devmode} from '@feltcoop/felt/ui/devmode.js';
+	import {get_app} from '$lib/ui/app';
 
-	import {get_socket} from '$lib/ui/socket';
-
-	const socket = get_socket();
-	const devmode = get_devmode();
+	const {socket, devmode} = get_app();
 
 	let new_url = $socket.url || '';
 	const reset_url = () => (new_url = $socket.url || '');

--- a/src/lib/ui/Space_Input.svelte
+++ b/src/lib/ui/Space_Input.svelte
@@ -2,10 +2,10 @@
 	import Modal from '$lib/ui/Modal.svelte';
 	import Markup from '@feltcoop/felt/ui/Markup.svelte';
 	import type {Community_Model} from '$lib/communities/community.js';
-	import {get_api} from '$lib/ui/api';
 	import {autofocus} from '$lib/ui/actions';
+	import {get_app} from '$lib/ui/app';
 
-	const api = get_api();
+	const {api} = get_app();
 
 	export let community: Community_Model;
 

--- a/src/lib/ui/Space_Nav.svelte
+++ b/src/lib/ui/Space_Nav.svelte
@@ -2,11 +2,11 @@
 	import type {Space} from '$lib/spaces/space.js';
 	import Space_Input from '$lib/ui/Space_Input.svelte';
 	import type {Community_Model} from '$lib/communities/community.js';
-	import {get_api} from '$lib/ui/api';
 	import Member_Input from '$lib/ui/Member_Input.svelte';
 	import type {Member} from '$lib/members/member.js';
+	import {get_app} from '$lib/ui/app';
 
-	const api = get_api();
+	const {api} = get_app();
 
 	export let community: Community_Model;
 	export let spaces: Space[];

--- a/src/lib/ui/Workspace.svelte
+++ b/src/lib/ui/Workspace.svelte
@@ -2,11 +2,9 @@
 	import Space_Input from '$lib/ui/Space_Input.svelte';
 	import Space_View from '$lib/ui/Space_View.svelte';
 	import Workspace_Header from '$lib/ui/Workspace_Header.svelte';
-	import {get_data} from '$lib/ui/data';
-	import {get_ui} from '$lib/ui/ui';
+	import {get_app} from '$lib/ui/app';
 
-	const data = get_data();
-	const ui = get_ui();
+	const {data, ui} = get_app();
 
 	$: communities = $data.communities;
 

--- a/src/lib/ui/Workspace_Header.svelte
+++ b/src/lib/ui/Workspace_Header.svelte
@@ -1,14 +1,16 @@
 <script lang="ts">
 	import {get_api} from '$lib/ui/api';
+	import {get_ui} from '$lib/ui/ui';
 	import type {Space} from '$lib/spaces/space';
 
 	const api = get_api();
+	const ui = get_ui();
 
 	export let space: Space | null | undefined;
 </script>
 
-<div class="workspace-header">
-	<button on:click={() => api.toggle_main_nav()}> ☰ </button>
+<div class="workspace-header" class:expanded-nav={$ui.expand_main_nav}>
+	<button class="icon-button" on:click={() => api.toggle_main_nav()}> ☰ </button>
 	<div>{space?.url}</div>
 </div>
 
@@ -21,9 +23,16 @@
 		border-bottom: var(--border);
 		font-size: var(--font_size_xl);
 	}
-	button {
-		width: var(--navbar_size);
-		height: var(--navbar_size);
+	.icon-button {
+		display: block;
 		margin-right: var(--spacing_lg);
+	}
+	.expanded-nav .icon-button {
+		display: none;
+	}
+	@media (max-width: 800px) {
+		.workspace-header .icon-button {
+			display: block;
+		}
 	}
 </style>

--- a/src/lib/ui/Workspace_Header.svelte
+++ b/src/lib/ui/Workspace_Header.svelte
@@ -1,10 +1,8 @@
 <script lang="ts">
-	import {get_api} from '$lib/ui/api';
-	import {get_ui} from '$lib/ui/ui';
 	import type {Space} from '$lib/spaces/space';
+	import {get_app} from '$lib/ui/app';
 
-	const api = get_api();
-	const ui = get_ui();
+	const {ui, api} = get_app();
 
 	export let space: Space | null | undefined;
 </script>

--- a/src/lib/ui/Workspace_Header.svelte
+++ b/src/lib/ui/Workspace_Header.svelte
@@ -27,7 +27,8 @@
 	.expanded-nav .icon-button {
 		display: none;
 	}
-	@media (max-width: 800px) {
+	/* `50rem` in media queries is the same as `800px`, which is `--column_width` */
+	@media (max-width: 50rem) {
 		.workspace-header .icon-button {
 			display: block;
 		}

--- a/src/lib/ui/Workspace_Header.svelte
+++ b/src/lib/ui/Workspace_Header.svelte
@@ -22,7 +22,6 @@
 		font-size: var(--font_size_xl);
 	}
 	.icon-button {
-		display: block;
 		margin-right: var(--spacing_lg);
 	}
 	.expanded-nav .icon-button {

--- a/src/lib/ui/app.ts
+++ b/src/lib/ui/app.ts
@@ -1,0 +1,26 @@
+import {setContext, getContext} from 'svelte';
+import type {Writable} from 'svelte/store';
+
+import type {Data_Store} from '$lib/ui/data';
+import type {Ui_Store} from '$lib/ui/ui';
+import type {Api_Store} from '$lib/ui/api';
+import type {Socket_Store} from '$lib/ui/socket';
+
+// TODO refactor/rethink
+
+export interface App_Stores {
+	api: Api_Store;
+	data: Data_Store;
+	ui: Ui_Store;
+	socket: Socket_Store;
+	devmode: Writable<boolean>;
+}
+
+const KEY = Symbol();
+
+export const get_app = (): App_Stores => getContext(KEY);
+
+export const set_app = (stores: App_Stores): App_Stores => {
+	setContext(KEY, stores);
+	return stores;
+};

--- a/src/lib/ui/data.ts
+++ b/src/lib/ui/data.ts
@@ -7,6 +7,8 @@ import {Community_Model, to_community_model} from '$lib/communities/community';
 import type {Member} from '$lib/members/member';
 import type {Space} from '$lib/spaces/space';
 
+// TODO refactor/rethink
+
 // TODO name? maybe `db`? do we need more abstractions?
 
 const KEY = Symbol();

--- a/src/lib/ui/style.css
+++ b/src/lib/ui/style.css
@@ -5,6 +5,9 @@
 	--bg_lightness: 96%;
 	--bg_color_lightness: 91%; /* TODO ? */
 	--navbar_size: var(--icon_size_md);
+
+	--transition_duration_md: 0.32s;
+	--transition_duration_sm: 0.24s;
 }
 
 body {
@@ -19,8 +22,29 @@ main {
 	width: 100%;
 }
 
-/* TODO refactor or upstream */
+/* TODO refactor or upstream -- `navbar_size` maybe should be `input_height` */
 .icon-button {
 	width: var(--navbar_size);
 	height: var(--navbar_size);
+}
+
+/* TODO upstream to Felt */
+@keyframes fade-in {
+	from {
+		opacity: 0;
+	}
+	to {
+		opacity: 1;
+	}
+}
+
+@keyframes fly-in {
+	from {
+		transform: translate3d(-100%, 0, 0);
+		opacity: 0;
+	}
+	to {
+		transform: translate3d(0, 0, 0);
+		opacity: 1;
+	}
 }

--- a/src/lib/ui/style.css
+++ b/src/lib/ui/style.css
@@ -18,3 +18,9 @@ body {
 main {
 	width: 100%;
 }
+
+/* TODO refactor or upstream */
+.icon-button {
+	width: var(--navbar_size);
+	height: var(--navbar_size);
+}

--- a/src/lib/ui/ui.ts
+++ b/src/lib/ui/ui.ts
@@ -2,6 +2,8 @@ import {Readable, writable} from 'svelte/store';
 import {setContext, getContext} from 'svelte';
 import type {Data_State} from '$lib/ui/data';
 
+// TODO refactor/rethink
+
 const KEY = Symbol();
 
 export const get_ui = (): Ui_Store => getContext(KEY);

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -12,6 +12,7 @@
 	import {set_data} from '$lib/ui/data';
 	import {set_ui} from '$lib/ui/ui';
 	import {set_api, to_api_store} from '$lib/ui/api';
+	import {set_app} from '$lib/ui/app';
 
 	const devmode = set_devmode();
 	const socket = set_socket();
@@ -19,7 +20,9 @@
 	$: data.update_session($session);
 	const ui = set_ui();
 	$: ui.update_data($data); // TODO this or make it an arg to the ui store?
-	set_api(to_api_store(ui, data, socket));
+	const api = set_api(to_api_store(ui, data, socket));
+	const app = set_app({data, ui, api, devmode, socket});
+	console.log('app', app);
 
 	onMount(() => {
 		const socket_url = dev ? `ws://localhost:3001/ws` : `wss://staging.felt.dev/ws`;


### PR DESCRIPTION
Makes the mobile view much better, using animations and responsive layout on the main menu.

Also adds an `app` context helper to keep things succinct. I think it's a good call but I could be off.

Possible followup TODOs for later PRs:

- [ ] keep the menu button fixed onscreen z-index overlaying the menu as it slides in/out, so quick tapping always hits it
- [ ] consider a transition out animation
- [ ] consider ways to share the media query size with the JS variable to DRY things up, tweak the transitions for desktop vs mobile, and avoid inserting the bg element into the DOM when not used -- gets tricky with SSR