### PR TITLE
fix account password creation

### DIFF
--- a/src/lib/util/password.ts
+++ b/src/lib/util/password.ts
@@ -8,17 +8,20 @@ const toScrypt = promisify(scrypt);
 
 // Returns the string `salt:hash` to be stored in the database.
 // The returned key can be compared to a password attempt with `verifyPassword`.
-export const toPasswordKey = async (password: string): Promise<string> => {
+export const toPasswordKey = async (passwordText: string): Promise<string> => {
 	const salt = randomBytes(SALT_SIZE).toString('hex');
-	const hash = (await toHash(password, salt)).toString('hex');
+	const hash = (await toHash(passwordText, salt)).toString('hex');
 	return `${salt}:${hash}`;
 };
 
 // Checks if a `password` matches the generated hash and salt in `key` from `toPasswordKey`.
-export const verifyPassword = async (passwordText: string, key: string): Promise<boolean> => {
-	const [salt, hash] = key.split(':');
+export const verifyPassword = async (
+	passwordText: string,
+	passwordKey: string,
+): Promise<boolean> => {
+	const [salt, hash] = passwordKey.split(':');
 	return timingSafeEqual(Buffer.from(hash, 'hex'), await toHash(passwordText, salt));
 };
 
-const toHash = (password: string, salt: string): Promise<Buffer> =>
-	toScrypt(password, salt, HASH_SIZE) as any;
+const toHash = (passwordText: string, salt: string): Promise<Buffer> =>
+	toScrypt(passwordText, salt, HASH_SIZE) as any;

--- a/src/lib/vocab/account/accountRepo.ts
+++ b/src/lib/vocab/account/accountRepo.ts
@@ -4,15 +4,17 @@ import type {Account, AccountParams} from '$lib/vocab/account/account.js';
 import {accountProperties} from '$lib/vocab/account/account';
 import type {Database} from '$lib/db/Database';
 import type {ErrorResponse} from '$lib/util/error';
+import {toPasswordKey} from '$lib/util/password';
 
 export const accountRepo = (db: Database) => ({
 	create: async ({
 		name,
 		password,
 	}: AccountParams): Promise<Result<{value: Account}, ErrorResponse>> => {
+		const passwordKey = await toPasswordKey(password);
 		const data = await db.sql<Account[]>`
       insert into accounts (name, password) values (
-        ${name}, ${password}
+        ${name}, ${passwordKey}
       ) RETURNING *`;
 		console.log('[db] created account', data);
 		const account = data[0];


### PR DESCRIPTION
Fixes `account.create` to hash the password into the key with salt. Previously, any calls to `account.create` outside of the login middleware, like tests and seed, were storing the wrong value. Now the responsibility for hashing is in the correct place, inside `account.create`.

Also uses `passwordText` instead of `password` throughout `$lib/util/password.ts` to match the changes in #120 