### PR TITLE
implement persona data updates on client

### DIFF
--- a/src/lib/communities/community_middleware.ts
+++ b/src/lib/communities/community_middleware.ts
@@ -35,7 +35,7 @@ export const to_community_middleware = (server: ApiServer): Middleware => {
 			return send(res, 401, {reason: 'not logged in'});
 		}
 
-		console.log('[community_middleware] account', req.account_session.account.account_id!); // TODO logging
+		console.log('[community_middleware] account', req.account_session.account.account_id); // TODO logging
 		console.log('[community_middleware] community', req.params.community_id);
 
 		const find_community_result = await db.repos.communities.find_by_id(req.params.community_id);
@@ -62,13 +62,15 @@ export const to_create_community_middleware = (server: ApiServer): Middleware =>
 
 		const create_community_result = await db.repos.communities.insert(
 			req.body.name,
-			req.account_session.account.account_id!,
+			req.account_session.account.account_id,
 		);
 		console.log('create_community_result', create_community_result);
 		if (create_community_result.ok) {
 			// TODO optimize this to return `create_community_result.value` instead of making another db call,
 			// needs to populate members, but we probably want to normalize the data, returning only ids
-			const community_data = await db.repos.communities.filter_by_account(req.session.account_id!);
+			const community_data = await db.repos.communities.filter_by_account(
+				req.account_session.account.account_id,
+			);
 			if (community_data.ok) {
 				const {community_id} = create_community_result.value;
 				return send(res, 200, {

--- a/src/lib/db/Database.ts
+++ b/src/lib/db/Database.ts
@@ -62,14 +62,11 @@ export class Database {
 					) RETURNING *`;
 				console.log(data);
 				const account = data[0];
-				const persona_response = await this.repos.personas.create(name, account.account_id!);
+				const persona_response = await this.repos.personas.create(name, account.account_id);
 				if (!persona_response.ok) {
 					return {ok: false, reason: 'Failed to create initial user persona'};
 				}
-				const result = await this.repos.communities.insert(
-					name,
-					persona_response.value.persona_id!,
-				);
+				const result = await this.repos.communities.insert(name, persona_response.value.persona_id);
 				if (!result.ok) {
 					return {ok: false, reason: 'Failed to create initial user community'};
 				}
@@ -264,7 +261,7 @@ export class Database {
 					) RETURNING *
 				`;
 				console.log('[db] created space', data);
-				const space_id: number = data[0].space_id!;
+				const space_id: number = data[0].space_id;
 				console.log('[db] creating community space', community_id, space_id);
 				// TODO more robust error handling or condense into single query
 				const association = await this.sql<any>`

--- a/src/lib/personas/persona.ts
+++ b/src/lib/personas/persona.ts
@@ -1,5 +1,5 @@
 export interface Persona {
-	persona_id?: number;
+	persona_id: number;
 	account_id: number;
 	name: string;
 	communities: number[];

--- a/src/lib/posts/post_middleware.ts
+++ b/src/lib/posts/post_middleware.ts
@@ -36,7 +36,7 @@ export const to_create_post_middleware = (server: ApiServer): Middleware => {
 		// TODO take content from body & build post to pass along with it
 
 		const find_posts_result = await db.repos.posts.insert(
-			req.account_session.account.account_id!,
+			req.account_session.account.account_id,
 			req.params.space_id,
 			req.body.content,
 		);

--- a/src/lib/ui/MainNav.svelte
+++ b/src/lib/ui/MainNav.svelte
@@ -21,7 +21,7 @@
 		communities.find((c) => c.community_id === $ui.selected_community_id) || null;
 	$: selected_space = selected_community
 		? selected_community.spaces.find(
-				(s) => s.space_id === $ui.selected_space_id_by_community[selected_community!.community_id!],
+				(s) => s.space_id === $ui.selected_space_id_by_community[selected_community!.community_id],
 		  ) || null
 		: null;
 

--- a/src/lib/ui/Workspace.svelte
+++ b/src/lib/ui/Workspace.svelte
@@ -14,7 +14,7 @@
 		communities.find((c) => c.community_id === $ui.selected_community_id) || null;
 	$: selected_space = selected_community
 		? selected_community.spaces.find(
-				(s) => s.space_id === $ui.selected_space_id_by_community[selected_community!.community_id!],
+				(s) => s.space_id === $ui.selected_space_id_by_community[selected_community!.community_id],
 		  )
 		: null;
 	$: members_by_id = selected_community?.members_by_id;

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -23,6 +23,7 @@
 	$: ui.update_data($data); // TODO this or make it an arg to the ui store?
 	const api = set_api(to_api_store(ui, data, socket));
 	const app = set_app({data, ui, api, devmode, socket});
+	$: console.log('$ui', $ui);
 	console.log('app', app);
 
 	onMount(() => {


### PR DESCRIPTION
This is the `update_data` implementation that's really gnarly. I tested it for a few use cases, might be buggy, and all of this code needs to be refactored anyway, but I think this'll get us working.

Also removes a bunch of unnecessary `!` which are no longer needed after splitting out model types into things like `AccountParams`.