### PR TITLE
Add space type picker

### DIFF
--- a/src/lib/ui/SpaceInput.svelte
+++ b/src/lib/ui/SpaceInput.svelte
@@ -42,22 +42,16 @@
 			<Markup>
 				<h1>Create a new space</h1>
 				<form>
-					<input
-						type="text"
-						placeholder="> name"						
-						bind:value={new_name}
-						use:autofocus
-					/>
-					<label class="type-label">Select Type:
-					<select class="type-selector" bind:value={new_type}>
-						{#each Object.entries(SpaceTypes) as type (type)}
-							<option value={type[1]}>{type[0]}</option>
-						{/each}
-					</select>
+					<input type="text" placeholder="> name" bind:value={new_name} use:autofocus />
+					<label class="type-label"
+						>Select Type:
+						<select class="type-selector" bind:value={new_type}>
+							{#each Object.entries(SpaceTypes) as type (type)}
+								<option value={type[1]}>{type[0]}</option>
+							{/each}
+						</select>
 					</label>
-					<button on:click={create}>
-						Create
-					</button>
+					<button on:click={create}> Create </button>
 				</form>
 			</Markup>
 		</div>
@@ -74,5 +68,5 @@
 	}
 	.type-selector {
 		margin-left: var(--spacing_xs);
-	}	
+	}
 </style>

--- a/src/lib/ui/SpaceInput.svelte
+++ b/src/lib/ui/SpaceInput.svelte
@@ -16,13 +16,6 @@
 	let new_name = '';
 	let new_type = Object.entries(SpaceTypes)[0][1];
 
-	const on_keydown = async (e: KeyboardEvent) => {
-		if (e.key === 'Enter') {
-			await create();
-			open = false;
-		}
-	};
-
 	const create = async () => {
 		if (!new_name || !new_type) return;
 		//Needs to collect url(i.e. name for now), type (currently default application/json), & content (hardcoded JSON struct)
@@ -48,20 +41,24 @@
 		<div>
 			<Markup>
 				<h1>Create a new space</h1>
-				<p>
+				<form>
 					<input
 						type="text"
-						placeholder="> name"
-						on:keydown={on_keydown}
+						placeholder="> name"						
 						bind:value={new_name}
 						use:autofocus
 					/>
+					<label class="type-label">Select Type:
 					<select class="type-selector" bind:value={new_type}>
 						{#each Object.entries(SpaceTypes) as type (type)}
 							<option value={type[1]}>{type[0]}</option>
 						{/each}
 					</select>
-				</p>
+					</label>
+					<button on:click={create}>
+						Create
+					</button>
+				</form>
 			</Markup>
 		</div>
 	</Dialog>
@@ -75,4 +72,7 @@
 		margin: 0;
 		word-wrap: break-word;
 	}
+	.type-selector {
+		margin-left: var(--spacing_xs);
+	}	
 </style>

--- a/src/lib/ui/SpaceInput.svelte
+++ b/src/lib/ui/SpaceInput.svelte
@@ -30,7 +30,7 @@
 			url,
 			//TODO : add space type picker
 			'application/fuz+json',
-			`{"type": "Chat", "props": {"data": "${url}/files"}}`,
+			`{"type": "chat", "props": {"data": "${url}/files"}}`,
 		);
 		new_name = '';
 	};

--- a/src/lib/ui/SpaceInput.svelte
+++ b/src/lib/ui/SpaceInput.svelte
@@ -6,12 +6,15 @@
 	import {autofocus} from '$lib/ui/actions';
 	import {get_app} from '$lib/ui/app';
 
+	import {SpaceTypes} from '$lib/vocab/space/space';
+
 	const {api} = get_app();
 
 	export let community: CommunityModel;
 
 	let open = false;
 	let new_name = '';
+	let new_type = Object.entries(SpaceTypes)[0][1];
 
 	const on_keydown = async (e: KeyboardEvent) => {
 		if (e.key === 'Enter') {
@@ -21,7 +24,7 @@
 	};
 
 	const create = async () => {
-		if (!new_name) return;
+		if (!new_name || !new_type) return;
 		//Needs to collect url(i.e. name for now), type (currently default application/json), & content (hardcoded JSON struct)
 		const url = `/${new_name}`;
 		await api.create_space(
@@ -30,9 +33,10 @@
 			url,
 			//TODO : add space type picker
 			'application/fuz+json',
-			`{"type": "chat", "props": {"data": "${url}/files"}}`,
+			`{"type": "${new_type}", "props": {"data": "${url}/files"}}`,
 		);
 		new_name = '';
+		new_type = Object.entries(SpaceTypes)[0][1];
 	};
 </script>
 
@@ -52,6 +56,11 @@
 						bind:value={new_name}
 						use:autofocus
 					/>
+					<select class="type-selector" bind:value={new_type}>
+						{#each Object.entries(SpaceTypes) as type (type)}
+							<option value={type[1]}>{type[0]}</option>
+						{/each}
+					</select>
 				</p>
 			</Markup>
 		</div>

--- a/src/lib/ui/SpaceView.svelte
+++ b/src/lib/ui/SpaceView.svelte
@@ -4,6 +4,7 @@
 	import Forum from '$lib/ui/Forum.svelte';
 	import Notes from '$lib/ui/Notes.svelte';
 	import type {Space} from '$lib/vocab/space/space';
+	import {SpaceTypes} from '$lib/vocab/space/space';
 	import Iframe from '$lib/ui/Iframe.svelte';
 	import Voice from '$lib/ui/Voice.svelte';
 	import type {Member} from '$lib/vocab/member/member';
@@ -28,17 +29,17 @@
 </script>
 
 <!-- TODO make this a lookup by type and handle generically -->
-{#if space_data.type === 'Chat'}
+{#if space_data.type === SpaceTypes.Chat}
 	<Chat {space} {members_by_id} />
-{:else if space_data.type === 'Board'}
+{:else if space_data.type === SpaceTypes.Board}
 	<Board {space} {members_by_id} />
-{:else if space_data.type === 'Forum'}
+{:else if space_data.type === SpaceTypes.Forum}
 	<Forum {space} {members_by_id} />
-{:else if space_data.type === 'Notes'}
+{:else if space_data.type === SpaceTypes.Notes}
 	<Notes {space} />
-{:else if space_data.type === 'Voice'}
+{:else if space_data.type === SpaceTypes.Voice}
 	<Voice {space} />
-{:else if space_data.type === 'Iframe'}
+{:else if space_data.type === SpaceTypes.Iframe}
 	<Iframe {space} {...space_data.props} />
 {:else}
 	unknown space type: {space_data.type}

--- a/src/lib/vocab/space/default_spaces.ts
+++ b/src/lib/vocab/space/default_spaces.ts
@@ -36,8 +36,7 @@ export const default_spaces: SpaceParams[] = [
 		name: 'felt library',
 		url: '/library',
 		media_type: 'application/fuz+json',
-		content:
-			`{"type": "${SpaceTypes.Iframe}", "props": {"url": "https://www.felt.dev/sketch/library"}}`,
+		content: `{"type": "${SpaceTypes.Iframe}", "props": {"url": "https://www.felt.dev/sketch/library"}}`,
 	},
 	{
 		name: 'dealt: tar',

--- a/src/lib/vocab/space/default_spaces.ts
+++ b/src/lib/vocab/space/default_spaces.ts
@@ -1,46 +1,47 @@
 import type {SpaceParams} from '$lib/vocab/space/space';
+import { SpaceTypes } from '$lib/vocab/space/space';
 
 export const default_spaces: SpaceParams[] = [
 	{
 		name: 'chat',
 		url: '/chat',
 		media_type: 'application/fuz+json',
-		content: '{"type": "Chat", "props": {"data": "/chat/files"}}',
+		content: '{"type": "'+SpaceTypes.Chat+'", "props": {"data": "/chat/files"}}',
 	},
 	{
 		name: 'board',
 		url: '/board',
 		media_type: 'application/fuz+json',
-		content: '{"type": "Board", "props": {"data": "/board/files"}}',
+		content: '{"type": "'+SpaceTypes.Board+'", "props": {"data": "/board/files"}}',
 	},
 	{
 		name: 'forum',
 		url: '/forum',
 		media_type: 'application/fuz+json',
-		content: '{"type": "Forum", "props": {"data": "/forum/files"}}',
+		content: '{"type": "'+SpaceTypes.Forum+'", "props": {"data": "/forum/files"}}',
 	},
 	{
 		name: 'notes',
 		url: '/notes',
 		media_type: 'application/fuz+json',
-		content: '{"type": "Notes", "props": {"data": "/notes/files"}}',
+		content: '{"type": "'+SpaceTypes.Notes+'", "props": {"data": "/notes/files"}}',
 	},
 	{
 		name: 'voice',
 		url: '/voice',
 		media_type: 'application/fuz+json',
-		content: '{"type": "Voice", "props": {"data": "/voice/stream"}}',
+		content: '{"type": "'+SpaceTypes.Voice+'", "props": {"data": "/voice/stream"}}',
 	},
 	{
 		name: 'felt library',
 		url: '/library',
 		media_type: 'application/fuz+json',
-		content: '{"type": "Iframe", "props": {"url": "https://www.felt.dev/sketch/library"}}',
+		content: '{"type": "'+SpaceTypes.Iframe+'", "props": {"url": "https://www.felt.dev/sketch/library"}}',
 	},
 	{
 		name: 'dealt: tar',
 		url: '/tar',
 		media_type: 'application/fuz+json',
-		content: '{"type": "Iframe", "props": {"url": "https://www.dealt.dev/tar"}}',
+		content: '{"type": "'+SpaceTypes.Iframe+'", "props": {"url": "https://www.dealt.dev/tar"}}',
 	},
 ];

--- a/src/lib/vocab/space/default_spaces.ts
+++ b/src/lib/vocab/space/default_spaces.ts
@@ -6,45 +6,43 @@ export const default_spaces: SpaceParams[] = [
 		name: 'chat',
 		url: '/chat',
 		media_type: 'application/fuz+json',
-		content: '{"type": "' + SpaceTypes.Chat + '", "props": {"data": "/chat/files"}}',
+		content: `{"type": "${SpaceTypes.Chat}", "props": {"data": "/chat/files"}}`,
 	},
 	{
 		name: 'board',
 		url: '/board',
 		media_type: 'application/fuz+json',
-		content: '{"type": "' + SpaceTypes.Board + '", "props": {"data": "/board/files"}}',
+		content: `{"type": "${SpaceTypes.Board}", "props": {"data": "/board/files"}}`,
 	},
 	{
 		name: 'forum',
 		url: '/forum',
 		media_type: 'application/fuz+json',
-		content: '{"type": "' + SpaceTypes.Forum + '", "props": {"data": "/forum/files"}}',
+		content: `{"type": "${SpaceTypes.Forum}", "props": {"data": "/forum/files"}}`,
 	},
 	{
 		name: 'notes',
 		url: '/notes',
 		media_type: 'application/fuz+json',
-		content: '{"type": "' + SpaceTypes.Notes + '", "props": {"data": "/notes/files"}}',
+		content: `{"type": "${SpaceTypes.Notes}", "props": {"data": "/notes/files"}}`,
 	},
 	{
 		name: 'voice',
 		url: '/voice',
 		media_type: 'application/fuz+json',
-		content: '{"type": "' + SpaceTypes.Voice + '", "props": {"data": "/voice/stream"}}',
+		content: `{"type": "${SpaceTypes.Voice}", "props": {"data": "/voice/stream"}}`,
 	},
 	{
 		name: 'felt library',
 		url: '/library',
 		media_type: 'application/fuz+json',
 		content:
-			'{"type": "' +
-			SpaceTypes.Iframe +
-			'", "props": {"url": "https://www.felt.dev/sketch/library"}}',
+			`{"type": "${SpaceTypes.Iframe}", "props": {"url": "https://www.felt.dev/sketch/library"}}`,
 	},
 	{
 		name: 'dealt: tar',
 		url: '/tar',
 		media_type: 'application/fuz+json',
-		content: '{"type": "' + SpaceTypes.Iframe + '", "props": {"url": "https://www.dealt.dev/tar"}}',
+		content: `{"type": "${SpaceTypes.Iframe}", "props": {"url": "https://www.dealt.dev/tar"}}`,
 	},
 ];

--- a/src/lib/vocab/space/default_spaces.ts
+++ b/src/lib/vocab/space/default_spaces.ts
@@ -1,47 +1,50 @@
 import type {SpaceParams} from '$lib/vocab/space/space';
-import { SpaceTypes } from '$lib/vocab/space/space';
+import {SpaceTypes} from '$lib/vocab/space/space';
 
 export const default_spaces: SpaceParams[] = [
 	{
 		name: 'chat',
 		url: '/chat',
 		media_type: 'application/fuz+json',
-		content: '{"type": "'+SpaceTypes.Chat+'", "props": {"data": "/chat/files"}}',
+		content: '{"type": "' + SpaceTypes.Chat + '", "props": {"data": "/chat/files"}}',
 	},
 	{
 		name: 'board',
 		url: '/board',
 		media_type: 'application/fuz+json',
-		content: '{"type": "'+SpaceTypes.Board+'", "props": {"data": "/board/files"}}',
+		content: '{"type": "' + SpaceTypes.Board + '", "props": {"data": "/board/files"}}',
 	},
 	{
 		name: 'forum',
 		url: '/forum',
 		media_type: 'application/fuz+json',
-		content: '{"type": "'+SpaceTypes.Forum+'", "props": {"data": "/forum/files"}}',
+		content: '{"type": "' + SpaceTypes.Forum + '", "props": {"data": "/forum/files"}}',
 	},
 	{
 		name: 'notes',
 		url: '/notes',
 		media_type: 'application/fuz+json',
-		content: '{"type": "'+SpaceTypes.Notes+'", "props": {"data": "/notes/files"}}',
+		content: '{"type": "' + SpaceTypes.Notes + '", "props": {"data": "/notes/files"}}',
 	},
 	{
 		name: 'voice',
 		url: '/voice',
 		media_type: 'application/fuz+json',
-		content: '{"type": "'+SpaceTypes.Voice+'", "props": {"data": "/voice/stream"}}',
+		content: '{"type": "' + SpaceTypes.Voice + '", "props": {"data": "/voice/stream"}}',
 	},
 	{
 		name: 'felt library',
 		url: '/library',
 		media_type: 'application/fuz+json',
-		content: '{"type": "'+SpaceTypes.Iframe+'", "props": {"url": "https://www.felt.dev/sketch/library"}}',
+		content:
+			'{"type": "' +
+			SpaceTypes.Iframe +
+			'", "props": {"url": "https://www.felt.dev/sketch/library"}}',
 	},
 	{
 		name: 'dealt: tar',
 		url: '/tar',
 		media_type: 'application/fuz+json',
-		content: '{"type": "'+SpaceTypes.Iframe+'", "props": {"url": "https://www.dealt.dev/tar"}}',
+		content: '{"type": "' + SpaceTypes.Iframe + '", "props": {"url": "https://www.dealt.dev/tar"}}',
 	},
 ];

--- a/src/lib/vocab/space/space.ts
+++ b/src/lib/vocab/space/space.ts
@@ -13,11 +13,12 @@ export interface SpaceParams {
 	content: string;
 }
 
+//TODO make TypeScript String enum
 export const SpaceTypes = {
-	Chat: 'chat',
-	Board: 'board',
-	Forum: 'forum',
-	Notes: 'notes',
-	Voice: 'voice',
-	Iframe: 'iframe',
+	Chat: 'Chat',
+	Board: 'Board',
+	Forum: 'Forum',
+	Notes: 'Notes',
+	Voice: 'Voice',
+	Iframe: 'Iframe',
 };

--- a/src/lib/vocab/space/space.ts
+++ b/src/lib/vocab/space/space.ts
@@ -13,11 +13,11 @@ export interface SpaceParams {
 	content: string;
 }
 
-export enum SpaceTypes {
-	Chat = "chat",
-	Board = "board",
-	Forum = "forum",
-	Notes = "notes",
-	Voice = "voice",
-	Iframe = "iframe"
-}
+export const SpaceTypes = {
+	Chat: 'chat',
+	Board: 'board',
+	Forum: 'forum',
+	Notes: 'notes',
+	Voice: 'voice',
+	Iframe: 'iframe',
+};

--- a/src/lib/vocab/space/space.ts
+++ b/src/lib/vocab/space/space.ts
@@ -12,3 +12,12 @@ export interface SpaceParams {
 	media_type: string;
 	content: string;
 }
+
+export enum SpaceTypes {
+	Chat = "chat",
+	Board = "board",
+	Forum = "forum",
+	Notes = "notes",
+	Voice = "voice",
+	Iframe = "iframe"
+}


### PR DESCRIPTION
This PR adds a simple selector element to the new Space dialog box which allows a user to select the Type of new space.

It also adds an enumeration object (SpaceType) although I'm not sure if it's actually in the right "semantics" for our framework.

There's also currently a weird bug, where if you click into a new space just after creating it, Svelte throws a bunch of errors (see below)
<img width="358" alt="Screen Shot 2021-09-09 at 3 30 13 PM" src="https://user-images.githubusercontent.com/4512607/132765457-a33ac0b2-7ea8-4579-9de1-c11a1fc3d1f8.png">
