### PR TITLE
remove `CommunityModel` and rearrange its data

### DIFF
--- a/src/lib/ui/CommunityNav.svelte
+++ b/src/lib/ui/CommunityNav.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type {CommunityModel} from '$lib/vocab/community/community.js';
+	import type {Community} from '$lib/vocab/community/community.js';
 	import CommunityInput from '$lib/ui/CommunityInput.svelte';
 	import CommunityNavButton from '$lib/ui/CommunityNavButton.svelte';
 	import type {Persona} from '$lib/vocab/persona/persona';
@@ -14,7 +14,7 @@
 	$: selectedSpaceIdByCommunity = $ui.selectedSpaceIdByCommunity;
 
 	// TODO improve the efficiency of this with better data structures and caching
-	const toPersonaCommunity = (persona: Persona): CommunityModel =>
+	const toPersonaCommunity = (persona: Persona): Community =>
 		$communitiesByPersonaId[persona.persona_id].find((c) => c.name === persona.name)!;
 </script>
 

--- a/src/lib/ui/CommunityNavButton.svelte
+++ b/src/lib/ui/CommunityNavButton.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type {CommunityModel} from '$lib/vocab/community/community.js';
+	import type {Community} from '$lib/vocab/community/community.js';
 	import ActorIcon from '$lib/ui/ActorIcon.svelte';
 	import {randomHue} from '$lib/ui/color';
 	import type {Persona} from '$lib/vocab/persona/persona';
@@ -12,10 +12,10 @@
 	// could `ui` be more composable, so it could be easily reused e.g. in docs for demonstration purposes?
 
 	export let persona: Persona;
-	export let community: CommunityModel;
+	export let community: Community;
 	export let selected: boolean = false;
 	// export let communitiesByPersonaId: {
-	// 	[persona_id: number]: CommunityModel[];
+	// 	[persona_id: number]: Community[];
 	// };
 	export let selectedSpaceIdByCommunity: {[key: number]: number | null};
 	// TODO this is causing a double state change (rendering an invalid in between state)

--- a/src/lib/ui/HttpApiClient.ts
+++ b/src/lib/ui/HttpApiClient.ts
@@ -60,7 +60,7 @@ export const toHttpApiClient = <
 				return {
 					ok: false,
 					status: null,
-					reason: 'Something went wrong. Is your Internet down?',
+					reason: 'Something went wrong. Is your Internet ok?',
 				};
 			}
 		},

--- a/src/lib/ui/HttpApiClient.ts
+++ b/src/lib/ui/HttpApiClient.ts
@@ -16,7 +16,9 @@ import type {ServiceMeta} from '$lib/server/servicesMeta';
 export const toHttpApiClient = <
 	TParamsMap extends Record<string, any>,
 	TResultMap extends Record<string, any>,
->(): ApiClient<TParamsMap, TResultMap> => {
+>(
+	fetch: typeof globalThis.fetch = globalThis.fetch,
+): ApiClient<TParamsMap, TResultMap> => {
 	const client: ApiClient<TParamsMap, TResultMap> = {
 		invoke: async (name, params) => {
 			console.log('[http api client] invoke', name, params);
@@ -58,7 +60,7 @@ export const toHttpApiClient = <
 				return {
 					ok: false,
 					status: null,
-					reason: 'Network error: please check your Internet connection and try again',
+					reason: 'Something went wrong. Is your Internet down?',
 				};
 			}
 		},

--- a/src/lib/ui/SpaceInput.svelte
+++ b/src/lib/ui/SpaceInput.svelte
@@ -2,14 +2,14 @@
 	import Dialog from '@feltcoop/felt/ui/Dialog.svelte';
 	import Markup from '@feltcoop/felt/ui/Markup.svelte';
 
-	import type {CommunityModel} from '$lib/vocab/community/community.js';
+	import type {Community} from '$lib/vocab/community/community.js';
 	import {autofocus} from '$lib/ui/actions';
 	import {getApp} from '$lib/ui/app';
 	import {spaceTypes} from '$lib/vocab/space/space';
 
 	const {api} = getApp();
 
-	export let community: CommunityModel;
+	export let community: Community;
 
 	let open = false;
 	let newName = '';

--- a/src/lib/ui/SpaceNav.svelte
+++ b/src/lib/ui/SpaceNav.svelte
@@ -3,11 +3,11 @@
 
 	import type {Space} from '$lib/vocab/space/space.js';
 	import SpaceInput from '$lib/ui/SpaceInput.svelte';
-	import type {CommunityModel} from '$lib/vocab/community/community.js';
+	import type {Community} from '$lib/vocab/community/community.js';
 	import MembershipInput from '$lib/ui/MembershipInput.svelte';
 	import type {Persona} from '$lib/vocab/persona/persona.js';
 
-	export let community: CommunityModel;
+	export let community: Community;
 	export let spaces: Space[];
 	export let selectedSpace: Space | null;
 	export let allPersonas: Persona[];

--- a/src/lib/ui/Workspace.svelte
+++ b/src/lib/ui/Workspace.svelte
@@ -11,7 +11,6 @@
 	$: selectedCommunity = ui.selectedCommunity;
 	$: selectedSpace = ui.selectedSpace;
 	// TODO should display just the space's members, not the community's
-	// TODO cache this on the data
 	$: memberPersonasById = new Map(
 		$selectedCommunity?.memberPersonas.map((persona) => [persona.persona_id, persona]) || [],
 	);

--- a/src/lib/ui/Workspace.svelte
+++ b/src/lib/ui/Workspace.svelte
@@ -11,7 +11,10 @@
 	$: selectedCommunity = ui.selectedCommunity;
 	$: selectedSpace = ui.selectedSpace;
 	// TODO should display just the space's members, not the community's
-	$: memberPersonasById = $selectedCommunity?.memberPersonasById;
+	// TODO cache this on the data
+	$: memberPersonasById = new Map(
+		$selectedCommunity?.memberPersonas.map((persona) => [persona.persona_id, persona]) || [],
+	);
 </script>
 
 <div class="workspace">

--- a/src/lib/ui/api.ts
+++ b/src/lib/ui/api.ts
@@ -151,21 +151,21 @@ export const toApi = (
 			}
 			return result;
 		},
+		// TODO: This implementation is currently unconsentful,
+		// because does not give the potential member an opportunity to deny an invite
+		createMembership: async (params) => {
+			const result = await client2.invoke('create_membership', params);
+			console.log('[api] create_membership result', result);
+			if (result.ok) {
+				data.addMembership(result.value.membership);
+			}
+			return result;
+		},
 		createSpace: async (params) => {
 			const result = await client2.invoke('create_space', params);
 			console.log('[api] create_space result', result);
 			if (result.ok) {
 				data.addSpace(result.value.space, params.community_id);
-			}
-			return result;
-		},
-		// TODO: This implementation is currently unconsentful,
-		// because does not give the potential member an opportunity to deny an invite
-		createMembership: async (params) => {
-			const result = await client2.invoke('create_membership', params);
-			if (result.ok) {
-				console.log('TODO handle create_membership result', result);
-				// data.addMembership(result.value.member);
 			}
 			return result;
 		},

--- a/src/lib/ui/api.ts
+++ b/src/lib/ui/api.ts
@@ -3,8 +3,7 @@ import {session} from '$app/stores';
 
 import type {DataStore} from '$lib/ui/data';
 import type {UiStore} from '$lib/ui/ui';
-import type {Community, CommunityModel, CommunityParams} from '$lib/vocab/community/community';
-import {toCommunityModel} from '$lib/vocab/community/community';
+import type {Community, Community, CommunityParams} from '$lib/vocab/community/community';
 import type {Space, SpaceParams} from '$lib/vocab/space/space';
 import type {Membership, MembershipParams} from '$lib/vocab/membership/membership';
 import type {File, FileParams} from '$lib/vocab/file/file';
@@ -48,7 +47,7 @@ export interface Api {
 	createPersona: (
 		params: PersonaParams,
 	) => Promise<ApiResult<{persona: Persona; community: Community}>>;
-	createCommunity: (params: CommunityParams) => Promise<ApiResult<CommunityModel>>;
+	createCommunity: (params: CommunityParams) => Promise<ApiResult<Community>>;
 	createSpace: (params: SpaceParams) => Promise<ApiResult<{space: Space}>>;
 	createMembership: (params: MembershipParams) => Promise<ApiResult<{membership: Membership}>>;
 	createFile: (params: FileParams) => Promise<ApiResult<{file: File}>>;
@@ -128,11 +127,11 @@ export const toApi = (
 			console.log('[api] create_community result', result);
 			if (result.ok) {
 				const {persona, community: rawCommunity} = result.value;
-				const community = toCommunityModel(rawCommunity as Community); // TODO `Community` type is off with schema
+				const community = toCommunity(rawCommunity as Community); // TODO `Community` type is off with schema
 				data.addCommunity(community, persona.persona_id);
 				data.addPersona(persona);
 				// TODO refactor to not return here, do `return result` below --
-				// can't return `result` right now because the `CommunityModel` is different,
+				// can't return `result` right now because the `Community` is different,
 				// but we probably want to change it to have associated data instead of a different interface
 				return {ok: true, status: result.status, value: {persona, community}};
 			}
@@ -143,10 +142,10 @@ export const toApi = (
 			const result = await client2.invoke('create_community', params);
 			console.log('[api] create_community result', result);
 			if (result.ok) {
-				const community = toCommunityModel(result.value.community as any); // TODO `Community` type is off with schema
+				const community = toCommunity(result.value.community as any); // TODO `Community` type is off with schema
 				data.addCommunity(community, params.persona_id);
 				// TODO refactor to not return here, do `return result` below --
-				// can't return `result` right now because the `CommunityModel` is different,
+				// can't return `result` right now because the `Community` is different,
 				// but we probably want to change it to have associated data instead of a different interface
 				return {ok: true, status: result.status, value: community};
 			}

--- a/src/lib/ui/api.ts
+++ b/src/lib/ui/api.ts
@@ -3,7 +3,7 @@ import {session} from '$app/stores';
 
 import type {DataStore} from '$lib/ui/data';
 import type {UiStore} from '$lib/ui/ui';
-import type {Community, Community, CommunityParams} from '$lib/vocab/community/community';
+import type {Community, CommunityParams} from '$lib/vocab/community/community';
 import type {Space, SpaceParams} from '$lib/vocab/space/space';
 import type {Membership, MembershipParams} from '$lib/vocab/membership/membership';
 import type {File, FileParams} from '$lib/vocab/file/file';
@@ -127,7 +127,7 @@ export const toApi = (
 			console.log('[api] create_community result', result);
 			if (result.ok) {
 				const {persona, community: rawCommunity} = result.value;
-				const community = toCommunity(rawCommunity as Community); // TODO `Community` type is off with schema
+				const community = rawCommunity as Community; // TODO `Community` type is off with schema
 				data.addCommunity(community, persona.persona_id);
 				data.addPersona(persona);
 				// TODO refactor to not return here, do `return result` below --
@@ -142,7 +142,7 @@ export const toApi = (
 			const result = await client2.invoke('create_community', params);
 			console.log('[api] create_community result', result);
 			if (result.ok) {
-				const community = toCommunity(result.value.community as any); // TODO `Community` type is off with schema
+				const community = result.value.community as any; // TODO `Community` type is off with schema
 				data.addCommunity(community, params.persona_id);
 				// TODO refactor to not return here, do `return result` below --
 				// can't return `result` right now because the `Community` is different,

--- a/src/lib/ui/data.ts
+++ b/src/lib/ui/data.ts
@@ -3,8 +3,7 @@ import type {Readable} from 'svelte/store';
 import {setContext, getContext} from 'svelte';
 
 import type {ClientSession} from '$lib/session/clientSession';
-import {toCommunityModel} from '$lib/vocab/community/community';
-import type {CommunityModel} from '$lib/vocab/community/community';
+import type {Community} from '$lib/vocab/community/community';
 import type {Space} from '$lib/vocab/space/space';
 import type {AccountModel} from '$lib/vocab/account/account';
 import type {Persona} from '$lib/vocab/persona/persona';
@@ -26,7 +25,7 @@ export const setData = (session: ClientSession): DataStore => {
 
 export interface DataState {
 	account: AccountModel | null;
-	communities: CommunityModel[];
+	communities: Community[];
 	spaces: Space[];
 	allPersonas: Persona[]; //TODO; remove this when a real invite system is in place
 	personas: Persona[];
@@ -37,7 +36,7 @@ export interface DataStore {
 	subscribe: Readable<DataState>['subscribe'];
 	updateSession: (session: ClientSession) => void;
 	addPersona: (persona: Persona) => void;
-	addCommunity: (community: CommunityModel, persona_id: number) => void;
+	addCommunity: (community: Community, persona_id: number) => void;
 	addSpace: (space: Space, community_id: number) => void;
 	addFile: (file: File) => void;
 	setFiles: (space_id: number, files: File[]) => void;
@@ -127,7 +126,7 @@ const toDefaultData = (session: ClientSession): DataState => {
 	} else {
 		return {
 			account: session.account,
-			communities: session.communities.map((community) => toCommunityModel(community)),
+			communities: session.communities.map((community) => toCommunity(community)),
 			// TODO session should already have a flat array of spaces
 			spaces: session.communities.flatMap((community) => community.spaces),
 			allPersonas: session.allPersonas,

--- a/src/lib/ui/data.ts
+++ b/src/lib/ui/data.ts
@@ -8,6 +8,7 @@ import type {Space} from '$lib/vocab/space/space';
 import type {AccountModel} from '$lib/vocab/account/account';
 import type {Persona} from '$lib/vocab/persona/persona';
 import type {File} from '$lib/vocab/file/file';
+import type {Membership} from '$lib/vocab/membership/membership';
 
 // TODO refactor/rethink
 
@@ -26,6 +27,7 @@ export const setData = (session: ClientSession): DataStore => {
 export interface DataState {
 	account: AccountModel | null;
 	communities: Community[];
+	memberships: Membership[]; // TODO needs to be used, currently only gets populated when a new membership is created
 	spaces: Space[];
 	allPersonas: Persona[]; //TODO; remove this when a real invite system is in place
 	personas: Persona[];
@@ -37,6 +39,7 @@ export interface DataStore {
 	updateSession: (session: ClientSession) => void;
 	addPersona: (persona: Persona) => void;
 	addCommunity: (community: Community, persona_id: number) => void;
+	addMembership: (membership: Membership) => void;
 	addSpace: (space: Space, community_id: number) => void;
 	addFile: (file: File) => void;
 	setFiles: (space_id: number, files: File[]) => void;
@@ -71,6 +74,15 @@ export const toDataStore = (initialSession: ClientSession): DataStore => {
 						? {...persona, community_ids: persona.community_ids.concat(community.community_id)}
 						: persona,
 				),
+			}));
+		},
+		addMembership: (membership) => {
+			// TODO instead of this, probably want to set more granularly with nested stores
+			console.log('[data.addMembership]', membership);
+			update(($data) => ({
+				...$data,
+				memberships: $data.memberships.concat(membership),
+				// TODO update `communities.memberPersonas` (which will be refactored)
 			}));
 		},
 		addSpace: (space, community_id) => {
@@ -118,6 +130,7 @@ const toDefaultData = (session: ClientSession): DataState => {
 		return {
 			account: null,
 			communities: [],
+			memberships: [],
 			spaces: [],
 			allPersonas: [],
 			personas: [],
@@ -126,7 +139,8 @@ const toDefaultData = (session: ClientSession): DataState => {
 	} else {
 		return {
 			account: session.account,
-			communities: session.communities.map((community) => toCommunity(community)),
+			communities: session.communities,
+			memberships: [], // TODO should be on session
 			// TODO session should already have a flat array of spaces
 			spaces: session.communities.flatMap((community) => community.spaces),
 			allPersonas: session.allPersonas,

--- a/src/lib/ui/ui.ts
+++ b/src/lib/ui/ui.ts
@@ -6,7 +6,11 @@ import type {Community} from '$lib/vocab/community/community';
 import type {Space} from '$lib/vocab/space/space';
 import type {Persona} from '$lib/vocab/persona/persona';
 
-// TODO refactor/rethink
+// TODO in the current design,
+// the methods on the `UiStore` are intended to be called *only* by the `api`
+// when we're talking about being inside an app context.
+// Of course you can make more of these stores than what's given to you in the app.
+// Use cases may include documentation and dueling apps.
 
 const KEY = Symbol();
 

--- a/src/lib/ui/ui.ts
+++ b/src/lib/ui/ui.ts
@@ -2,7 +2,7 @@ import type {Readable} from 'svelte/store';
 import {writable, derived} from 'svelte/store';
 import {setContext, getContext} from 'svelte';
 import type {DataState, DataStore} from '$lib/ui/data';
-import type {CommunityModel} from '$lib/vocab/community/community';
+import type {Community} from '$lib/vocab/community/community';
 import type {Space} from '$lib/vocab/space/space';
 import type {Persona} from '$lib/vocab/persona/persona';
 
@@ -32,9 +32,9 @@ export interface UiStore {
 	subscribe: Readable<UiState>['subscribe'];
 	// derived state
 	selectedPersona: Readable<Persona | null>;
-	selectedCommunity: Readable<CommunityModel | null>;
+	selectedCommunity: Readable<Community | null>;
 	selectedSpace: Readable<Space | null>;
-	communitiesByPersonaId: Readable<{[persona_id: number]: CommunityModel[]}>; // TODO or name `personaCommunities`?
+	communitiesByPersonaId: Readable<{[persona_id: number]: Community[]}>; // TODO or name `personaCommunities`?
 	// methods
 	updateData: (data: DataState) => void;
 	selectPersona: (persona_id: number) => void;
@@ -75,7 +75,7 @@ export const toUiStore = (data: DataStore): UiStore => {
 				persona.community_ids.includes(community.community_id),
 			);
 			return result;
-		}, {} as {[persona_id: number]: CommunityModel[]}),
+		}, {} as {[persona_id: number]: Community[]}),
 	);
 
 	const store: UiStore = {

--- a/src/lib/ui/ui.ts
+++ b/src/lib/ui/ui.ts
@@ -7,9 +7,10 @@ import type {Space} from '$lib/vocab/space/space';
 import type {Persona} from '$lib/vocab/persona/persona';
 
 // TODO in the current design,
-// the methods on the `UiStore` are intended to be called *only* by the `api`
-// when we're talking about being inside an app context.
-// Of course you can make more of these stores than what's given to you in the app.
+// the methods on the `UiStore` should not be called directly in an app context.
+// They're intended to be called by the api for future orchestration reasons.
+// Of course you can make more of these stores than what's given to you in the app,
+// and call methods all you want without weird bugs.
 // Use cases may include documentation and dueling apps.
 
 const KEY = Symbol();

--- a/src/lib/vocab/community/community.ts
+++ b/src/lib/vocab/community/community.ts
@@ -34,22 +34,6 @@ export const CommunityParamsSchema = Type.Object(
 );
 export const validateCommunityParams = toValidateSchema<CommunityParams>(CommunityParamsSchema);
 
-// TODO think through alternatives to this, probably caching `membershipById` on `data`
-export interface CommunityModel {
-	community_id: number;
-	name: string;
-	spaces: Space[];
-	memberPersonas: Persona[];
-	memberPersonasById: Map<number, Persona>;
-}
-
-export const toCommunityModel = (community: Community): CommunityModel => ({
-	...community,
-	memberPersonasById: new Map(
-		community.memberPersonas.map((persona) => [persona.persona_id, persona]),
-	),
-});
-
 export interface CommunitySpaces {
 	community_id: number;
 	space_id: number;

--- a/src/lib/vocab/community/community.ts
+++ b/src/lib/vocab/community/community.ts
@@ -45,7 +45,6 @@ export interface CommunityModel {
 
 export const toCommunityModel = (community: Community): CommunityModel => ({
 	...community,
-	memberPersonas: community.memberPersonas,
 	memberPersonasById: new Map(
 		community.memberPersonas.map((persona) => [persona.persona_id, persona]),
 	),


### PR DESCRIPTION
The `CommunityModel` was an experimental pattern where we added client-side-only properties to communities returned from the server. Instead of this mode of storing and accessing data, we're moving towards having normalized immutable data. This keeps things simpler, so we don't have to modify data received from the server. We can use `WeakMap` to get the same behavior if needed.