### PR TITLE
pass through api result from services to clients

### DIFF
--- a/src/lib/server/api.ts
+++ b/src/lib/server/api.ts
@@ -1,0 +1,8 @@
+import type {Result} from '@feltcoop/felt';
+
+import type {ErrorResponse} from '$lib/util/error';
+
+export type ApiResult<TValue> = Result<
+	{status: number; value: TValue},
+	ErrorResponse & {status: number | null}
+>;

--- a/src/lib/server/service.ts
+++ b/src/lib/server/service.ts
@@ -2,7 +2,7 @@ import type {ValidateFunction} from 'ajv';
 import type {TSchema, Static} from '@sinclair/typebox';
 
 import type {ApiServer} from '$lib/server/ApiServer.js';
-import type {ErrorResponse} from '$lib/util/error';
+import type {ApiResult} from '$lib/server/api';
 
 // A `Service` can be reused across both http and websocket handlers.
 // The generics are required to avoid mistakes with service definitions.
@@ -17,21 +17,11 @@ export interface Service<TParamsSchema extends TSchema, TResponseSchema extends 
 	validateParams: () => ValidateFunction<Static<TParamsSchema>>; // lazy to avoid wasteful compilation
 	responseSchema: TResponseSchema;
 	validateResponse: () => ValidateFunction<Static<TResponseSchema>>; // lazy to avoid wasteful compilation
-	perform(
-		request: ServiceRequest<TParamsSchema>,
-	): Promise<ServiceResponse<Static<TResponseSchema>>>;
+	perform(request: ServiceRequest<TParamsSchema>): Promise<ApiResult<Static<TResponseSchema>>>;
 }
 
 export interface ServiceRequest<TParamsSchema extends TSchema> {
 	server: ApiServer;
 	params: Static<TParamsSchema>;
 	account_id: number;
-}
-
-export interface ServiceResponse<TResponseValue extends object> {
-	status: number;
-	// TODO handle the types compatible with both websockets and http:
-	// websocket types: `string | Buffer | ArrayBuffer | Buffer[]`
-	// http types: `string | object | Stream | Buffer | undefined`
-	value: TResponseValue | ErrorResponse;
 }

--- a/src/lib/server/serviceMiddleware.ts
+++ b/src/lib/server/serviceMiddleware.ts
@@ -57,7 +57,7 @@ export const toServiceMiddleware =
 			}
 			const result = await service.perform({server, params, account_id: req.account_id});
 			if (!result.ok) {
-				send(res, result.status || 500, {reason: result.reason}); // TODO consider returning the entire `result` for convenience (but it's less efficient)
+				send(res, result.status || 500, {reason: result.reason});
 				return;
 			}
 			if (process.env.NODE_ENV !== 'production') {

--- a/src/lib/server/serviceMiddleware.ts
+++ b/src/lib/server/serviceMiddleware.ts
@@ -55,14 +55,18 @@ export const toServiceMiddleware =
 				// Should each service declare if `account_id` is required?
 				return send(res, 401, {reason: 'not logged in'});
 			}
-			const response = await service.perform({server, params, account_id: req.account_id});
+			const result = await service.perform({server, params, account_id: req.account_id});
+			if (!result.ok) {
+				send(res, result.status || 500, {reason: result.reason}); // TODO consider returning the entire `result` for convenience (but it's less efficient)
+				return;
+			}
 			if (process.env.NODE_ENV !== 'production') {
-				if (!service.validateResponse()(response.value)) {
-					console.error(red('validation failed:'), response, service.validateResponse().errors);
+				if (!service.validateResponse()(result.value)) {
+					console.error(red('validation failed:'), result, service.validateResponse().errors);
 				}
 			}
-			console.log('[serviceMiddleware] result.code', response.status);
-			send(res, response.status, response.value);
+			console.log('[serviceMiddleware] result.status', result.status);
+			send(res, result.status, result.value); // TODO consider returning the entire `result` for convenience (but it's less efficient)
 		} catch (err) {
 			console.error(err);
 			send(res, 500, {reason: 'unknown server error'});

--- a/src/lib/server/services.test.ts
+++ b/src/lib/server/services.test.ts
@@ -28,16 +28,16 @@ test__services('perform services', async ({server}) => {
 				)}`,
 			);
 		}
-		const response = await service.perform({server, params, account_id: account.account_id});
-		if (!validateSchema(service.responseSchema)(response.value)) {
-			console.error(red(`failed to validate service response: ${service.name}`), response);
+		const result = await service.perform({server, params, account_id: account.account_id});
+		if (!result.ok || !validateSchema(service.responseSchema)(result.value)) {
+			console.error(red(`failed to validate service response: ${service.name}`), result);
 			throw new Error(
 				`Failed to validate response for service: ${service.name}: ${toValidationErrorMessage(
 					validateSchema(service.responseSchema).errors![0],
 				)}`,
 			);
 		}
-		t.is(response.status, 200); // TODO generate invalid data and test those params+responses too
+		t.is(result.status, 200); // TODO generate invalid data and test those params+responses too
 	}
 });
 

--- a/src/lib/ui/ApiClient.ts
+++ b/src/lib/ui/ApiClient.ts
@@ -1,11 +1,4 @@
-import type {Result} from '@feltcoop/felt';
-
-import type {ErrorResponse} from '$lib/util/error';
-
-export type ApiResult<TValue> = Result<
-	{status: number; value: TValue},
-	ErrorResponse & {status: number | null}
->;
+import type {ApiResult} from '$lib/server/api';
 
 export interface ApiClient<
 	TParamsMap extends Record<string, any> = any, // TODO default type?

--- a/src/lib/ui/api.ts
+++ b/src/lib/ui/api.ts
@@ -10,7 +10,8 @@ import type {Membership, MembershipParams} from '$lib/vocab/membership/membershi
 import type {File, FileParams} from '$lib/vocab/file/file';
 import type {LoginRequest} from '$lib/session/loginMiddleware.js';
 import type {ClientAccountSession} from '$lib/session/clientSession';
-import type {ApiClient, ApiResult} from '$lib/ui/ApiClient';
+import type {ApiClient} from '$lib/ui/ApiClient';
+import type {ApiResult} from '$lib/server/api';
 import type {ServicesParamsMap, ServicesResultMap} from '$lib/server/servicesTypes';
 import type {Persona, PersonaParams} from '$lib/vocab/persona/persona';
 

--- a/src/lib/vocab/community/communityServices.ts
+++ b/src/lib/vocab/community/communityServices.ts
@@ -36,10 +36,10 @@ export const readCommunitiesService: Service<
 		const {db} = server;
 		const findCommunitiesResult = await db.repos.community.filterByAccount(account_id);
 		if (findCommunitiesResult.ok) {
-			return {status: 200, value: {communities: findCommunitiesResult.value}};
+			return {ok: true, status: 200, value: {communities: findCommunitiesResult.value}};
 		} else {
 			console.log('[read_communities] error searching for communities');
-			return {status: 500, value: {reason: 'error searching for communities'}};
+			return {ok: false, status: 500, reason: 'error searching for communities'};
 		}
 	},
 };
@@ -78,11 +78,12 @@ export const readCommunityService: Service<
 
 		const findCommunityResult = await db.repos.community.findById(params.community_id);
 		if (findCommunityResult.ok) {
-			return {status: 200, value: {community: findCommunityResult.value}};
+			return {ok: true, status: 200, value: {community: findCommunityResult.value}};
 		} else {
 			return {
+				ok: false,
 				status: findCommunityResult.type === 'no_community_found' ? 404 : 500,
-				value: {reason: findCommunityResult.reason},
+				reason: findCommunityResult.reason,
 			};
 		}
 	},
@@ -121,7 +122,11 @@ export const createCommunityService: Service<
 	perform: async ({server, params, account_id}) => {
 		if (!params.name) {
 			// TODO declarative validation
-			return {status: 400, value: {reason: 'invalid name'}};
+			return {
+				ok: false,
+				status: 400,
+				reason: 'invalid name',
+			};
 		}
 		console.log('created community account_id', account_id);
 		// TODO validate that `account_id` is `persona_id`
@@ -136,6 +141,7 @@ export const createCommunityService: Service<
 				console.log('community_id', community_id);
 				console.log('communityData', communityData);
 				return {
+					ok: true,
 					status: 200,
 					value: {
 						community: communityData.value.find((c) => c.community_id === community_id)!,
@@ -143,11 +149,19 @@ export const createCommunityService: Service<
 				}; // TODO API types
 			} else {
 				console.log('[create_community] error retrieving community data');
-				return {status: 500, value: {reason: 'error retrieving community data'}};
+				return {
+					ok: false,
+					status: 500,
+					reason: 'error retrieving community data',
+				};
 			}
 		} else {
 			console.log('[create_community] error creating community');
-			return {status: 500, value: {reason: 'error creating community'}};
+			return {
+				ok: false,
+				status: 500,
+				reason: 'error creating community',
+			};
 		}
 	},
 };
@@ -186,10 +200,10 @@ export const createMembershipService: Service<
 
 		const createMembershipResult = await server.db.repos.membership.create(params);
 		if (createMembershipResult.ok) {
-			return {status: 200, value: {membership: createMembershipResult.value}};
+			return {ok: true, status: 200, value: {membership: createMembershipResult.value}};
 		} else {
 			console.log('[create_membership] error creating membership');
-			return {status: 500, value: {reason: 'error creating membership'}};
+			return {ok: false, status: 500, reason: 'error creating membership'};
 		}
 	},
 };

--- a/src/lib/vocab/file/fileServices.ts
+++ b/src/lib/vocab/file/fileServices.ts
@@ -34,10 +34,10 @@ export const readFilesService: Service<
 		const {db} = server;
 		const findFilesResult = await db.repos.file.filterBySpace(params.space_id);
 		if (findFilesResult.ok) {
-			return {status: 200, value: {files: findFilesResult.value}}; // TODO API types
+			return {ok: true, status: 200, value: {files: findFilesResult.value}}; // TODO API types
 		} else {
 			console.log('[read_files] error searching for files');
-			return {status: 500, value: {reason: 'error searching for files'}};
+			return {ok: false, status: 500, reason: 'error searching for files'};
 		}
 	},
 };
@@ -78,10 +78,10 @@ export const createFileService: Service<
 		// server.db.repos.account.validatePersona(account_id, actor_id);
 		const insertFilesResult = await server.db.repos.file.create(params);
 		if (insertFilesResult.ok) {
-			return {status: 200, value: {file: insertFilesResult.value}}; // TODO API types
+			return {ok: true, status: 200, value: {file: insertFilesResult.value}}; // TODO API types
 		} else {
 			console.log('[create_file] error searching for files');
-			return {status: 500, value: {reason: 'error searching for files'}};
+			return {ok: false, status: 500, reason: 'error searching for files'};
 		}
 	},
 };

--- a/src/lib/vocab/persona/personaServices.ts
+++ b/src/lib/vocab/persona/personaServices.ts
@@ -44,10 +44,10 @@ export const createPersonaService: Service<
 		// this begs the question, should repos use the `__Params` interfaces or not?
 		const createPersonaResult = await db.repos.persona.create(params, account_id);
 		if (createPersonaResult.ok) {
-			return {status: 200, value: createPersonaResult.value};
+			return {ok: true, status: 200, value: createPersonaResult.value};
 		} else {
 			console.log('[create_persona] error searching for community personas');
-			return {status: 500, value: {reason: 'error searching for community personas'}};
+			return {ok: false, status: 500, reason: 'error searching for community personas'};
 		}
 	},
 };

--- a/src/lib/vocab/space/spaceServices.ts
+++ b/src/lib/vocab/space/spaceServices.ts
@@ -38,12 +38,13 @@ export const readSpaceService: Service<
 
 		const findSpaceResult = await db.repos.space.findById(params.space_id);
 		if (findSpaceResult.ok) {
-			return {status: 200, value: {space: findSpaceResult.value}};
+			return {ok: true, status: 200, value: {space: findSpaceResult.value}};
 		} else {
 			console.log('[read_space] no space found');
 			return {
+				ok: false,
 				status: findSpaceResult.type === 'no_space_found' ? 404 : 500,
-				value: {reason: findSpaceResult.reason},
+				reason: findSpaceResult.reason,
 			};
 		}
 	},
@@ -83,10 +84,10 @@ export const readSpacesService: Service<
 
 		const findSpacesResult = await db.repos.space.filterByCommunity(params.community_id);
 		if (findSpacesResult.ok) {
-			return {status: 200, value: {spaces: findSpacesResult.value}};
+			return {ok: true, status: 200, value: {spaces: findSpacesResult.value}};
 		} else {
 			console.log('[read_spaces] error searching for community spaces');
-			return {status: 500, value: {reason: 'error searching for community spaces'}};
+			return {ok: false, status: 500, reason: 'error searching for community spaces'};
 		}
 	},
 };
@@ -139,21 +140,21 @@ export const createSpaceService: Service<
 
 		if (!findByCommunityUrlResult.ok) {
 			console.log('[create_space] error validating unique url for new space');
-			return {ok: false, status: 500, value: {reason: 'error validating unique url for new space'}};
+			return {ok: false, status: 500, reason: 'error validating unique url for new space'};
 		}
 
 		if (findByCommunityUrlResult.value) {
 			console.log('[create_space] provided url for space already exists');
-			return {ok: false, status: 409, value: {reason: 'a space with that url already exists'}};
+			return {ok: false, status: 409, reason: 'a space with that url already exists'};
 		}
 
 		console.log('[create_space] creating space for community', params.community_id);
 		const createSpaceResult = await db.repos.space.create(params);
 		if (createSpaceResult.ok) {
-			return {status: 200, value: {space: createSpaceResult.value}};
+			return {ok: true, status: 200, value: {space: createSpaceResult.value}};
 		} else {
 			console.log('[create_space] error searching for community spaces');
-			return {ok: false, status: 500, value: {reason: 'error searching for community spaces'}};
+			return {ok: false, status: 500, reason: 'error searching for community spaces'};
 		}
 	},
 };


### PR DESCRIPTION
Extracts the `ApiResult` type to `$lib/server/api.ts` and uses it on both the client and server:

- http service middleware uses http/`globalThis.fetch` conventions for the `status` and `ok`
- websocket middleware sends the unmodified `Result` object (for now, we may need to add more features in the future)

The `ApiResult` is now the return value of each `Service`'s `perform` function. It's then passed through to clients, rather than being a bespoke form of data+error.