### PR TITLE
mount space views generically and refactor space input

### DIFF
--- a/src/lib/ui/SpaceInput.svelte
+++ b/src/lib/ui/SpaceInput.svelte
@@ -5,7 +5,7 @@
 	import type {CommunityModel} from '$lib/vocab/community/community.js';
 	import {autofocus} from '$lib/ui/actions';
 	import {getApp} from '$lib/ui/app';
-	import {SpaceTypes} from '$lib/vocab/space/space';
+	import {spaceTypes} from '$lib/vocab/space/space';
 
 	const {api} = getApp();
 
@@ -13,10 +13,14 @@
 
 	let open = false;
 	let newName = '';
-	let newType = Object.entries(SpaceTypes)[0][1];
+	let newType = spaceTypes[0];
+	let nameEl: HTMLInputElement;
 
 	const create = async () => {
-		if (!newName || !newType) return;
+		if (!newName) {
+			nameEl.focus();
+			return;
+		}
 		//Needs to collect url(i.e. name for now), type (currently default application/json), & content (hardcoded JSON struct)
 		const url = `/${newName}`;
 		await api.createSpace({
@@ -28,7 +32,15 @@
 			content: `{"type": "${newType}", "props": {"data": "${url}/files"}}`,
 		});
 		newName = '';
-		newType = Object.entries(SpaceTypes)[0][1];
+		newType = spaceTypes[0];
+		open = false;
+	};
+
+	const onKeydown = async (e: KeyboardEvent) => {
+		if (e.key === 'Enter') {
+			e.preventDefault();
+			await create();
+		}
 	};
 </script>
 
@@ -41,16 +53,23 @@
 			<Markup>
 				<h1>Create a new space</h1>
 				<form>
-					<input type="text" placeholder="> name" bind:value={newName} use:autofocus />
-					<label class="type-label"
-						>Select Type:
+					<input
+						type="text"
+						placeholder="> name"
+						bind:value={newName}
+						use:autofocus
+						bind:this={nameEl}
+						on:keydown={onKeydown}
+					/>
+					<label>
+						Select Type:
 						<select class="type-selector" bind:value={newType}>
-							{#each Object.entries(SpaceTypes) as type (type)}
-								<option value={type[1]}>{type[0]}</option>
+							{#each spaceTypes as type (type)}
+								<option value={type}>{type}</option>
 							{/each}
 						</select>
 					</label>
-					<button on:click={create}> Create </button>
+					<button type="button" on:click={create}> Create space </button>
 				</form>
 			</Markup>
 		</div>

--- a/src/lib/ui/SpaceView.svelte
+++ b/src/lib/ui/SpaceView.svelte
@@ -1,46 +1,28 @@
 <script lang="ts">
-	import Chat from '$lib/ui/Chat.svelte';
-	import Board from '$lib/ui/Board.svelte';
-	import Forum from '$lib/ui/Forum.svelte';
-	import Notes from '$lib/ui/Notes.svelte';
-	import type {Space} from '$lib/vocab/space/space';
-	import {SpaceTypes} from '$lib/vocab/space/space';
-	import Iframe from '$lib/ui/Iframe.svelte';
-	import Voice from '$lib/ui/Voice.svelte';
+	import {spaceViews} from '$lib/ui/spaceViews';
+	import type {Space, SpaceViewData} from '$lib/vocab/space/space';
 	import type {Member} from '$lib/vocab/member/member';
 
 	export let space: Space;
 	export let membersById: Map<number, Member>;
 
-	// TODO types
-	const toSpaceData = (space: Space): any => {
+	const toSpaceData = (space: Space): SpaceViewData => {
 		switch (space.media_type) {
 			case 'application/fuz+json': {
 				return JSON.parse(space.content);
 			}
 			default: {
-				return space.content;
+				throw Error(`Unhandled space media type ${space.media_type}`);
 			}
 		}
 	};
 
 	$: spaceData = toSpaceData(space);
-	$: console.log('spaceData', spaceData);
+	$: component = spaceViews[spaceData.type];
 </script>
 
-<!-- TODO make this a lookup by type and handle generically -->
-{#if spaceData.type === SpaceTypes.Chat}
-	<Chat {space} {membersById} />
-{:else if spaceData.type === SpaceTypes.Board}
-	<Board {space} {membersById} />
-{:else if spaceData.type === SpaceTypes.Forum}
-	<Forum {space} {membersById} />
-{:else if spaceData.type === SpaceTypes.Notes}
-	<Notes {space} />
-{:else if spaceData.type === SpaceTypes.Voice}
-	<Voice {space} />
-{:else if spaceData.type === SpaceTypes.Iframe}
-	<Iframe {space} {...spaceData.props} />
+{#if component}
+	<svelte:component this={component} {space} {membersById} {...spaceData.props} />
 {:else}
 	unknown space type: {spaceData.type}
 {/if}

--- a/src/lib/ui/spaceViews.ts
+++ b/src/lib/ui/spaceViews.ts
@@ -1,0 +1,18 @@
+import type {SvelteComponent} from 'svelte';
+
+import type {SpaceType} from '$lib/vocab/space/space';
+import Chat from '$lib/ui/Chat.svelte';
+import Board from '$lib/ui/Board.svelte';
+import Forum from '$lib/ui/Forum.svelte';
+import Notes from '$lib/ui/Notes.svelte';
+import Iframe from '$lib/ui/Iframe.svelte';
+import Voice from '$lib/ui/Voice.svelte';
+
+export const spaceViews: Record<SpaceType, typeof SvelteComponent> = {
+	Chat,
+	Board,
+	Forum,
+	Notes,
+	Voice,
+	Iframe,
+};

--- a/src/lib/vocab/space/defaultSpaces.ts
+++ b/src/lib/vocab/space/defaultSpaces.ts
@@ -1,5 +1,5 @@
 import type {SpaceParams} from '$lib/vocab/space/space';
-import {SpaceTypes} from '$lib/vocab/space/space';
+import {SpaceType} from '$lib/vocab/space/space';
 
 export const toDefaultSpaces = (community_id: number): SpaceParams[] => [
 	{
@@ -7,48 +7,48 @@ export const toDefaultSpaces = (community_id: number): SpaceParams[] => [
 		name: 'chat',
 		url: '/chat',
 		media_type: 'application/fuz+json',
-		content: `{"type": "${SpaceTypes.Chat}", "props": {"data": "/chat/files"}}`,
+		content: `{"type": "${SpaceType.Chat}", "props": {"data": "/chat/files"}}`,
 	},
 	{
 		community_id,
 		name: 'board',
 		url: '/board',
 		media_type: 'application/fuz+json',
-		content: `{"type": "${SpaceTypes.Board}", "props": {"data": "/board/files"}}`,
+		content: `{"type": "${SpaceType.Board}", "props": {"data": "/board/files"}}`,
 	},
 	{
 		community_id,
 		name: 'forum',
 		url: '/forum',
 		media_type: 'application/fuz+json',
-		content: `{"type": "${SpaceTypes.Forum}", "props": {"data": "/forum/files"}}`,
+		content: `{"type": "${SpaceType.Forum}", "props": {"data": "/forum/files"}}`,
 	},
 	{
 		community_id,
 		name: 'notes',
 		url: '/notes',
 		media_type: 'application/fuz+json',
-		content: `{"type": "${SpaceTypes.Notes}", "props": {"data": "/notes/files"}}`,
+		content: `{"type": "${SpaceType.Notes}", "props": {"data": "/notes/files"}}`,
 	},
 	{
 		community_id,
 		name: 'voice',
 		url: '/voice',
 		media_type: 'application/fuz+json',
-		content: `{"type": "${SpaceTypes.Voice}", "props": {"data": "/voice/stream"}}`,
+		content: `{"type": "${SpaceType.Voice}", "props": {"data": "/voice/stream"}}`,
 	},
 	{
 		community_id,
 		name: 'felt library',
 		url: '/library',
 		media_type: 'application/fuz+json',
-		content: `{"type": "${SpaceTypes.Iframe}", "props": {"url": "https://www.felt.dev/sketch/library"}}`,
+		content: `{"type": "${SpaceType.Iframe}", "props": {"url": "https://www.felt.dev/sketch/library"}}`,
 	},
 	{
 		community_id,
 		name: 'dealt: tar',
 		url: '/tar',
 		media_type: 'application/fuz+json',
-		content: `{"type": "${SpaceTypes.Iframe}", "props": {"url": "https://www.dealt.dev/tar"}}`,
+		content: `{"type": "${SpaceType.Iframe}", "props": {"url": "https://www.dealt.dev/tar"}}`,
 	},
 ];

--- a/src/lib/vocab/space/space.ts
+++ b/src/lib/vocab/space/space.ts
@@ -32,12 +32,19 @@ export const validateSpaceParams = (): ValidateFunction<SpaceParams> =>
 	_validateSpaceParams || (_validateSpaceParams = ajv.compile(SpaceParamsSchema));
 let _validateSpaceParams: ValidateFunction<SpaceParams> | undefined;
 
-//TODO make TypeScript String enum
-export const SpaceTypes = {
-	Chat: 'Chat',
-	Board: 'Board',
-	Forum: 'Forum',
-	Notes: 'Notes',
-	Voice: 'Voice',
-	Iframe: 'Iframe',
-};
+export enum SpaceType {
+	Chat = 'Chat',
+	Board = 'Board',
+	Forum = 'Forum',
+	Notes = 'Notes',
+	Voice = 'Voice',
+	Iframe = 'Iframe',
+}
+export const spaceTypes: SpaceType[] = Object.keys(SpaceType) as SpaceType[];
+
+// TODO refactor? rename? or how to define this?
+export interface SpaceViewData {
+	type: SpaceType;
+	props: SpaceProps;
+}
+export type SpaceProps = any; // TODO generic per type?


### PR DESCRIPTION
Makes space views mount generically based on their type, looking up the component from a typesafe mapping of type to component. Changes `SpaceType` to an enum and caches `spaceTypes` with type `SpaceType[]`.  This pattern could probably be improved a bit, but I think codegen ultimately will get the best results. Also improves some UX things in the space input and adds initial types for the space data that's encoded as stringified json.

Also fixes a UX issue caused by making the input a `form` in the PR that added space types -- pressing `Enter` caused the page to refresh because it caused the default `submit` action. We'll want to start looking at form components soon now that we have more use cases. 