### PR TITLE
fix creating community

### DIFF
--- a/src/lib/ui/ui.ts
+++ b/src/lib/ui/ui.ts
@@ -141,7 +141,7 @@ export const toUi = (session: Readable<ClientSession>, mobile: boolean): Ui => {
 		([$communities, $selectedCommunityId]) =>
 			$communities.find((c) => get(c).community_id === $selectedCommunityId) || null,
 	);
-	// TODO do we care about making this reactive to new communities, or is `undefined` ok?
+	// TODO this should store the selected space by community+persona
 	const selectedSpaceIdByCommunity = writable<{[key: number]: number | null}>(
 		initialSession.guest
 			? {}
@@ -265,7 +265,6 @@ export const toUi = (session: Readable<ClientSession>, mobile: boolean): Ui => {
 				}));
 				console.log('updated persona community ids', get(persona));
 			}
-			// TODO can this be derived? efficiently?
 			const $spacesById = get(spacesById);
 			let spacesToAdd: Space[] | null = null;
 			for (const space of community.spaces) {
@@ -276,14 +275,10 @@ export const toUi = (session: Readable<ClientSession>, mobile: boolean): Ui => {
 			if (spacesToAdd) {
 				spaces.update(($spaces) => $spaces.concat(spacesToAdd!.map((s) => writable(s))));
 			}
-			// TODO change this to derived?
 			selectedSpaceIdByCommunity.update(($selectedSpaceIdByCommunity) => {
-				// TODO is it ok to mutate here as long as nothing relies on reacting to new keys?
-				// Is it better to make this a map of community id to space ids or stores?
 				$selectedSpaceIdByCommunity[community.community_id] = community.spaces[0].space_id;
 				return $selectedSpaceIdByCommunity;
 			});
-			// TODO selectedSpaceIdByCommunity isn't updated
 			const communityStore = writable(community);
 			communities.update(($communities) => $communities.concat(communityStore));
 			// TODO update spaces

--- a/src/lib/ui/ui.ts
+++ b/src/lib/ui/ui.ts
@@ -265,6 +265,23 @@ export const toUi = (session: Readable<ClientSession>, mobile: boolean): Ui => {
 				}));
 				console.log('updated persona community ids', get(persona));
 			}
+			const $spacesById = get(spacesById);
+			let spacesToAdd: Space[] | null = null;
+			for (const space of community.spaces) {
+				if (!$spacesById.has(space.space_id)) {
+					(spacesToAdd || (spacesToAdd = [])).push(space);
+				}
+			}
+			if (spacesToAdd) {
+				spaces.update(($spaces) => $spaces.concat(spacesToAdd!.map((s) => writable(s))));
+			}
+			selectedSpaceIdByCommunity.update(($selectedSpaceIdByCommunity) => {
+				// TODO is it ok to mutate here as long as nothing relies on reacting to new keys?
+				// Is it better to make this a map of community id to space ids or stores?
+				$selectedSpaceIdByCommunity[community.community_id] = community.spaces[0].space_id;
+				return $selectedSpaceIdByCommunity;
+			});
+			// TODO selectedSpaceIdByCommunity isn't updated
 			const communityStore = writable(community);
 			communities.update(($communities) => $communities.concat(communityStore));
 			// TODO update spaces

--- a/src/lib/ui/ui.ts
+++ b/src/lib/ui/ui.ts
@@ -141,7 +141,8 @@ export const toUi = (session: Readable<ClientSession>, mobile: boolean): Ui => {
 		([$communities, $selectedCommunityId]) =>
 			$communities.find((c) => get(c).community_id === $selectedCommunityId) || null,
 	);
-	// TODO this should store the selected space by community+persona
+	// TODO this should store the selected space by community+persona,
+	// possibly alongside additional UI state, maybe in a store or namespace of stores
 	const selectedSpaceIdByCommunity = writable<{[key: number]: number | null}>(
 		initialSession.guest
 			? {}

--- a/src/lib/ui/ui.ts
+++ b/src/lib/ui/ui.ts
@@ -265,6 +265,7 @@ export const toUi = (session: Readable<ClientSession>, mobile: boolean): Ui => {
 				}));
 				console.log('updated persona community ids', get(persona));
 			}
+			// TODO can this be derived? efficiently?
 			const $spacesById = get(spacesById);
 			let spacesToAdd: Space[] | null = null;
 			for (const space of community.spaces) {
@@ -275,6 +276,7 @@ export const toUi = (session: Readable<ClientSession>, mobile: boolean): Ui => {
 			if (spacesToAdd) {
 				spaces.update(($spaces) => $spaces.concat(spacesToAdd!.map((s) => writable(s))));
 			}
+			// TODO change this to derived?
 			selectedSpaceIdByCommunity.update(($selectedSpaceIdByCommunity) => {
 				// TODO is it ok to mutate here as long as nothing relies on reacting to new keys?
 				// Is it better to make this a map of community id to space ids or stores?


### PR DESCRIPTION
Fixes the `create_community` API call on the client. The code wasn't handling the spaces in the return value -- it now (should) populate the local caches. It's a good example of how our sources of truth on the client are a little wonky -- maybe worth thinking through using `derived` for `selectedSpaceIdByCommunity` before merging this. Or maybe not because `selectedSpaceIdByCommunity` needs to be rethought -- it should store the selected space by the combination of community+persona like we talked about.