### PR TITLE
refactor client state

### DIFF
--- a/src/lib/ui/CommunityNav.svelte
+++ b/src/lib/ui/CommunityNav.svelte
@@ -1,11 +1,9 @@
 <script lang="ts">
 	import type {Community} from '$lib/vocab/community/community.js';
-	import type {Member} from '$lib/vocab/member/member.js';
 	import CommunityInput from '$lib/ui/CommunityInput.svelte';
 	import ActorIcon from '$lib/ui/ActorIcon.svelte';
 	import {randomHue} from '$lib/ui/color';
 
-	export let members: Member[];
 	export let selectedPersonaCommunities: Community[];
 	export let selectedCommunity: Community;
 </script>

--- a/src/lib/ui/MainNav.svelte
+++ b/src/lib/ui/MainNav.svelte
@@ -19,11 +19,7 @@
 
 	// TODO speed up these lookups, probably with a map of all entities by id
 	$: selectedCommunity = ui.selectedCommunity;
-	$: selectedSpace = $selectedCommunity
-		? $selectedCommunity.spaces.find(
-				(s) => s.space_id === $ui.selectedSpaceIdByCommunity[$selectedCommunity!.community_id],
-		  ) || null
-		: null;
+	$: selectedSpace = ui.selectedSpace;
 	$: selectedPersona = personas.find((p) => p.persona_id === $ui.selectedPersonaId) || null;
 	$: console.log('selected persona', selectedPersona);
 	$: selectedPersonaCommunities = communities.filter((community) =>
@@ -69,15 +65,11 @@
 		{#if $ui.mainNavView === 'explorer'}
 			<div class="explorer">
 				{#if $selectedCommunity}
-					<CommunityNav
-						{members}
-						{selectedPersonaCommunities}
-						selectedCommunity={$selectedCommunity}
-					/>
+					<CommunityNav {selectedPersonaCommunities} selectedCommunity={$selectedCommunity} />
 					<SpaceNav
 						community={$selectedCommunity}
 						spaces={$selectedCommunity.spaces}
-						{selectedSpace}
+						selectedSpace={$selectedSpace}
 						{members}
 					/>
 				{/if}

--- a/src/lib/ui/MainNav.svelte
+++ b/src/lib/ui/MainNav.svelte
@@ -18,11 +18,10 @@
 	$: personas = $data.personas;
 
 	// TODO speed up these lookups, probably with a map of all entities by id
-	$: selectedCommunity =
-		communities.find((c) => c.community_id === $ui.selectedCommunityId) || null;
-	$: selectedSpace = selectedCommunity
-		? selectedCommunity.spaces.find(
-				(s) => s.space_id === $ui.selectedSpaceIdByCommunity[selectedCommunity!.community_id],
+	$: selectedCommunity = ui.selectedCommunity;
+	$: selectedSpace = $selectedCommunity
+		? $selectedCommunity.spaces.find(
+				(s) => s.space_id === $ui.selectedSpaceIdByCommunity[$selectedCommunity!.community_id],
 		  ) || null
 		: null;
 	$: selectedPersona = personas.find((p) => p.persona_id === $ui.selectedPersonaId) || null;
@@ -32,7 +31,7 @@
 	);
 
 	// TODO refactor to some client view-model for the account
-	$: hue = randomHue($data.account.name);
+	$: hue = randomHue($data.account?.name || 'guest');
 
 	let selectedPersonaId = $ui.selectedPersonaId;
 	$: ui.selectPersona(selectedPersonaId!);
@@ -69,11 +68,15 @@
 		</div>
 		{#if $ui.mainNavView === 'explorer'}
 			<div class="explorer">
-				{#if selectedCommunity}
-					<CommunityNav {members} {selectedPersonaCommunities} {selectedCommunity} />
+				{#if $selectedCommunity}
+					<CommunityNav
+						{members}
+						{selectedPersonaCommunities}
+						selectedCommunity={$selectedCommunity}
+					/>
 					<SpaceNav
-						community={selectedCommunity}
-						spaces={selectedCommunity.spaces}
+						community={$selectedCommunity}
+						spaces={$selectedCommunity.spaces}
 						{selectedSpace}
 						{members}
 					/>

--- a/src/lib/ui/MainNav.svelte
+++ b/src/lib/ui/MainNav.svelte
@@ -20,7 +20,6 @@
 	$: selectedCommunity = ui.selectedCommunity;
 	$: selectedSpace = ui.selectedSpace;
 	$: communitiesByPersonaId = ui.communitiesByPersonaId;
-	// TODO speed up this lookup, probably with a map of all entities by id
 	$: selectedPersonaCommunities = $ui.selectedPersonaId
 		? $communitiesByPersonaId[$ui.selectedPersonaId]
 		: null;

--- a/src/lib/ui/MainNav.svelte
+++ b/src/lib/ui/MainNav.svelte
@@ -14,16 +14,16 @@
 	const {data, ui, api} = getApp();
 
 	$: members = $data.members;
-	$: communities = $data.communities;
 	$: personas = $data.personas;
 
-	// TODO speed up these lookups, probably with a map of all entities by id
 	$: selectedPersona = ui.selectedPersona;
 	$: selectedCommunity = ui.selectedCommunity;
 	$: selectedSpace = ui.selectedSpace;
-	$: selectedPersonaCommunities = communities.filter((community) =>
-		$selectedPersona?.community_ids.includes(community.community_id),
-	);
+	$: communitiesByPersonaId = ui.communitiesByPersonaId;
+	// TODO speed up this lookup, probably with a map of all entities by id
+	$: selectedPersonaCommunities = $ui.selectedPersonaId
+		? $communitiesByPersonaId[$ui.selectedPersonaId]
+		: null;
 
 	// TODO refactor to some client view-model for the account
 	$: hue = randomHue($data.account?.name || 'guest');
@@ -63,7 +63,7 @@
 		</div>
 		{#if $ui.mainNavView === 'explorer'}
 			<div class="explorer">
-				{#if $selectedCommunity}
+				{#if $selectedCommunity && selectedPersonaCommunities}
 					<CommunityNav {selectedPersonaCommunities} selectedCommunity={$selectedCommunity} />
 					<SpaceNav
 						community={$selectedCommunity}

--- a/src/lib/ui/MainNav.svelte
+++ b/src/lib/ui/MainNav.svelte
@@ -18,12 +18,11 @@
 	$: personas = $data.personas;
 
 	// TODO speed up these lookups, probably with a map of all entities by id
+	$: selectedPersona = ui.selectedPersona;
 	$: selectedCommunity = ui.selectedCommunity;
 	$: selectedSpace = ui.selectedSpace;
-	$: selectedPersona = personas.find((p) => p.persona_id === $ui.selectedPersonaId) || null;
-	$: console.log('selected persona', selectedPersona);
 	$: selectedPersonaCommunities = communities.filter((community) =>
-		selectedPersona?.community_ids.includes(community.community_id),
+		$selectedPersona?.community_ids.includes(community.community_id),
 	);
 
 	// TODO refactor to some client view-model for the account
@@ -51,7 +50,7 @@
 				class:selected={$ui.mainNavView === 'explorer'}
 				class="explorer-button"
 			>
-				<ActorIcon name={selectedPersona?.name || 'no name'} />
+				<ActorIcon name={$selectedPersona?.name || 'guest'} />
 			</button>
 			<button
 				on:click={() => ui.setMainNavView('account')}

--- a/src/lib/ui/Workspace.svelte
+++ b/src/lib/ui/Workspace.svelte
@@ -4,29 +4,24 @@
 	import WorkspaceHeader from '$lib/ui/WorkspaceHeader.svelte';
 	import {getApp} from '$lib/ui/app';
 
-	const {data, ui} = getApp();
+	const {ui} = getApp();
 
-	$: communities = $data.communities;
-
-	// TODO speed up these lookups, probably with a map of all entities by id
-	// $: selectedCommunity = data.entities.get($ui.selectedCommunityId);
-	$: selectedCommunity =
-		communities.find((c) => c.community_id === $ui.selectedCommunityId) || null;
-	$: selectedSpace = selectedCommunity
-		? selectedCommunity.spaces.find(
-				(s) => s.space_id === $ui.selectedSpaceIdByCommunity[selectedCommunity!.community_id],
+	$: selectedCommunity = ui.selectedCommunity;
+	$: selectedSpace = $selectedCommunity
+		? $selectedCommunity.spaces.find(
+				(s) => s.space_id === $ui.selectedSpaceIdByCommunity[$selectedCommunity!.community_id],
 		  )
 		: null;
-	$: membersById = selectedCommunity?.membersById;
+	$: membersById = $selectedCommunity?.membersById;
 </script>
 
 <div class="workspace">
 	<div class="column">
-		<WorkspaceHeader space={selectedSpace} community={selectedCommunity} />
+		<WorkspaceHeader space={selectedSpace} community={$selectedCommunity} />
 		{#if selectedSpace && membersById}
 			<SpaceView space={selectedSpace} {membersById} />
-		{:else if selectedCommunity}
-			<SpaceInput community={selectedCommunity}>Create a new space</SpaceInput>
+		{:else if $selectedCommunity}
+			<SpaceInput community={$selectedCommunity}>Create a new space</SpaceInput>
 		{/if}
 	</div>
 </div>

--- a/src/lib/ui/Workspace.svelte
+++ b/src/lib/ui/Workspace.svelte
@@ -7,19 +7,15 @@
 	const {ui} = getApp();
 
 	$: selectedCommunity = ui.selectedCommunity;
-	$: selectedSpace = $selectedCommunity
-		? $selectedCommunity.spaces.find(
-				(s) => s.space_id === $ui.selectedSpaceIdByCommunity[$selectedCommunity!.community_id],
-		  )
-		: null;
+	$: selectedSpace = ui.selectedSpace;
 	$: membersById = $selectedCommunity?.membersById;
 </script>
 
 <div class="workspace">
 	<div class="column">
-		<WorkspaceHeader space={selectedSpace} community={$selectedCommunity} />
-		{#if selectedSpace && membersById}
-			<SpaceView space={selectedSpace} {membersById} />
+		<WorkspaceHeader space={$selectedSpace} community={$selectedCommunity} />
+		{#if $selectedSpace && membersById}
+			<SpaceView space={$selectedSpace} {membersById} />
 		{:else if $selectedCommunity}
 			<SpaceInput community={$selectedCommunity}>Create a new space</SpaceInput>
 		{/if}

--- a/src/lib/ui/data.ts
+++ b/src/lib/ui/data.ts
@@ -26,7 +26,7 @@ export const setData = (session: ClientSession): DataStore => {
 };
 
 export interface DataState {
-	account: AccountModel;
+	account: AccountModel | null;
 	communities: CommunityModel[];
 	spaces: Space[];
 	members: Member[];
@@ -114,7 +114,14 @@ export const toDataStore = (initialSession: ClientSession): DataStore => {
 
 const toDefaultData = (session: ClientSession): DataState => {
 	if (session.guest) {
-		return null as any;
+		return {
+			account: null,
+			communities: [],
+			spaces: [],
+			members: [],
+			personas: [],
+			filesBySpace: {},
+		};
 	} else {
 		return {
 			account: session.account,

--- a/src/lib/ui/ui.ts
+++ b/src/lib/ui/ui.ts
@@ -49,6 +49,7 @@ export const toUiStore = (data: DataStore) => {
 	const {subscribe, update} = state;
 
 	// derived state
+	// TODO speed up these lookups with id maps
 	const selectedPersona = derived(
 		[state, data],
 		([$ui, $data]) => $data.personas.find((p) => p.persona_id === $ui.selectedPersonaId) || null,

--- a/src/lib/ui/ui.ts
+++ b/src/lib/ui/ui.ts
@@ -33,6 +33,7 @@ export interface UiStore {
 	selectedPersona: Readable<Persona | null>;
 	selectedCommunity: Readable<CommunityModel | null>;
 	selectedSpace: Readable<Space | null>;
+	communitiesByPersonaId: Readable<{[persona_id: number]: CommunityModel[]}>; // TODO or name `personaCommunities`?
 	// methods
 	updateData: (data: DataState | null) => void;
 	selectPersona: (persona_id: number) => void;
@@ -64,6 +65,15 @@ export const toUiStore = (data: DataStore) => {
 				(s) => s.space_id === $ui.selectedSpaceIdByCommunity[$selectedCommunity.community_id],
 			) || null,
 	);
+	const communitiesByPersonaId = derived([data], ([$data]) =>
+		$data.personas.reduce((result, persona) => {
+			// TODO speed up this lookup, probably with a map of all communities by id
+			result[persona.persona_id] = $data.communities.filter((community) =>
+				persona.community_ids.includes(community.community_id),
+			);
+			return result;
+		}, {} as {[persona_id: number]: CommunityModel[]}),
+	);
 
 	const store: UiStore = {
 		subscribe,
@@ -71,6 +81,7 @@ export const toUiStore = (data: DataStore) => {
 		selectedPersona,
 		selectedCommunity,
 		selectedSpace,
+		communitiesByPersonaId,
 		// methods
 		updateData: (data) => {
 			console.log('[ui.updateData]', {data});

--- a/src/lib/ui/ui.ts
+++ b/src/lib/ui/ui.ts
@@ -4,6 +4,7 @@ import {setContext, getContext} from 'svelte';
 import type {DataState, DataStore} from '$lib/ui/data';
 import type {CommunityModel} from '$lib/vocab/community/community';
 import type {Space} from '$lib/vocab/space/space';
+import type {Persona} from '$lib/vocab/persona/persona';
 
 // TODO refactor/rethink
 
@@ -29,6 +30,7 @@ export interface UiState {
 export interface UiStore {
 	subscribe: Readable<UiState>['subscribe'];
 	// derived state
+	selectedPersona: Readable<Persona | null>;
 	selectedCommunity: Readable<CommunityModel | null>;
 	selectedSpace: Readable<Space | null>;
 	// methods
@@ -46,6 +48,10 @@ export const toUiStore = (data: DataStore) => {
 	const {subscribe, update} = state;
 
 	// derived state
+	const selectedPersona = derived(
+		[state, data],
+		([$ui, $data]) => $data.personas.find((p) => p.persona_id === $ui.selectedPersonaId) || null,
+	);
 	const selectedCommunity = derived(
 		[state, data],
 		([$ui, $data]) =>
@@ -62,6 +68,7 @@ export const toUiStore = (data: DataStore) => {
 	const store: UiStore = {
 		subscribe,
 		// derived state
+		selectedPersona,
 		selectedCommunity,
 		selectedSpace,
 		// methods

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -37,7 +37,7 @@
 	const updateStateFromPageParams = (params: {community?: string; space?: string}) => {
 		if (!params.community) return;
 		const community = $data.communities.find((c) => c.name === params.community);
-		if (!community) throw Error(`TODO Unable to find community: ${params.community}`);
+		if (!community) return; // occurs when a session routes to a community they can't access
 		const {community_id} = community;
 		if (community_id !== $ui.selectedCommunityId) {
 			api.selectCommunity(community_id);

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -14,7 +14,7 @@
 	import Luggage from '$lib/ui/Luggage.svelte';
 	import MainNav from '$lib/ui/MainNav.svelte';
 	import {setData} from '$lib/ui/data';
-	import {setUi} from '$lib/ui/ui';
+	import {setUi, toUiStore} from '$lib/ui/ui';
 	import {setApi, toApiStore} from '$lib/ui/api';
 	import {setApp} from '$lib/ui/app';
 	import {randomHue} from '$lib/ui/color';
@@ -26,7 +26,7 @@
 	const data = setData($session);
 	$: data.updateSession($session);
 	const socket = setSocket(toSocketStore(toHandleSocketMessage(data)));
-	const ui = setUi();
+	const ui = setUi(toUiStore(data));
 	$: ui.updateData($data); // TODO this or make it an arg to the ui store?
 	const api = setApi(toApiStore(ui, data, socket));
 	const app = setApp({data, ui, api, devmode, socket});
@@ -84,7 +84,7 @@
 	<Devmode {devmode} />
 </div>
 
-<FeltWindowHost query={() => ({hue: randomHue($data.account.name)})} />
+<FeltWindowHost query={() => ({hue: randomHue($data.account?.name || 'guest')})} />
 
 <style>
 	.layout {


### PR DESCRIPTION
This is our first significant usage of [the Svelte `derived` store](https://svelte.dev/docs#derived). It sets a good pattern for hoisting often-used cached data out of the components. The `ui` store now has several store properties that can be granularly subscribed and shared app-wide.

- [x] change selected persona, community, and space to derived stores