### PR TITLE
change services to have declarative http path and method

### DIFF
--- a/src/lib/server/ApiServer.test.ts
+++ b/src/lib/server/ApiServer.test.ts
@@ -8,6 +8,7 @@ import {ApiServer} from '$lib/server/ApiServer.js';
 import {Database} from '$lib/db/Database.js';
 import {defaultPostgresOptions} from '$lib/db/postgres.js';
 import {WebsocketServer} from '$lib/server/WebsocketServer.js';
+import {services} from '$lib/server/services';
 
 const TEST_PORT = 3003; // TODO
 
@@ -21,6 +22,7 @@ test__ApiServer('init and close', async () => {
 		app: polka({server}),
 		websocketServer: new WebsocketServer(server),
 		db: new Database({sql: postgres(defaultPostgresOptions)}),
+		services,
 		port: TEST_PORT,
 	});
 	t.is(apiServer.port, TEST_PORT);

--- a/src/lib/server/ApiServer.ts
+++ b/src/lib/server/ApiServer.ts
@@ -10,24 +10,12 @@ import {toAuthenticationMiddleware} from '$lib/session/authenticationMiddleware.
 import {toAuthorizationMiddleware} from '$lib/session/authorizationMiddleware.js';
 import {toLoginMiddleware} from '$lib/session/loginMiddleware.js';
 import {toLogoutMiddleware} from '$lib/session/logoutMiddleware.js';
-import {
-	readCommunityService,
-	readCommunitiesService,
-	createMemberService,
-	createCommunityService,
-} from '$lib/vocab/community/communityServices.js';
-import {readFilesService, createFileService} from '$lib/vocab/file/fileServices.js';
-import {
-	readSpaceService,
-	readSpacesService,
-	createSpaceService,
-} from '$lib/vocab/space/spaceServices.js';
 import type {Database} from '$lib/db/Database.js';
 import type {WebsocketServer} from '$lib/server/WebsocketServer.js';
 import {toCookieSessionMiddleware} from '$lib/session/cookieSession';
 import type {CookieSessionRequest} from '$lib/session/cookieSession';
+import type {Service, ServiceParamsSchema, ServiceResponseData} from '$lib/server/service';
 import {toServiceMiddleware} from '$lib/server/serviceMiddleware';
-import {services} from '$lib/server/services';
 
 const log = new Logger([blue('[ApiServer]')]);
 
@@ -44,6 +32,7 @@ export interface Options {
 	websocketServer: WebsocketServer;
 	port?: number;
 	db: Database;
+	services: Map<string, Service<ServiceParamsSchema, ServiceResponseData>>;
 	loadInstance?: () => Promise<Polka | null>;
 }
 
@@ -53,6 +42,7 @@ export class ApiServer {
 	readonly websocketServer: WebsocketServer;
 	readonly port: number | undefined;
 	readonly db: Database;
+	readonly services: Map<string, Service<ServiceParamsSchema, ServiceResponseData>>;
 	readonly loadInstance: () => Promise<Polka | null>;
 
 	constructor(options: Options) {
@@ -61,6 +51,7 @@ export class ApiServer {
 		this.websocketServer = options.websocketServer;
 		this.port = options.port;
 		this.db = options.db;
+		this.services = options.services;
 		this.loadInstance = options.loadInstance || (async () => null);
 		log.info('created');
 	}
@@ -97,19 +88,12 @@ export class ApiServer {
 			// TODO we want to support unauthenticated routes so users can publish public content,
 			// but for now it's simple and secure to just require an authenticated account for everything
 			.use('/api', toAuthorizationMiddleware(this))
-			.post('/api/v1/logout', toLogoutMiddleware(this))
-			.get('/api/v1/communities', toServiceMiddleware(this, readCommunitiesService))
-			.post('/api/v1/communities', toServiceMiddleware(this, createCommunityService))
-			.get('/api/v1/communities/:community_id', toServiceMiddleware(this, readCommunityService))
-			.post(
-				'/api/v1/communities/:community_id/spaces',
-				toServiceMiddleware(this, createSpaceService),
-			)
-			.get('/api/v1/communities/:community_id/spaces', toServiceMiddleware(this, readSpacesService))
-			.get('/api/v1/spaces/:space_id', toServiceMiddleware(this, readSpaceService))
-			.post('/api/v1/spaces/:space_id/files', toServiceMiddleware(this, createFileService))
-			.get('/api/v1/spaces/:space_id/files', toServiceMiddleware(this, readFilesService))
-			.post('/api/v1/members', toServiceMiddleware(this, createMemberService));
+			.post('/api/v1/logout', toLogoutMiddleware(this));
+
+		// Register services as http routes.
+		for (const service of this.services.values()) {
+			this.app[service.http.method](service.http.path, toServiceMiddleware(this, service));
+		}
 
 		// SvelteKit Node adapter, adapted to our production API server
 		// TODO needs a lot of work, especially for production
@@ -172,7 +156,7 @@ export class ApiServer {
 			console.error('[handleWebsocketMessage] invalid message', message);
 			return;
 		}
-		const service = services.get(message.type);
+		const service = this.services.get(message.type);
 		if (!service) {
 			console.error('[handleWebsocketMessage] unhandled message type', message.type);
 			return;

--- a/src/lib/server/ApiServer.ts
+++ b/src/lib/server/ApiServer.ts
@@ -92,7 +92,7 @@ export class ApiServer {
 
 		// Register services as http routes.
 		for (const service of this.services.values()) {
-			this.app[service.http.method](service.http.path, toServiceMiddleware(this, service));
+			this.app[service.route.method](service.route.path, toServiceMiddleware(this, service));
 		}
 
 		// SvelteKit Node adapter, adapted to our production API server

--- a/src/lib/server/server.ts
+++ b/src/lib/server/server.ts
@@ -6,6 +6,7 @@ import {ApiServer} from '$lib/server/ApiServer.js';
 import {Database} from '$lib/db/Database.js';
 import {defaultPostgresOptions} from '$lib/db/postgres.js';
 import {WebsocketServer} from '$lib/server/WebsocketServer.js';
+import {services} from '$lib/server/services';
 
 const server = createServer();
 
@@ -16,6 +17,7 @@ export const apiServer: ApiServer = new ApiServer({
 	app: polka({server}),
 	websocketServer: new WebsocketServer(server),
 	db: new Database({sql: postgres(defaultPostgresOptions)}),
+	services,
 	loadInstance: async () => {
 		try {
 			// TODO this is a hack to make Rollup not bundle this - needs refactoring

--- a/src/lib/server/service.ts
+++ b/src/lib/server/service.ts
@@ -11,8 +11,7 @@ export interface Service<
 	TResponseData extends ServiceResponseData, // TODO change to an output response schema
 > {
 	name: string; // `snake_cased`
-	// TODO better name than `http`? `route`? something else?
-	http: {
+	route: {
 		path: string; // e.g. '/api/v1/some/:neat/:path'
 		// supports each `trouter` http method: https://github.com/lukeed/trouter#method
 		method: 'get' | 'head' | 'patch' | 'options' | 'connect' | 'delete' | 'trace' | 'post' | 'put';

--- a/src/lib/server/service.ts
+++ b/src/lib/server/service.ts
@@ -11,6 +11,12 @@ export interface Service<
 	TResponseData extends ServiceResponseData, // TODO change to an output response schema
 > {
 	name: string; // `snake_cased`
+	// TODO better name than `http`? `route`? something else?
+	http: {
+		path: string; // e.g. '/api/v1/some/:neat/:path'
+		// supports each `trouter` http method: https://github.com/lukeed/trouter#method
+		method: 'get' | 'head' | 'patch' | 'options' | 'connect' | 'delete' | 'trace' | 'post' | 'put';
+	};
 	paramsSchema: TParamsSchema;
 	validateParams?: ValidateFunction<Static<TParamsSchema>>; // created lazily
 	// TODO is `handle` the best name?

--- a/src/lib/vocab/community/communityServices.ts
+++ b/src/lib/vocab/community/communityServices.ts
@@ -18,7 +18,7 @@ export const readCommunitiesService: Service<
 	{communities: Community[]}
 > = {
 	name: 'read_communities',
-	http: {
+	route: {
 		path: '/api/v1/communities',
 		method: 'get',
 	},
@@ -48,7 +48,7 @@ export const readCommunityService: Service<
 	{community: Community}
 > = {
 	name: 'read_community',
-	http: {
+	route: {
 		path: '/api/v1/communities/:community_id',
 		method: 'get',
 	},
@@ -85,7 +85,7 @@ export const createCommunityService: Service<
 	{community: Community}
 > = {
 	name: 'create_community',
-	http: {
+	route: {
 		path: '/api/v1/communities',
 		method: 'post',
 	},
@@ -130,7 +130,7 @@ const CreateMemberServiceParams = MemberParamsSchema;
 //Creates a new member relation for a community
 export const createMemberService: Service<typeof CreateMemberServiceParams, {member: Member}> = {
 	name: 'create_member',
-	http: {
+	route: {
 		path: '/api/v1/members',
 		method: 'post',
 	},

--- a/src/lib/vocab/community/communityServices.ts
+++ b/src/lib/vocab/community/communityServices.ts
@@ -18,6 +18,10 @@ export const readCommunitiesService: Service<
 	{communities: Community[]}
 > = {
 	name: 'read_communities',
+	http: {
+		path: '/api/v1/communities',
+		method: 'get',
+	},
 	paramsSchema: ReadCommunitiesServiceParams,
 	handle: async (server, _params, account_id) => {
 		const {db} = server;
@@ -44,6 +48,10 @@ export const readCommunityService: Service<
 	{community: Community}
 > = {
 	name: 'read_community',
+	http: {
+		path: '/api/v1/communities/:community_id',
+		method: 'get',
+	},
 	paramsSchema: ReadCommunityServiceParams,
 	handle: async (server, params, account_id) => {
 		const {db} = server;
@@ -77,6 +85,10 @@ export const createCommunityService: Service<
 	{community: Community}
 > = {
 	name: 'create_community',
+	http: {
+		path: '/api/v1/communities',
+		method: 'post',
+	},
 	paramsSchema: CreateCommunityServiceParams,
 	// TODO declarative validation for `req.body` and the rest
 	handle: async (server, params, account_id) => {
@@ -118,6 +130,10 @@ const CreateMemberServiceParams = MemberParamsSchema;
 //Creates a new member relation for a community
 export const createMemberService: Service<typeof CreateMemberServiceParams, {member: Member}> = {
 	name: 'create_member',
+	http: {
+		path: '/api/v1/members',
+		method: 'post',
+	},
 	paramsSchema: CreateMemberServiceParams,
 	handle: async (server, params) => {
 		console.log('[create_member] creating member', params.persona_id, params.community_id);

--- a/src/lib/vocab/file/fileServices.ts
+++ b/src/lib/vocab/file/fileServices.ts
@@ -12,6 +12,10 @@ const ReadFilesServiceParams = Type.Object(
 
 export const readFilesService: Service<typeof ReadFilesServiceParams, {files: File[]}> = {
 	name: 'read_files',
+	http: {
+		path: '/api/v1/spaces/:space_id/files',
+		method: 'get',
+	},
 	paramsSchema: ReadFilesServiceParams,
 	handle: async (server, params) => {
 		const {db} = server;
@@ -39,6 +43,10 @@ const CreateFileServiceParams = Type.Object(
 // TODO should this use the `FileParams` type?
 export const createFileService: Service<typeof CreateFileServiceParams, {file: File}> = {
 	name: 'create_file',
+	http: {
+		path: '/api/v1/spaces/:space_id/files',
+		method: 'post',
+	},
 	paramsSchema: CreateFileServiceParams,
 	handle: async (server, params, _accountId) => {
 		// TODO validate `account_id` against the persona -- maybe as an optimized standalone method?

--- a/src/lib/vocab/file/fileServices.ts
+++ b/src/lib/vocab/file/fileServices.ts
@@ -12,7 +12,7 @@ const ReadFilesServiceParams = Type.Object(
 
 export const readFilesService: Service<typeof ReadFilesServiceParams, {files: File[]}> = {
 	name: 'read_files',
-	http: {
+	route: {
 		path: '/api/v1/spaces/:space_id/files',
 		method: 'get',
 	},
@@ -43,7 +43,7 @@ const CreateFileServiceParams = Type.Object(
 // TODO should this use the `FileParams` type?
 export const createFileService: Service<typeof CreateFileServiceParams, {file: File}> = {
 	name: 'create_file',
-	http: {
+	route: {
 		path: '/api/v1/spaces/:space_id/files',
 		method: 'post',
 	},

--- a/src/lib/vocab/space/spaceServices.ts
+++ b/src/lib/vocab/space/spaceServices.ts
@@ -13,6 +13,10 @@ const ReadSpaceServiceParams = Type.Object(
 //Returns a single space object
 export const readSpaceService: Service<typeof ReadSpaceServiceParams, {space: Space}> = {
 	name: 'read_space',
+	http: {
+		path: '/api/v1/spaces/:space_id',
+		method: 'get',
+	},
 	paramsSchema: ReadSpaceServiceParams,
 	handle: async (server, params) => {
 		const {db} = server;
@@ -40,6 +44,10 @@ const ReadSpacesServiceSchema = Type.Object(
 //Returns all spaces in a given community
 export const readSpacesService: Service<typeof ReadSpacesServiceSchema, {spaces: Space[]}> = {
 	name: 'read_spaces',
+	http: {
+		path: '/api/v1/communities/:community_id/spaces',
+		method: 'get',
+	},
 	paramsSchema: ReadSpacesServiceSchema,
 	handle: async (server, params) => {
 		const {db} = server;
@@ -75,6 +83,10 @@ const CreateSpaceServiceSchema = Type.Object(
 //Creates a new space for a given community
 export const createSpaceService: Service<typeof CreateSpaceServiceSchema, {space: Space}> = {
 	name: 'create_space',
+	http: {
+		path: '/api/v1/communities/:community_id/spaces',
+		method: 'post',
+	},
 	paramsSchema: CreateSpaceServiceSchema,
 	// TODO verify the `account_id` has permission to modify this space
 	// TODO add `actor_id` and verify it's one of the `account_id`'s personas

--- a/src/lib/vocab/space/spaceServices.ts
+++ b/src/lib/vocab/space/spaceServices.ts
@@ -13,7 +13,7 @@ const ReadSpaceServiceParams = Type.Object(
 //Returns a single space object
 export const readSpaceService: Service<typeof ReadSpaceServiceParams, {space: Space}> = {
 	name: 'read_space',
-	http: {
+	route: {
 		path: '/api/v1/spaces/:space_id',
 		method: 'get',
 	},
@@ -44,7 +44,7 @@ const ReadSpacesServiceSchema = Type.Object(
 //Returns all spaces in a given community
 export const readSpacesService: Service<typeof ReadSpacesServiceSchema, {spaces: Space[]}> = {
 	name: 'read_spaces',
-	http: {
+	route: {
 		path: '/api/v1/communities/:community_id/spaces',
 		method: 'get',
 	},
@@ -83,7 +83,7 @@ const CreateSpaceServiceSchema = Type.Object(
 //Creates a new space for a given community
 export const createSpaceService: Service<typeof CreateSpaceServiceSchema, {space: Space}> = {
 	name: 'create_space',
-	http: {
+	route: {
 		path: '/api/v1/communities/:community_id/spaces',
 		method: 'post',
 	},


### PR DESCRIPTION
This continues the work to make services declarative and data-driven. It adds an `http` object to services with `method` and `path`, e.g. `'post'` and `'/api/v1/communities/:community_id'`. The `http` name could maybe be improved, like `route`? The equivalent to `method`+`path` for websockets is simply the service `name` which corresponds to events/rpc/etc.

Since services are now mostly declared as data, it should be fairly trivial to generate some basic docs. Maybe a good first usecase for adding them to the frontend.