### PR TITLE
fix session for deleted accounts

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -22,7 +22,7 @@ export const getSession: GetSession<CookieSessionRequest, ClientSession> = async
 		if (result.ok) {
 			return result.value;
 		} else {
-			request.session = null!; // TODO this resets the session, but need to also clear user's cookies
+			request.session = null!;
 			return {guest: true};
 		}
 	} else {

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -19,7 +19,12 @@ export const getSession: GetSession<CookieSessionRequest, ClientSession> = async
 	if (account_id !== undefined) {
 		// TODO this swallows errors
 		const result = await db.repos.session.loadClientSession(account_id);
-		return result.ok ? result.value : {guest: true};
+		if (result.ok) {
+			return result.value;
+		} else {
+			request.session = null!; // TODO this resets the session, but need to also clear user's cookies
+			return {guest: true};
+		}
 	} else {
 		return {guest: true};
 	}

--- a/src/lib/session/loginMiddleware.ts
+++ b/src/lib/session/loginMiddleware.ts
@@ -59,7 +59,7 @@ export const toLoginMiddleware = (server: ApiServer): Middleware => {
 		if (clientSessionResult.ok) {
 			return send(res, 200, {session: clientSessionResult.value}); // TODO API types
 		} else {
-			req.session = null!; // TODO this resets the session, but need to also clear user's cookies
+			req.session = null!;
 			return send(res, 500, {reason: 'problem loading client session'});
 		}
 	};

--- a/src/lib/session/loginMiddleware.ts
+++ b/src/lib/session/loginMiddleware.ts
@@ -59,6 +59,7 @@ export const toLoginMiddleware = (server: ApiServer): Middleware => {
 		if (clientSessionResult.ok) {
 			return send(res, 200, {session: clientSessionResult.value}); // TODO API types
 		} else {
+			req.session = null!; // TODO this resets the session, but need to also clear user's cookies
 			return send(res, 500, {reason: 'problem loading client session'});
 		}
 	};

--- a/src/lib/session/sessionRepo.ts
+++ b/src/lib/session/sessionRepo.ts
@@ -1,33 +1,37 @@
 import type {Result} from '@feltcoop/felt';
-import {unwrap} from '@feltcoop/felt';
 
 import type {Database} from '$lib/db/Database';
 import type {ClientAccountSession} from '$lib/session/clientSession.js';
-import type {Persona} from '$lib/vocab/persona/persona.js';
-import type {Community} from '$lib/vocab/community/community.js';
-import type {Member} from '$lib/vocab/member/member.js';
 import {accountModelProperties} from '$lib/vocab/account/account';
 import type {ErrorResponse} from '$lib/util/error';
 
 export const sessionRepo = (db: Database) => ({
 	loadClientSession: async (
 		account_id: number,
-	): Promise<Result<{value: ClientAccountSession}, {type: 'no_account_found'} & ErrorResponse>> => {
+	): Promise<
+		Result<{value: ClientAccountSession}, {type?: 'no_account_found'} & ErrorResponse>
+	> => {
 		console.log('[db] loadClientSession', account_id);
 		const accountResult = await db.repos.account.findById(account_id, accountModelProperties);
-		if (!accountResult.ok) {
-			return accountResult;
-		}
+		if (!accountResult.ok) return accountResult;
 		const account = accountResult.value;
-		// TODO instead of unwrapping these, handle errors for better UX
-		let personas: Persona[] = unwrap(await db.repos.persona.filterByAccount(account.account_id));
-		const communities: Community[] = unwrap(
-			await db.repos.community.filterByAccount(account.account_id),
-		);
-		const members: Member[] = unwrap(await db.repos.member.getAll());
+		// TODO make this a single query
+		const [personasResult, communitiesResult, membershipsResult] = await Promise.all([
+			db.repos.persona.filterByAccount(account.account_id),
+			db.repos.community.filterByAccount(account.account_id),
+			db.repos.member.getAll(),
+		]);
+		if (!personasResult.ok) return personasResult;
+		if (!communitiesResult.ok) return communitiesResult;
+		if (!membershipsResult.ok) return membershipsResult;
 		return {
 			ok: true,
-			value: {account, personas, communities, members},
+			value: {
+				account,
+				personas: personasResult.value,
+				communities: communitiesResult.value,
+				members: membershipsResult.value,
+			},
 		};
 	},
 });

--- a/src/lib/session/sessionRepo.ts
+++ b/src/lib/session/sessionRepo.ts
@@ -6,15 +6,20 @@ import type {ClientAccountSession} from '$lib/session/clientSession.js';
 import type {Persona} from '$lib/vocab/persona/persona.js';
 import type {Community} from '$lib/vocab/community/community.js';
 import type {Member} from '$lib/vocab/member/member.js';
-import type {AccountModel} from '$lib/vocab/account/account.js';
 import {accountModelProperties} from '$lib/vocab/account/account';
+import type {ErrorResponse} from '$lib/util/error';
 
 export const sessionRepo = (db: Database) => ({
-	loadClientSession: async (account_id: number): Promise<Result<{value: ClientAccountSession}>> => {
+	loadClientSession: async (
+		account_id: number,
+	): Promise<Result<{value: ClientAccountSession}, {type: 'no_account_found'} & ErrorResponse>> => {
 		console.log('[db] loadClientSession', account_id);
-		const account: AccountModel = unwrap(
-			await db.repos.account.findById(account_id, accountModelProperties),
-		);
+		const accountResult = await db.repos.account.findById(account_id, accountModelProperties);
+		if (!accountResult.ok) {
+			return accountResult;
+		}
+		const account = accountResult.value;
+		// TODO instead of unwrapping these, handle errors for better UX
 		let personas: Persona[] = unwrap(await db.repos.persona.filterByAccount(account.account_id));
 		const communities: Community[] = unwrap(
 			await db.repos.community.filterByAccount(account.account_id),

--- a/src/lib/vocab/community/communityRepo.ts
+++ b/src/lib/vocab/community/communityRepo.ts
@@ -39,7 +39,9 @@ export const communityRepo = (db: Database) => ({
 			reason: `No community found with id: ${community_id}`,
 		};
 	},
-	filterByAccount: async (account_id: number): Promise<Result<{value: Community[]}>> => {
+	filterByAccount: async (
+		account_id: number,
+	): Promise<Result<{value: Community[]}, ErrorResponse>> => {
 		console.log(`[db] preparing to query for communities & spaces persona: ${account_id}`);
 		const data = await db.sql<Community[]>`		
 			SELECT c.community_id, c.name,


### PR DESCRIPTION
When the browser has cookies for a deleted account (like after seeding, we don't support a delete service yet), the server was throwing an error when it tried to `loadClientSession`. The code was taking a shortcut, and now it's time to handle those errors explicitly.

- [x] fix the server erroring if the session account doesn't exist
- [x] handle the other possible errors in `loadClientSession` without throwing