### PR TITLE
remove unnecessary type signatures

### DIFF
--- a/src/lib/ui/api.ts
+++ b/src/lib/ui/api.ts
@@ -242,7 +242,7 @@ export const to_api_store = (ui: UiStore, data: DataStore, socket: SocketStore):
 				throw Error(`error sending post: ${res.status}: ${res.statusText}`);
 			}
 		},
-		load_posts: async (space_id: number) => {
+		load_posts: async (space_id) => {
 			data.set_posts(space_id, []);
 			const res = await fetch(`/api/v1/spaces/${space_id}/posts`);
 			if (res.ok) {

--- a/src/lib/ui/ui.ts
+++ b/src/lib/ui/ui.ts
@@ -39,7 +39,8 @@ export const to_ui_store = () => {
 
 	const store: UiStore = {
 		subscribe,
-		update_data: (data: DataState | null) => {
+		update_data: (data) => {
+			console.log('[ui.update_data]', {data});
 			update(($ui) => {
 				// TODO this needs to be rethought, it's just preserving the existing ui state
 				// when new data gets set, which happens when e.g. a new community is created --
@@ -93,7 +94,7 @@ export const to_ui_store = () => {
 				}
 			});
 		},
-		select_persona: (persona_id: number) => {
+		select_persona: (persona_id) => {
 			console.log(typeof persona_id);
 			update(($ui) => ({
 				...$ui,
@@ -101,7 +102,7 @@ export const to_ui_store = () => {
 				selected_community_id: $ui.selected_community_id_by_persona[persona_id],
 			}));
 		},
-		select_community: (community_id: number | null) => {
+		select_community: (community_id) => {
 			console.log('[ui.select_community] community_id', {community_id});
 			update(($ui) => ({
 				...$ui,
@@ -115,7 +116,7 @@ export const to_ui_store = () => {
 						  },
 			}));
 		},
-		select_space: (community_id: number, space_id: number | null) => {
+		select_space: (community_id, space_id) => {
 			console.log('[ui.select_space] community_id, space_id', {community_id, space_id});
 			update(($ui) => {
 				// TODO speed this up using stores maybe?

--- a/src/lib/ui/ui.ts
+++ b/src/lib/ui/ui.ts
@@ -95,7 +95,7 @@ export const to_ui_store = () => {
 			});
 		},
 		select_persona: (persona_id) => {
-			console.log(typeof persona_id);
+			console.log('[ui.select_persona] persona_id', {persona_id});
 			update(($ui) => ({
 				...$ui,
 				selected_persona_id: persona_id,


### PR DESCRIPTION
These aren't needed because of how they're declared, and they're error prone if included because TypeScript's rules allow them to be subtypes. (e.g. unions with types that aren't in the original signature)