### PR TITLE
add support for iframe connection and querying

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@feltcoop/felt": "^0.8.1",
+        "@feltcoop/felt": "^0.9.0",
         "@polka/send-type": "^0.5.2",
         "@types/ws": "^7.4.4",
         "body-parser": "^1.19.0",
@@ -22,7 +22,7 @@
         "ws": "^7.4.4"
       },
       "devDependencies": {
-        "@feltcoop/gro": "^0.39.1",
+        "@feltcoop/gro": "^0.40.0",
         "@sveltejs/adapter-node": "^1.0.0-next.35",
         "@sveltejs/kit": "^1.0.0-next.136",
         "@types/body-parser": "^1.19.1",
@@ -39,9 +39,9 @@
       }
     },
     "node_modules/@feltcoop/felt": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@feltcoop/felt/-/felt-0.8.1.tgz",
-      "integrity": "sha512-hXiH0MEiT+ByCXLUux3q195tIVn0S3/ZHydY0D05il4wYrW7ttRwIrM6YDk5oWQzdjIUi4ZPyjTMUB5IKu2SJQ==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@feltcoop/felt/-/felt-0.9.0.tgz",
+      "integrity": "sha512-dewbwdX3xgq7Y6qaEyorS3zSwl+2tv1wH+VZqMapY2CURV4rhOxv2t+cQWpHIqYD1YS/wDNV4jBl/05Y8242UA==",
       "dependencies": {
         "@lukeed/uuid": "^2.0.0",
         "dequal": "^2.0.2",
@@ -56,12 +56,12 @@
       }
     },
     "node_modules/@feltcoop/gro": {
-      "version": "0.39.1",
-      "resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.39.1.tgz",
-      "integrity": "sha512-ClEJD1eTCsTQMVkmLkO2Ys6w+Hh+uXrj7DLhFOY+zgnR2klYcvfo9fHJ9qIMwK+5pr7e9FIYw3dkfCvq7r97Cw==",
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.40.0.tgz",
+      "integrity": "sha512-ETFSNIZrpgDFCVu1ApHxvZm7FfgtCOfi3K1o+hzaLpA/9tHu8OoSJy+Or4cGjVANHEJojH3HtaVCYTTMCLMT+Q==",
       "dev": true,
       "dependencies": {
-        "@feltcoop/felt": "^0.4.0",
+        "@feltcoop/felt": "^0.9.0",
         "@rollup/plugin-commonjs": "^18.0.0",
         "@rollup/plugin-node-resolve": "^11.2.1",
         "@rollup/pluginutils": "^4.1.0",
@@ -100,20 +100,6 @@
         "tslib": "^2.3.0",
         "typescript": "^4.3.5",
         "uvu": "^0.5.1"
-      }
-    },
-    "node_modules/@feltcoop/gro/node_modules/@feltcoop/felt": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/@feltcoop/felt/-/felt-0.4.5.tgz",
-      "integrity": "sha512-G+P3Ehq/WMjwaD7aX7NcteEw342hfEfJCUTNv8ZvPlVGgzTV3edno96bqzS9SJ7tOvQs1rT8P7qBgjWl7hDiyA==",
-      "dev": true,
-      "dependencies": {
-        "@lukeed/uuid": "^2.0.0",
-        "dequal": "^2.0.2",
-        "kleur": "^4.1.4"
-      },
-      "engines": {
-        "node": ">= 14.16.0"
       }
     },
     "node_modules/@lukeed/csprng": {
@@ -1769,9 +1755,9 @@
   },
   "dependencies": {
     "@feltcoop/felt": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@feltcoop/felt/-/felt-0.8.1.tgz",
-      "integrity": "sha512-hXiH0MEiT+ByCXLUux3q195tIVn0S3/ZHydY0D05il4wYrW7ttRwIrM6YDk5oWQzdjIUi4ZPyjTMUB5IKu2SJQ==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@feltcoop/felt/-/felt-0.9.0.tgz",
+      "integrity": "sha512-dewbwdX3xgq7Y6qaEyorS3zSwl+2tv1wH+VZqMapY2CURV4rhOxv2t+cQWpHIqYD1YS/wDNV4jBl/05Y8242UA==",
       "requires": {
         "@lukeed/uuid": "^2.0.0",
         "dequal": "^2.0.2",
@@ -1779,12 +1765,12 @@
       }
     },
     "@feltcoop/gro": {
-      "version": "0.39.1",
-      "resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.39.1.tgz",
-      "integrity": "sha512-ClEJD1eTCsTQMVkmLkO2Ys6w+Hh+uXrj7DLhFOY+zgnR2klYcvfo9fHJ9qIMwK+5pr7e9FIYw3dkfCvq7r97Cw==",
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.40.0.tgz",
+      "integrity": "sha512-ETFSNIZrpgDFCVu1ApHxvZm7FfgtCOfi3K1o+hzaLpA/9tHu8OoSJy+Or4cGjVANHEJojH3HtaVCYTTMCLMT+Q==",
       "dev": true,
       "requires": {
-        "@feltcoop/felt": "^0.4.0",
+        "@feltcoop/felt": "^0.9.0",
         "@rollup/plugin-commonjs": "^18.0.0",
         "@rollup/plugin-node-resolve": "^11.2.1",
         "@rollup/pluginutils": "^4.1.0",
@@ -1807,19 +1793,6 @@
         "tslib": "^2.3.0",
         "typescript": "^4.3.5",
         "uvu": "^0.5.1"
-      },
-      "dependencies": {
-        "@feltcoop/felt": {
-          "version": "0.4.5",
-          "resolved": "https://registry.npmjs.org/@feltcoop/felt/-/felt-0.4.5.tgz",
-          "integrity": "sha512-G+P3Ehq/WMjwaD7aX7NcteEw342hfEfJCUTNv8ZvPlVGgzTV3edno96bqzS9SJ7tOvQs1rT8P7qBgjWl7hDiyA==",
-          "dev": true,
-          "requires": {
-            "@lukeed/uuid": "^2.0.0",
-            "dequal": "^2.0.2",
-            "kleur": "^4.1.4"
-          }
-        }
       }
     },
     "@lukeed/csprng": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "node": ">=16.6.0"
   },
   "devDependencies": {
-    "@feltcoop/gro": "^0.39.1",
+    "@feltcoop/gro": "^0.40.0",
     "@sveltejs/adapter-node": "^1.0.0-next.35",
     "@sveltejs/kit": "^1.0.0-next.136",
     "@types/body-parser": "^1.19.1",
@@ -35,7 +35,7 @@
     "typescript": "^4.3.5"
   },
   "dependencies": {
-    "@feltcoop/felt": "^0.8.1",
+    "@feltcoop/felt": "^0.9.0",
     "@polka/send-type": "^0.5.2",
     "@types/ws": "^7.4.4",
     "body-parser": "^1.19.0",

--- a/src/infra/deploy.task.ts
+++ b/src/infra/deploy.task.ts
@@ -5,9 +5,9 @@ import {DIST_DIRNAME} from '@feltcoop/gro/dist/paths.js';
 export const task: Task = {
 	summary: 'deploy felt server to prod',
 	dev: false,
-	run: async ({invoke_task}) => {
-		await invoke_task('clean');
-		await invoke_task('build');
+	run: async ({invokeTask}) => {
+		await invokeTask('clean');
+		await invokeTask('build');
 		let timestamp = Date.now();
 		let artifact_name = `felt_server_${timestamp}`;
 		console.log(`Working with artifact: ${artifact_name}`);

--- a/src/lib/db/create.task.ts
+++ b/src/lib/db/create.task.ts
@@ -11,12 +11,12 @@ export interface TaskArgs {
 
 export const task: Task<TaskArgs> = {
 	summary: 'create the database from scratch, deleting and seeding data',
-	run: async ({invoke_task, args}) => {
+	run: async ({invokeTask, args}) => {
 		const {seed = true} = args;
 		const [_, unobtain_db] = obtain_db();
-		await invoke_task('lib/db/destroy');
-		// await invoke_task('lib/db/up'); // TODO add task that migrates up using `ley`
-		if (seed) await invoke_task('lib/db/seed');
+		await invokeTask('lib/db/destroy');
+		// await invokeTask('lib/db/up'); // TODO add task that migrates up using `ley`
+		if (seed) await invokeTask('lib/db/seed');
 		unobtain_db();
 	},
 };

--- a/src/lib/db/obtain_db.ts
+++ b/src/lib/db/obtain_db.ts
@@ -1,10 +1,10 @@
-import {to_obtainable} from '@feltcoop/felt/util/obtainable.js';
+import {toObtainable} from '@feltcoop/felt/util/obtainable.js';
 import postgres from 'postgres';
 
 import {default_postgres_options} from '$lib/db/postgres.js';
 import {Database} from '$lib/db/Database.js';
 
-export const obtain_db = to_obtainable(
+export const obtain_db = toObtainable(
 	(): Database => new Database({sql: postgres(default_postgres_options)}),
 	(db) => db.close(),
 );

--- a/src/lib/db/postgres.ts
+++ b/src/lib/db/postgres.ts
@@ -1,5 +1,5 @@
 import type {Sql, Options} from 'postgres';
-import {to_env_number, to_env_string} from '@feltcoop/felt/util/env.js';
+import {toEnvNumber, toEnvString} from '@feltcoop/felt/util/env.js';
 
 // Postgres.js - PostgreSQL client for Node.js
 // https://github.com/porsager/postgres
@@ -19,13 +19,13 @@ export interface PostgresOptions extends Options<PostgresTypeMap> {
 export type PostgresTypeMap = Record<string, unknown>;
 
 const to_default_postgres_options = (): PostgresOptions => ({
-	host: to_env_string('PGHOST', 'localhost'),
-	port: to_env_number('PGPORT', 5432),
-	database: to_env_string('PGDATABASE', 'felt'),
-	username: to_env_string('PGUSERNAME', to_env_string('PGUSER', 'postgres')),
-	password: to_env_string('PGPASSWORD', 'password'),
-	idle_timeout: to_env_number('PGIDLE_TIMEOUT'),
-	connect_timeout: to_env_number('PGCONNECT_TIMEOUT'),
+	host: toEnvString('PGHOST', 'localhost'),
+	port: toEnvNumber('PGPORT', 5432),
+	database: toEnvString('PGDATABASE', 'felt'),
+	username: toEnvString('PGUSERNAME', toEnvString('PGUSER', 'postgres')),
+	password: toEnvString('PGPASSWORD', 'password'),
+	idle_timeout: toEnvNumber('PGIDLE_TIMEOUT'),
+	connect_timeout: toEnvNumber('PGCONNECT_TIMEOUT'),
 });
 
 export const default_postgres_options = to_default_postgres_options();

--- a/src/lib/ui/Modal.svelte
+++ b/src/lib/ui/Modal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import {is_editable} from '@feltcoop/felt/util/dom.js';
+	import {isEditable} from '@feltcoop/felt/util/dom.js';
 	import {fade} from 'svelte/transition';
 
 	import Portal from '$lib/ui/Portal.svelte';
@@ -11,7 +11,7 @@
 
 	// TODO hook into a ui input system
 	const on_window_keydown = (e: KeyboardEvent) => {
-		if (!(e.target instanceof HTMLElement && is_editable(e.target))) {
+		if (!(e.target instanceof HTMLElement && isEditable(e.target))) {
 			if (e.key === 'Escape') {
 				close();
 			}

--- a/src/lib/ui/color.ts
+++ b/src/lib/ui/color.ts
@@ -1,4 +1,4 @@
-import {to_random_seeded} from '@feltcoop/felt/util/random_seeded.js';
+import {toRandomSeeded} from '@feltcoop/felt/util/randomSeeded.js';
 
 // TODO upstream to Felt -- need to figure out patterns with seed and swappable prng
-export const random_hue = (seed?: any): number => to_random_seeded(seed)() * 360; // TODO random int
+export const random_hue = (seed?: any): number => toRandomSeeded(seed)() * 360; // TODO random int

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -3,6 +3,7 @@
 	import '$lib/ui/style.css';
 	import {set_devmode} from '@feltcoop/felt/ui/devmode.js';
 	import Devmode from '@feltcoop/felt/ui/Devmode.svelte';
+	import FeltWindowHost from '@feltcoop/felt/ui/FeltWindowHost.svelte';
 	import {onMount} from 'svelte';
 	import {session} from '$app/stores';
 	import {dev} from '$app/env';
@@ -57,29 +58,11 @@
 			socket.disconnect();
 		};
 	});
-
-	const on_window_message = (e: MessageEvent) => {
-		console.log('[window.message]', e);
-		// TODO show request modal to user so they can accept/deny
-		// the iframe's connection/data/capability request
-		if (e.data === 'felt__connect') {
-			// TODO security -- pass origin, not '*'
-			(e.source as any).postMessage('felt__connected', '*');
-		} else if (e.data === 'felt__query') {
-			// TODO a real API
-			(e.source as any).postMessage(
-				JSON.stringify({type: 'Message', payload: {hue: random_hue($data.account.name)}}),
-				'*',
-			);
-		}
-	};
 </script>
 
 <svelte:head>
 	<link rel="shortcut icon" href="/favicon.png" />
 </svelte:head>
-
-<svelte:window on:message={on_window_message} />
 
 <div class="layout">
 	{#if !$session.guest}
@@ -100,6 +83,8 @@
 	<Devmode {devmode} />
 	<div id="modal-wrapper" />
 </div>
+
+<FeltWindowHost query={() => ({hue: random_hue($data.account.name)})} />
 
 <style>
 	.layout {

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -14,6 +14,7 @@
 	import {set_ui} from '$lib/ui/ui';
 	import {set_api, to_api_store} from '$lib/ui/api';
 	import {set_app} from '$lib/ui/app';
+	import {random_hue} from '$lib/ui/color';
 
 	const devmode = set_devmode();
 	const data = set_data($session);
@@ -32,11 +33,29 @@
 			socket.disconnect();
 		};
 	});
+
+	const on_window_message = (e: MessageEvent) => {
+		console.log('[window.message]', e);
+		// TODO show request modal to user so they can accept/deny
+		// the iframe's connection/data/capability request
+		if (e.data === 'felt__connect') {
+			// TODO security -- pass origin, not '*'
+			(e.source as any).postMessage('felt__connected', '*');
+		} else if (e.data === 'felt__query') {
+			// TODO a real API
+			(e.source as any).postMessage(
+				JSON.stringify({type: 'Message', payload: {hue: random_hue($data.account.name)}}),
+				'*',
+			);
+		}
+	};
 </script>
 
 <svelte:head>
 	<link rel="shortcut icon" href="favicon.png" />
 </svelte:head>
+
+<svelte:window on:message={on_window_message} />
 
 <div class="layout">
 	{#if !$session.guest}

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import '@feltcoop/felt/ui/style.css';
 	import '$lib/ui/style.css';
-	import {set_devmode} from '@feltcoop/felt/ui/devmode.js';
+	import {setDevmode} from '@feltcoop/felt/ui/devmode.js';
 	import Devmode from '@feltcoop/felt/ui/Devmode.svelte';
 	import FeltWindowHost from '@feltcoop/felt/ui/FeltWindowHost.svelte';
 	import {onMount} from 'svelte';
@@ -20,7 +20,7 @@
 	import {random_hue} from '$lib/ui/color';
 	import AccountForm from '$lib/ui/AccountForm.svelte';
 
-	const devmode = set_devmode();
+	const devmode = setDevmode();
 	const data = set_data($session);
 	$: data.update_session($session);
 	const socket = set_socket(to_socket_store(data));


### PR DESCRIPTION
This makes the server always respond to iframes posting the messages `'felt__connect'` and `'felt__query'`. It's a proof of concept and it's insecure for any private data -- for now the only data it forwards is the account's `hue`.

usage in this PR: https://github.com/feltcoop/dealt/pull/29