### PR TITLE
refactor cookie session

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,20 +1,24 @@
 import type {GetSession} from '@sveltejs/kit';
 import postgres from 'postgres';
-import {validateSession} from '$lib/session/client_session';
 
-import type {SessionRequest, ClientSession} from '$lib/session/client_session.js';
+import type {ClientSession} from '$lib/session/client_session.js';
+import type {CookieSessionRequest} from '$lib/session/cookie_session.js';
+import {to_cookie_session_middleware} from '$lib/session/cookie_session';
 import {Database} from '$lib/db/Database';
 import {default_postgres_options} from '$lib/db/postgres';
 
-// TODO source this from wherever Api_Server.js does
+// TODO source this from wherever ApiServer.js does
 const db = new Database({sql: postgres(default_postgres_options)});
 
-export const getSession: GetSession<SessionRequest, ClientSession> = async (req) => {
-	let request: SessionRequest = Object.assign(req);
-	validateSession(request);
-	// TODO is swallowing `context.error`, only return in dev mode? look for "reason"?
-	if (request.session?.account_id !== undefined) {
-		const result = await db.repos.session.load_client_session(request.session.account_id);
+const cookie_session_middleware = to_cookie_session_middleware();
+
+export const getSession: GetSession<CookieSessionRequest, ClientSession> = async (req) => {
+	cookie_session_middleware(req, {}, () => {});
+	const request: CookieSessionRequest = req as any;
+	const account_id = request.session?.account_id;
+	if (account_id !== undefined) {
+		// TODO this swallows errors
+		const result = await db.repos.session.load_client_session(account_id);
 		return result.ok ? result.value : {guest: true};
 	} else {
 		return {guest: true};

--- a/src/lib/session/client_session.ts
+++ b/src/lib/session/client_session.ts
@@ -2,8 +2,6 @@ import type {Community} from '$lib/communities/community.js';
 import type {AccountModel} from '$lib/vocab/account/account.js';
 import type {Member} from '$lib/members/member.js';
 import type {Persona} from '$lib/personas/persona.js';
-import type {IncomingMessage} from 'http';
-import cookie_session from 'cookie-session';
 
 export type ClientSession = AccountSession | GuestSession;
 
@@ -19,30 +17,3 @@ export interface AccountSession {
 export interface GuestSession {
 	guest: true;
 }
-
-export interface SessionRequest extends Request {
-	session?: SessionObject;
-}
-
-export interface SessionIncomingMessage extends IncomingMessage {
-	session?: SessionObject;
-}
-
-export interface SessionObject {
-	account_id: number;
-}
-
-const dev = process.env.NODE_ENV !== 'production';
-const TODO_SERVER_COOKIE_KEYS = ['TODO', 'KEY_2_TODO', 'KEY_3_TODO'];
-
-export const validateSession = (req: SessionRequest | SessionIncomingMessage) => {
-	cookie_session({
-		keys: TODO_SERVER_COOKIE_KEYS,
-		maxAge: 1000 * 60 * 60 * 24 * 7 * 6, // 6 weeks
-		secure: !dev, // this makes cookies break in prod unless https! see letsencrypt
-		sameSite: dev ? 'lax' : false,
-		name: 'session_id',
-	})(req, {}, function () {
-		return;
-	});
-};

--- a/src/lib/session/cookie_session.ts
+++ b/src/lib/session/cookie_session.ts
@@ -1,0 +1,30 @@
+import type {IncomingMessage} from 'http';
+import cookie_session from 'cookie-session';
+import type {
+	CookieSessionRequest as BaseCookieSessionRequest,
+	CookieSessionObject as BaseCookieSessionObject,
+} from 'cookie-session';
+
+export interface CookieSessionRequest extends BaseCookieSessionRequest {
+	session: CookieSessionObject;
+}
+
+export interface CookieSessionIncomingMessage extends IncomingMessage {
+	session?: CookieSessionObject;
+}
+
+export interface CookieSessionObject extends BaseCookieSessionObject {
+	account_id?: number;
+}
+
+const dev = process.env.NODE_ENV !== 'production';
+
+const TODO_SERVER_COOKIE_KEYS = ['TODO', 'KEY_2_TODO', 'KEY_3_TODO']; // TODO env
+
+export const to_cookie_session_middleware = () =>
+	cookie_session({
+		name: 'session_id',
+		keys: TODO_SERVER_COOKIE_KEYS,
+		maxAge: 1000 * 60 * 60 * 24 * 7 * 6, // 6 weeks
+		secure: !dev, // this makes cookies break in prod unless https! see letsencrypt
+	});

--- a/src/lib/session/login_middleware.ts
+++ b/src/lib/session/login_middleware.ts
@@ -6,7 +6,7 @@ import type {ApiServer, Middleware} from '$lib/server/ApiServer.js';
 import type {Account} from '$lib/vocab/account/account.js';
 
 // TODO move this?
-const salt = 'TODO_SALT_SECRET';
+const salt = 'TODO_SALT_SECRET'; // TODO env
 const to_scrypt = promisify(scrypt);
 const to_hash = async (password: string): Promise<string> =>
 	((await to_scrypt(password, salt, 32)) as any).toString('hex'); // TODO why is the type cast needed?

--- a/src/lib/ui/Board.svelte
+++ b/src/lib/ui/Board.svelte
@@ -64,7 +64,7 @@
 	textarea {
 		border-left: none;
 		border-right: none;
-		border-bottom: none;
+		border-top: none;
 		border-radius: 0;
 	}
 </style>

--- a/src/lib/ui/Forum.svelte
+++ b/src/lib/ui/Forum.svelte
@@ -64,7 +64,7 @@
 	textarea {
 		border-left: none;
 		border-right: none;
-		border-bottom: none;
+		border-top: none;
 		border-radius: 0;
 	}
 </style>


### PR DESCRIPTION
Creates a new module to centralize cookie session usage. It's used in 3 places -- as middleware to the main Polka server, as a manually called middleware in the websocket server, and as a manually called middleware in the SvelteKit hooks. Might need to refactor some of this eventually but it's a good improvement.