### PR TITLE
security pass

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -11,7 +11,7 @@ export interface SessionRequest extends Request {
 }
 
 export interface SessionObject {
-	name: string;
+	account_id: number;
 }
 
 // TODO source this from wherever Api_Server.js does
@@ -31,8 +31,8 @@ export const getSession: GetSession<SessionRequest, Client_Session> = async (req
 		return;
 	});
 	// TODO is swallowing `context.error`, only return in dev mode? look for "reason"?
-	if (request.session?.name) {
-		const result = await db.repos.session.load_client_session(request.session.name);
+	if (request.session?.account_id !== undefined) {
+		const result = await db.repos.session.load_client_session(request.session.account_id);
 		return result.ok ? result.value : {guest: true};
 	} else {
 		return {guest: true};

--- a/src/lib/db/Database.ts
+++ b/src/lib/db/Database.ts
@@ -7,7 +7,7 @@ import type {Space, Space_Params} from '$lib/spaces/space.js';
 import type {Post} from '$lib/posts/post.js';
 import type {Member} from '$lib/members/member.js';
 import type {Account, Account_Model, Account_Params} from '$lib/vocab/account/account.js';
-import {account_model_properties} from '$lib/vocab/account/account';
+import {account_properties, account_model_properties} from '$lib/vocab/account/account';
 import type {Postgres_Sql} from '$lib/db/postgres.js';
 
 export interface Options {
@@ -36,7 +36,6 @@ export class Database {
 				account_id: number,
 			): Promise<Result<{value: Account_Session}>> => {
 				console.log('[db] load_client_session', account_id);
-				// TODO refactor this hardcoded array with `Account_Model` data, make typesafe with columns
 				const account: Account_Model = unwrap(
 					await this.repos.accounts.find_by_id(account_id, account_model_properties),
 				);
@@ -69,7 +68,7 @@ export class Database {
 			},
 			find_by_id: async (
 				account_id: number,
-				columns: string[] = ['account_id', 'name', 'password'],
+				columns: string[] = account_properties,
 			): Promise<Result<{value: Account}, {type: 'no_account_found'; reason: string}>> => {
 				const data = await this.sql<Account[]>`
 					select ${this.sql(columns)} from accounts where account_id = ${account_id}

--- a/src/lib/db/Database.ts
+++ b/src/lib/db/Database.ts
@@ -7,6 +7,7 @@ import type {Space, Space_Params} from '$lib/spaces/space.js';
 import type {Post} from '$lib/posts/post.js';
 import type {Member} from '$lib/members/member.js';
 import type {Account, Account_Model} from '$lib/vocab/account/account.js';
+import {account_model_client_fields} from '$lib/vocab/account/account';
 import type {Postgres_Sql} from '$lib/db/postgres.js';
 
 export interface Options {
@@ -37,7 +38,7 @@ export class Database {
 				console.log('[db] load_client_session', account_id);
 				// TODO refactor this hardcoded array with `Account_Model` data, make typesafe with columns
 				const account: Account_Model = unwrap(
-					await this.repos.accounts.find_by_id(account_id, ['account_id', 'name']),
+					await this.repos.accounts.find_by_id(account_id, account_model_client_fields),
 				);
 				const communities: Community[] = unwrap(
 					await this.repos.communities.filter_by_account(account.account_id),

--- a/src/lib/db/Database.ts
+++ b/src/lib/db/Database.ts
@@ -7,7 +7,7 @@ import type {Space, Space_Params} from '$lib/spaces/space.js';
 import type {Post} from '$lib/posts/post.js';
 import type {Member} from '$lib/members/member.js';
 import type {Account, Account_Model, Account_Params} from '$lib/vocab/account/account.js';
-import {account_model_client_fields} from '$lib/vocab/account/account';
+import {account_model_properties} from '$lib/vocab/account/account';
 import type {Postgres_Sql} from '$lib/db/postgres.js';
 
 export interface Options {
@@ -38,7 +38,7 @@ export class Database {
 				console.log('[db] load_client_session', account_id);
 				// TODO refactor this hardcoded array with `Account_Model` data, make typesafe with columns
 				const account: Account_Model = unwrap(
-					await this.repos.accounts.find_by_id(account_id, account_model_client_fields),
+					await this.repos.accounts.find_by_id(account_id, account_model_properties),
 				);
 				const communities: Community[] = unwrap(
 					await this.repos.communities.filter_by_account(account.account_id),

--- a/src/lib/db/Database.ts
+++ b/src/lib/db/Database.ts
@@ -6,7 +6,7 @@ import type {Community} from '$lib/communities/community.js';
 import type {Space, Space_Params} from '$lib/spaces/space.js';
 import type {Post} from '$lib/posts/post.js';
 import type {Member} from '$lib/members/member.js';
-import type {Account, Account_Model} from '$lib/vocab/account/account.js';
+import type {Account, Account_Model, Account_Params} from '$lib/vocab/account/account.js';
 import {account_model_client_fields} from '$lib/vocab/account/account';
 import type {Postgres_Sql} from '$lib/db/postgres.js';
 
@@ -51,10 +51,10 @@ export class Database {
 			},
 		},
 		accounts: {
-			create: async (
-				name: string,
-				password: string,
-			): Promise<Result<{value: Account}, {reason: string}>> => {
+			create: async ({
+				name,
+				password,
+			}: Account_Params): Promise<Result<{value: Account}, {reason: string}>> => {
 				const data = await this.sql<Account[]>`
 					insert into accounts (name, password) values (
 						${name}, ${password}

--- a/src/lib/db/seed.ts
+++ b/src/lib/db/seed.ts
@@ -1,5 +1,5 @@
 import type {Database} from '$lib/db/Database.js';
-import type {Account} from '$lib/vocab/account/account.js';
+import type {Account, Account_Params} from '$lib/vocab/account/account.js';
 import type {Space, Space_Params} from '$lib/spaces/space.js';
 import type {Post} from '$lib/posts/post.js';
 import type {
@@ -125,7 +125,7 @@ export const seed = async (db: Database): Promise<void> => {
 	// example: insert literal values
 	const account1_doc = account_docs.find((d) => d.name === 'account1');
 	if (!account1_doc) {
-		const account1_initial_data = {
+		const account1: Account_Params = {
 			name: 'a',
 			password: 'ded6a3304309fe718831c3968bdda1b36fb0acae7de54a4cb011ba10923aab71', // 'a' hashed
 		};
@@ -133,7 +133,7 @@ export const seed = async (db: Database): Promise<void> => {
 			insert into accounts (
 				name, password
 			) values (
-				${account1_initial_data.name}, ${account1_initial_data.password}
+				${account1.name}, ${account1.password}
 			)
 		`;
 		console.log('[db] create_account1_result', create_account1_result);
@@ -142,7 +142,7 @@ export const seed = async (db: Database): Promise<void> => {
 	// example: insert with dynamic query helper
 	const account2_doc = account_docs.find((d) => d.name === 'account2');
 	if (!account2_doc) {
-		const account2: Account = {
+		const account2: Account_Params = {
 			name: 'b',
 			password: 'bff5c2262849491dd4047eb7086a7948428885aef62e3b90aa388c9db11d1c1e', // 'b' hashed
 		};

--- a/src/lib/server/Api_Server.ts
+++ b/src/lib/server/Api_Server.ts
@@ -23,10 +23,8 @@ import {
 	to_spaces_middleware,
 	to_create_space_middleware,
 } from '$lib/spaces/space_middleware.js';
-import type {Member} from '$lib/members/member.js';
-import type {Client_Account, Account_Session} from '$lib/session/client_session.js';
+import type {Account_Session} from '$lib/session/client_session.js';
 import type {Database} from '$lib/db/Database.js';
-import type {Community} from '$lib/communities/community.js';
 import type {Websocket_Server} from '$lib/server/Websocket_Server.js';
 
 const log = new Logger([blue('[Api_Server]')]);
@@ -106,9 +104,6 @@ export class Api_Server {
 				log.info('echo', req.body);
 				send(res, 200, req.body);
 			})
-			.get('/api/v1/context', (req, res) => {
-				send(res, 200, to_client_context(req));
-			})
 			.post('/api/v1/login', to_login_middleware(this))
 			.post('/api/v1/logout', to_logout_middleware(this))
 			// TODO replace these with a single resource middleware
@@ -162,29 +157,4 @@ export class Api_Server {
 			),
 		]);
 	}
-}
-
-const to_client_context = (req: Request): Client_Context => {
-	console.log(req.account_session);
-	let client_context: Client_Context;
-	client_context = req.account_session
-		? {
-				account: req.account_session.account,
-				communities: req.account_session.communities,
-				members: req.account_session.members,
-		  }
-		: {guest: true};
-	console.log(client_context);
-	return client_context;
-};
-export type Client_Context = Client_Account_Context | Client_Guest_Context;
-export interface Client_Account_Context {
-	account: Client_Account;
-	communities: Community[];
-	members: Member[];
-	guest?: false;
-}
-export interface Client_Guest_Context {
-	guest: true;
-	error?: Error;
 }

--- a/src/lib/server/Api_Server.ts
+++ b/src/lib/server/Api_Server.ts
@@ -39,7 +39,7 @@ export interface Request extends PolkaRequest, CookieSessionRequest {
 }
 export interface Middleware extends PolkaMiddleware<Request> {}
 export interface ServerSession extends CookieSessionObject {
-	name?: string;
+	account_id?: number;
 }
 
 const dev = process.env.NODE_ENV !== 'production';

--- a/src/lib/session/client_session.ts
+++ b/src/lib/session/client_session.ts
@@ -1,13 +1,11 @@
 import type {Community} from '$lib/communities/community.js';
-import type {Account} from '$lib/vocab/account/account.js';
+import type {Account_Model} from '$lib/vocab/account/account.js';
 import type {Member} from '$lib/members/member.js';
 
 export type Client_Session = Account_Session | Guest_Session;
 
-export type Client_Account = Pick<Account, 'name' | 'account_id'>;
-
 export interface Account_Session {
-	account: Client_Account;
+	account: Account_Model;
 	communities: Community[];
 	//Stub for a Friends feature in future release, for now just returns all users in an instance
 	members: Member[];

--- a/src/lib/session/login_middleware.ts
+++ b/src/lib/session/login_middleware.ts
@@ -47,7 +47,7 @@ export const to_login_middleware = (server: Api_Server): Middleware => {
 			// There's already an account, so proceed to log in after validating the password.
 			account = find_account_result.value;
 			if (account.password !== password_hash) {
-				return send(res, 400, {reason: 'wrong password'});
+				return send(res, 400, {reason: 'invalid account name or password'});
 			}
 		} else if (find_account_result.type === 'no_account_found') {
 			// There's no accoun, so create one.

--- a/src/lib/session/login_middleware.ts
+++ b/src/lib/session/login_middleware.ts
@@ -65,7 +65,7 @@ export const to_login_middleware = (server: Api_Server): Middleware => {
 		}
 
 		console.log('[login]', account.account_id); // TODO logging
-		req.session.name = account.account_id;
+		req.session.account_id = account.account_id;
 		const client_session_result = await db.repos.session.load_client_session(account.account_id);
 		if (client_session_result.ok) {
 			return send(res, 200, {session: client_session_result.value}); // TODO API types

--- a/src/lib/session/login_middleware.ts
+++ b/src/lib/session/login_middleware.ts
@@ -64,9 +64,9 @@ export const to_login_middleware = (server: Api_Server): Middleware => {
 			return send(res, 400, {reason: find_account_result.reason});
 		}
 
-		console.log('[login]', account.name); // TODO logging
-		req.session.name = account.name;
-		const client_session_result = await db.repos.session.load_client_session(account.name);
+		console.log('[login]', account.account_id); // TODO logging
+		req.session.name = account.account_id;
+		const client_session_result = await db.repos.session.load_client_session(account.account_id);
 		if (client_session_result.ok) {
 			return send(res, 200, {session: client_session_result.value}); // TODO API types
 		} else {

--- a/src/lib/session/login_middleware.ts
+++ b/src/lib/session/login_middleware.ts
@@ -51,7 +51,10 @@ export const to_login_middleware = (server: Api_Server): Middleware => {
 			}
 		} else if (find_account_result.type === 'no_account_found') {
 			// There's no accoun, so create one.
-			const find_account_result = await db.repos.accounts.create(account_name, password_hash);
+			const find_account_result = await db.repos.accounts.create({
+				name: account_name,
+				password: password_hash,
+			});
 			console.log('createAccountResult', find_account_result);
 			if (find_account_result.ok) {
 				account = find_account_result.value;

--- a/src/lib/session/session_account_middleware.ts
+++ b/src/lib/session/session_account_middleware.ts
@@ -7,12 +7,14 @@ export const to_session_account_middleware = (server: Api_Server): Middleware =>
 		if (req.account_session) {
 			return send(res, 500, {reason: 'invalid server configuration'});
 		}
-		if (!req.session.name) {
+		if (req.session.account_id === undefined) {
 			return next();
 		}
 
-		console.log('[session_account_middleware]', req.session.name); // TODO logging
-		const find_session_result = await server.db.repos.session.load_client_session(req.session.name);
+		console.log('[session_account_middleware]', req.session.account_id); // TODO logging
+		const find_session_result = await server.db.repos.session.load_client_session(
+			req.session.account_id,
+		);
 		if (find_session_result.ok) {
 			req.account_session = find_session_result.value;
 		}

--- a/src/lib/ui/Login_Form.svelte
+++ b/src/lib/ui/Login_Form.svelte
@@ -17,7 +17,8 @@
 
 	$: disabled = submitting;
 
-	const submit_name = async () => {
+	const log_in = async () => {
+		if (submitting) return;
 		if (!account_name) {
 			account_name_el.focus();
 			error_message = 'please enter an account name';
@@ -63,7 +64,7 @@
 
 	const on_keypress = (e: KeyboardEvent) => {
 		if (e.key === 'Enter') {
-			submit_name();
+			log_in();
 		}
 	};
 </script>
@@ -89,7 +90,7 @@
 		{disabled}
 		placeholder="password"
 	/>
-	<button type="button" bind:this={button_el} on:click={submit_name} {disabled}>
+	<button type="button" bind:this={button_el} on:click={log_in}>
 		{#if submitting}
 			<Pending_Animation />
 		{:else}log in{/if}

--- a/src/lib/ui/Logout_Form.svelte
+++ b/src/lib/ui/Logout_Form.svelte
@@ -2,9 +2,9 @@
 	import {session} from '$app/stores';
 	import Pending_Animation from '@feltcoop/felt/ui/Pending_Animation.svelte';
 
-	import type {Client_Account} from '$lib/session/client_session.js';
+	import type {Account_Model} from '$lib/vocab/account/account';
 
-	let account: Client_Account;
+	let account: Account_Model;
 	$: account = $session?.account;
 	$: console.log('<Logout_Form> account', account);
 

--- a/src/lib/ui/data.ts
+++ b/src/lib/ui/data.ts
@@ -2,10 +2,11 @@ import {writable} from 'svelte/store';
 import type {Readable} from 'svelte/store';
 import {setContext, getContext} from 'svelte';
 
-import type {Client_Account, Client_Session} from '$lib/session/client_session';
+import type {Client_Session} from '$lib/session/client_session';
 import {Community_Model, to_community_model} from '$lib/communities/community';
 import type {Member} from '$lib/members/member';
 import type {Space} from '$lib/spaces/space';
+import type {Account_Model} from '$lib/vocab/account/account';
 
 // TODO refactor/rethink
 
@@ -22,7 +23,7 @@ export const set_data = (session: Client_Session): Data_Store => {
 };
 
 export interface Data_State {
-	account: Client_Account;
+	account: Account_Model;
 	communities: Community_Model[];
 	spaces: Space[];
 	members: Member[];

--- a/src/lib/vocab/account/account.ts
+++ b/src/lib/vocab/account/account.ts
@@ -15,5 +15,6 @@ export interface Account_Model {
 	name: string;
 }
 
-// TODO improve type so it's exhaustive (maybe via schema/codegen)
+// TODO improve types so they're exhaustive (maybe via schema/codegen)
+export const account_properties: (keyof Account)[] = ['account_id', 'name', 'password'];
 export const account_model_properties: (keyof Account_Model)[] = ['account_id', 'name'];

--- a/src/lib/vocab/account/account.ts
+++ b/src/lib/vocab/account/account.ts
@@ -15,6 +15,6 @@ export interface Account_Model {
 	name: string;
 }
 
-// TODO improve types so they're exhaustive (maybe via schema/codegen)
+// TODO improve types so they're exhaustive but still static (maybe via schema/codegen)
 export const account_properties: (keyof Account)[] = ['account_id', 'name', 'password'];
 export const account_model_properties: (keyof Account_Model)[] = ['account_id', 'name'];

--- a/src/lib/vocab/account/account.ts
+++ b/src/lib/vocab/account/account.ts
@@ -1,7 +1,16 @@
 export interface Account {
-	account_id?: number;
+	account_id: number;
 	name: string;
-	// TODO don't send this to clients! enforce with code generation from JSON schema,
-	// marking this property as "server" or "private", or a sensitivity rating of 3
 	password: string;
+}
+
+export interface Account_Params {
+	name: string;
+	password: string;
+}
+
+// TODO rename? `Account_Client_Doc`? above could be `Account_Db_Doc` and `Account_Request_Doc`
+export interface Account_Model {
+	account_id: number;
+	name: string;
 }

--- a/src/lib/vocab/account/account.ts
+++ b/src/lib/vocab/account/account.ts
@@ -16,4 +16,4 @@ export interface Account_Model {
 }
 
 // TODO improve type so it's exhaustive (maybe via schema/codegen)
-export const account_model_client_fields: (keyof Account_Model)[] = ['account_id', 'name'];
+export const account_model_properties: (keyof Account_Model)[] = ['account_id', 'name'];

--- a/src/lib/vocab/account/account.ts
+++ b/src/lib/vocab/account/account.ts
@@ -14,3 +14,6 @@ export interface Account_Model {
 	account_id: number;
 	name: string;
 }
+
+// TODO improve type so it's exhaustive (maybe via schema/codegen)
+export const account_model_client_fields: (keyof Account_Model)[] = ['account_id', 'name'];

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -12,7 +12,7 @@
 
 <main>
 	{#if $session.guest}
-		<div>
+		<div class="column">
 			<Markup>
 				<Account_Form />
 			</Markup>


### PR DESCRIPTION
Changes the session to use `account_id`, and then sends only a subset of fields back to the client. Not sure about the naming of the various `Account` interfaces -- I left a todo with some ideas, and it fits the current pattern. Also removes the old hacky `/context` API route.