### PR TITLE
fix http error handling

### DIFF
--- a/src/lib/ui/ApiClient.ts
+++ b/src/lib/ui/ApiClient.ts
@@ -4,7 +4,7 @@ import type {ErrorResponse} from '$lib/util/error';
 
 export type ApiResult<TValue> = Result<
 	{status: number; value: TValue},
-	ErrorResponse & {status: number}
+	ErrorResponse & {status: number | null}
 >;
 
 export interface ApiClient<


### PR DESCRIPTION
The http client was returning malformed errors. This improves things, but it may be imperfect in some cases. There's some strangeness with trying to handle multiple classes of errors. Specifically our concept of an `ApiRequest` error has to handle not just http errors and their familiar status, but also problems like the Internet being down or the server returning a malformed result.

One weird bit is that there can be a non-status associated with failed requests, like if the device's network connection is down or if the server unexpectedly returns a non-JSON response. I added `| null` to the `status` type so it's now `number | null`, and I think this is the best way to model things, but I could be wrong. I considered a sentinel value like -1, which would mean downstream code could just treat it as a number and not have to handle `null` separately, but `null` is more explicit so I went with it.

Currently we never expect non-JSON responses back from the server. The code assumes it's an error, but this means the caller may have succeeded in doing what they wanted to do remotely, but it appears everything failed only because the client processing the return value failed. Instead of treating it like an error, we could return `ok: true` if the server returned `true`, but that's also confusing in its own way, so I dunno. We can revisit if needed.
