### PR TITLE
add luggage object permanence

### DIFF
--- a/src/lib/ui/Chat.svelte
+++ b/src/lib/ui/Chat.svelte
@@ -54,6 +54,7 @@
 		overflow: hidden; /* make the content scroll */
 	}
 	.posts {
+		max-width: var(--column_width);
 		overflow: auto;
 		flex: 1;
 		display: flex;

--- a/src/lib/ui/Login_Form.svelte
+++ b/src/lib/ui/Login_Form.svelte
@@ -2,6 +2,7 @@
 	import {session} from '$app/stores';
 	import {tick} from 'svelte';
 	import Pending_Animation from '@feltcoop/felt/ui/Pending_Animation.svelte';
+	import Markup from '@feltcoop/felt/ui/Markup.svelte';
 
 	import type {Login_Request} from '$lib/session/login_middleware.js';
 	import {autofocus} from '$lib/ui/actions';
@@ -69,33 +70,35 @@
 
 <div class="login-wrapper">
 	<img src="/favicon.png" alt="felt heart" />
-	<form>
-		<input
-			type="text"
-			bind:this={account_name_el}
-			bind:value={account_name}
-			on:keypress={on_keypress}
-			{disabled}
-			placeholder="account name"
-			use:autofocus
-		/>
-		<input
-			type="password"
-			bind:this={password_el}
-			bind:value={password}
-			on:keypress={on_keypress}
-			{disabled}
-			placeholder="password"
-		/>
-		<button type="button" bind:this={button_el} on:click={submit_name} {disabled}>
-			{#if submitting}
-				<Pending_Animation />
-			{:else}log in{/if}
-		</button>
-		{#if error_message}
-			<div class="error">{error_message}</div>
-		{/if}
-	</form>
+	<Markup>
+		<form>
+			<input
+				type="text"
+				bind:this={account_name_el}
+				bind:value={account_name}
+				on:keypress={on_keypress}
+				{disabled}
+				placeholder="account name"
+				use:autofocus
+			/>
+			<input
+				type="password"
+				bind:this={password_el}
+				bind:value={password}
+				on:keypress={on_keypress}
+				{disabled}
+				placeholder="password"
+			/>
+			<button type="button" bind:this={button_el} on:click={submit_name} {disabled}>
+				{#if submitting}
+					<Pending_Animation />
+				{:else}log in{/if}
+			</button>
+			{#if error_message}
+				<div class="error">{error_message}</div>
+			{/if}
+		</form>
+	</Markup>
 </div>
 
 <style>
@@ -111,7 +114,6 @@
 		font-weight: bold;
 		color: rgb(73, 84, 153);
 	}
-
 	form {
 		display: flex;
 		flex-direction: column;

--- a/src/lib/ui/Login_Form.svelte
+++ b/src/lib/ui/Login_Form.svelte
@@ -2,7 +2,7 @@
 	import {session} from '$app/stores';
 	import {tick} from 'svelte';
 	import Pending_Animation from '@feltcoop/felt/ui/Pending_Animation.svelte';
-	import Markup from '@feltcoop/felt/ui/Markup.svelte';
+	import {icons} from '@feltcoop/felt';
 
 	import type {Login_Request} from '$lib/session/login_middleware.js';
 	import {autofocus} from '$lib/ui/actions';
@@ -68,48 +68,36 @@
 	};
 </script>
 
-<div class="login-wrapper">
+<div class="icon">
 	<img src="/favicon.png" alt="felt heart" />
-	<Markup>
-		<form>
-			<input
-				type="text"
-				bind:this={account_name_el}
-				bind:value={account_name}
-				on:keypress={on_keypress}
-				{disabled}
-				placeholder="account name"
-				use:autofocus
-			/>
-			<input
-				type="password"
-				bind:this={password_el}
-				bind:value={password}
-				on:keypress={on_keypress}
-				{disabled}
-				placeholder="password"
-			/>
-			<button type="button" bind:this={button_el} on:click={submit_name} {disabled}>
-				{#if submitting}
-					<Pending_Animation />
-				{:else}log in{/if}
-			</button>
-			{#if error_message}
-				<div class="error">{error_message}</div>
-			{/if}
-		</form>
-	</Markup>
 </div>
+<form>
+	<input
+		type="text"
+		bind:this={account_name_el}
+		bind:value={account_name}
+		on:keypress={on_keypress}
+		{disabled}
+		placeholder="account name"
+		use:autofocus
+	/>
+	<input
+		type="password"
+		bind:this={password_el}
+		bind:value={password}
+		on:keypress={on_keypress}
+		{disabled}
+		placeholder="password"
+	/>
+	<button type="button" bind:this={button_el} on:click={submit_name} {disabled}>
+		{#if submitting}
+			<Pending_Animation />
+		{:else}log in{/if}
+	</button>
+	<div class:error={!!error_message}>{error_message || icons.felt}</div>
+</form>
 
 <style>
-	.login-wrapper {
-		height: 100%;
-		width: 100%;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		flex-direction: column;
-	}
 	.error {
 		font-weight: bold;
 		color: rgb(73, 84, 153);
@@ -119,5 +107,13 @@
 		flex-direction: column;
 		align-items: center;
 		justify-content: center;
+	}
+	.icon {
+		display: flex;
+		justify-content: center;
+		padding: var(--spacing_lg);
+	}
+	.icon img {
+		width: var(--icon_size_md);
 	}
 </style>

--- a/src/lib/ui/Luggage.svelte
+++ b/src/lib/ui/Luggage.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import {get_app} from '$lib/ui/app';
+
+	const {api} = get_app();
+</script>
+
+<button class="icon-button" on:click={() => api.toggle_main_nav()}> ☰ </button>
+
+<style>
+	button {
+		z-index: 9;
+		position: fixed;
+		left: 0;
+		top: 0;
+	}
+</style>

--- a/src/lib/ui/Luggage.svelte
+++ b/src/lib/ui/Luggage.svelte
@@ -4,7 +4,9 @@
 	const {api} = get_app();
 </script>
 
-<button class="luggage icon-button" on:click={() => api.toggle_main_nav()}> ☰ </button>
+<div class="luggage">
+	<button class="icon-button" on:click={() => api.toggle_main_nav()}> ☰ </button>
+</div>
 
 <style>
 	.luggage {

--- a/src/lib/ui/Luggage.svelte
+++ b/src/lib/ui/Luggage.svelte
@@ -4,12 +4,12 @@
 	const {api} = get_app();
 </script>
 
-<button class="icon-button" on:click={() => api.toggle_main_nav()}> ☰ </button>
+<button class="luggage icon-button" on:click={() => api.toggle_main_nav()}> ☰ </button>
 
 <style>
-	button {
+	.luggage {
 		z-index: 9;
-		position: fixed;
+		position: absolute;
 		left: 0;
 		top: 0;
 	}

--- a/src/lib/ui/Main_Nav.svelte
+++ b/src/lib/ui/Main_Nav.svelte
@@ -33,7 +33,8 @@
 />
 <div class="main-nav" class:expanded={$ui.expand_main_nav}>
 	<div class="header">
-		<button class="icon-button" on:click={() => api.toggle_main_nav()}> ☰ </button>
+		<!-- TODO how to do this? -->
+		<div class="icon-button button-placeholder" />
 		<button
 			on:click={() => ui.set_main_nav_view('explorer')}
 			class:selected={$ui.main_nav_view === 'explorer'}

--- a/src/lib/ui/Main_Nav.svelte
+++ b/src/lib/ui/Main_Nav.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import Markup from '@feltcoop/felt/ui/Markup.svelte';
+
 	import Community_Nav from '$lib/ui/Community_Nav.svelte';
 	import Space_Nav from '$lib/ui/Space_Nav.svelte';
 	import Socket_Connection from '$lib/ui/Socket_Connection.svelte';
@@ -63,7 +65,9 @@
 			{/if}
 		</div>
 	{:else if $ui.main_nav_view === 'account'}
-		<Account_Form />
+		<Markup>
+			<Account_Form />
+		</Markup>
 		<Socket_Connection />
 	{/if}
 </div>
@@ -80,10 +84,10 @@
 		flex-shrink: 0;
 		border-left: var(--border);
 		border-right: var(--border);
-		background-color: var(--bg);
+		transform-origin: top left;
 	}
 	.main-nav.expanded {
-		animation: fly-in var(--transition_duration_md) ease-out;
+		animation: fly-in var(--transition_duration_sm) ease-out;
 	}
 	.main-nav-bg {
 		z-index: 1;
@@ -108,7 +112,7 @@
 			display: block;
 		}
 		.main-nav-bg.expanded {
-			animation: fade-in var(--transition_duration_sm) linear;
+			animation: fade-in var(--transition_duration_md) linear;
 		}
 	}
 	.header {

--- a/src/lib/ui/Main_Nav.svelte
+++ b/src/lib/ui/Main_Nav.svelte
@@ -85,6 +85,7 @@
 		border-left: var(--border);
 		border-right: var(--border);
 		transform-origin: top left;
+		background-color: hsl(var(--bg_hue), var(--bg_saturation), var(--bg_lightness));
 	}
 	.main-nav.expanded {
 		animation: fly-in var(--transition_duration_sm) ease-out;

--- a/src/lib/ui/Workspace.svelte
+++ b/src/lib/ui/Workspace.svelte
@@ -32,6 +32,7 @@
 <style>
 	.workspace {
 		height: 100%;
+		width: 100%;
 		display: flex;
 		flex: 1;
 		flex-direction: column;

--- a/src/lib/ui/Workspace_Header.svelte
+++ b/src/lib/ui/Workspace_Header.svelte
@@ -2,34 +2,39 @@
 	import type {Space} from '$lib/spaces/space';
 	import {get_app} from '$lib/ui/app';
 
-	const {ui, api} = get_app();
+	const {ui} = get_app();
 
 	export let space: Space | null | undefined;
 </script>
 
-<div class="workspace-header" class:expanded-nav={$ui.expand_main_nav}>
-	<button class="icon-button" on:click={() => api.toggle_main_nav()}> ☰ </button>
-	<div>{space?.url}</div>
-</div>
+<ul class="workspace-header" class:expanded-nav={$ui.expand_main_nav}>
+	<li class="luggage-placeholder" />
+	<li class="breadcrumbs">{space?.url}</li>
+</ul>
 
 <style>
 	.workspace-header {
 		display: flex;
+		flex-direction: row;
 		align-items: center;
 		height: var(--navbar_size);
 		width: 100%;
 		border-bottom: var(--border);
 		font-size: var(--font_size_xl);
 	}
-	.icon-button {
-		margin-right: var(--spacing_lg);
+	.luggage-placeholder {
+		width: var(--luggage_size);
+		height: var(--luggage_size);
 	}
-	.expanded-nav .icon-button {
+	.breadcrumbs {
+		padding: 0 var(--spacing_lg);
+	}
+	.expanded-nav .luggage-placeholder {
 		display: none;
 	}
 	/* `50rem` in media queries is the same as `800px`, which is `--column_width` */
 	@media (max-width: 50rem) {
-		.workspace-header .icon-button {
+		.workspace-header .luggage-placeholder {
 			display: block;
 		}
 	}

--- a/src/lib/ui/style.css
+++ b/src/lib/ui/style.css
@@ -41,11 +41,11 @@ main {
 
 @keyframes fly-in {
 	from {
-		transform: translate3d(-100%, 0, 0);
+		transform: translate3d(-100%, 0, 0) scale3d(0.9, 0.9, 0.9);
 		opacity: 0;
 	}
 	to {
-		transform: translate3d(0, 0, 0);
+		transform: translate3d(0, 0, 0) scale3d(1, 1, 1);
 		opacity: 1;
 	}
 }

--- a/src/lib/ui/style.css
+++ b/src/lib/ui/style.css
@@ -4,7 +4,8 @@
 	--bg_saturation: 23%;
 	--bg_lightness: 96%;
 	--bg_color_lightness: 91%; /* TODO ? */
-	--navbar_size: var(--icon_size_md);
+	--luggage_size: var(--icon_size_md);
+	--navbar_size: var(--luggage_size);
 
 	--transition_duration_md: 0.32s;
 	--transition_duration_sm: 0.24s;

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -8,6 +8,7 @@
 	import {dev} from '$app/env';
 
 	import {set_socket} from '$lib/ui/socket';
+	import Luggage from '$lib/ui/Luggage.svelte';
 	import Main_Nav from '$lib/ui/Main_Nav.svelte';
 	import {set_data} from '$lib/ui/data';
 	import {set_ui} from '$lib/ui/ui';
@@ -38,8 +39,12 @@
 </svelte:head>
 
 <div class="layout">
-	{#if !$session.guest && $ui.expand_main_nav}
-		<Main_Nav />
+	{#if !$session.guest}
+		<Luggage />
+		<!-- TODO probably always render this, and have it hide offscreen -->
+		{#if $ui.expand_main_nav}
+			<Main_Nav />
+		{/if}
 	{/if}
 	<slot />
 	<Devmode {devmode} />

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -55,6 +55,7 @@
 		height: 100%;
 		width: 100%;
 		display: flex;
+		position: relative;
 		/* align-items: stretch; */
 	}
 </style>

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import {session} from '$app/stores';
+	import Markup from '@feltcoop/felt/ui/Markup.svelte';
 
 	import Account_Form from '$lib/ui/Account_Form.svelte';
 	import Workspace from '$lib/ui/Workspace.svelte';
@@ -11,8 +12,23 @@
 
 <main>
 	{#if $session.guest}
-		<Account_Form />
+		<div>
+			<Markup>
+				<Account_Form />
+			</Markup>
+		</div>
 	{:else}
 		<Workspace />
 	{/if}
 </main>
+
+<style>
+	main {
+		height: 100%;
+		width: 100%;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		flex-direction: column;
+	}
+</style>


### PR DESCRIPTION
This makes `<Luggage />` a static element onscreen: instead of rendering it in multiple places depending on app state context, it now just sits in the top left, so it just toggles stuff and is always overlays other stuff in the normal case. The `z-index` could probably be toned down from `9`, I dunno. The code now uses `.luggage-placeholder` elements in places where we need to adjust layout to accommodate the fact that the luggage is sitting atop things outside the normal layout.

Eventually it should be possible to hide and move it, probably later when we go into controls and custom options.