### PR TITLE
remove default text value from inputs

### DIFF
--- a/src/lib/ui/CommunityInput.svelte
+++ b/src/lib/ui/CommunityInput.svelte
@@ -36,13 +36,7 @@
 		<Markup>
 			<h1>Create a new community</h1>
 			<p>
-				<input
-					type="text"
-					placeholder="> name"
-					on:keydown={onKeydown}
-					bind:value={name}
-					use:autofocus
-				/>
+				<input placeholder="> name" on:keydown={onKeydown} bind:value={name} use:autofocus />
 			</p>
 		</Markup>
 	</Dialog>

--- a/src/lib/ui/CommunityInput.svelte
+++ b/src/lib/ui/CommunityInput.svelte
@@ -50,12 +50,7 @@
 		<Markup>
 			<h1>Create a new community</h1>
 			<form>
-				<input
-					placeholder="> name"
-					on:keydown={onKeydown}
-					bind:value={name}
-					use:autofocus
-				/>
+				<input placeholder="> name" on:keydown={onKeydown} bind:value={name} use:autofocus />
 				<PendingButton type="button" on:click={() => create()} {pending}>
 					Create community
 				</PendingButton>

--- a/src/lib/ui/LoginForm.svelte
+++ b/src/lib/ui/LoginForm.svelte
@@ -56,7 +56,6 @@
 </div>
 <form>
 	<input
-		type="text"
 		bind:this={accountNameEl}
 		bind:value={accountName}
 		on:keypress={onKeypress}

--- a/src/lib/ui/Notes.svelte
+++ b/src/lib/ui/Notes.svelte
@@ -43,7 +43,7 @@
 </script>
 
 <div class="notes">
-	<textarea type="text" placeholder="> note" on:keydown={onKeydown} bind:value={text} />
+	<textarea placeholder="> note" on:keydown={onKeydown} bind:value={text} />
 	<div class="files">
 		{#if files}
 			<NoteItems {files} />

--- a/src/lib/ui/PersonaInput.svelte
+++ b/src/lib/ui/PersonaInput.svelte
@@ -37,7 +37,6 @@
 	<h2>Create a persona</h2>
 	<form>
 		<input
-			type="text"
 			placeholder="> name"
 			bind:this={inputEl}
 			bind:value={name}

--- a/src/lib/ui/Room.svelte
+++ b/src/lib/ui/Room.svelte
@@ -50,7 +50,7 @@
 			<PendingAnimation />
 		{/if}
 	</div>
-	<input type="text" placeholder="> chat" on:keydown={onKeydown} bind:value={text} />
+	<input placeholder="> chat" on:keydown={onKeydown} bind:value={text} />
 </div>
 
 <style>

--- a/src/lib/ui/SocketConnection.svelte
+++ b/src/lib/ui/SocketConnection.svelte
@@ -12,7 +12,7 @@
 	<div class="socket-connection">
 		{#if $socket.connected}
 			<form>
-				<input bind:value={newUrl} type="text" disabled />
+				<input bind:value={newUrl} disabled />
 				<button
 					type="button"
 					on:click={() => socket.disconnect()}
@@ -23,7 +23,7 @@
 			</form>
 		{:else}
 			<form>
-				<input bind:value={newUrl} type="text" disabled={$socket.status === 'pending'} />
+				<input bind:value={newUrl} disabled={$socket.status === 'pending'} />
 				<button
 					type="button"
 					on:click={() => socket.connect(newUrl)}

--- a/src/lib/ui/SpaceInput.svelte
+++ b/src/lib/ui/SpaceInput.svelte
@@ -68,7 +68,6 @@
 				<form>
 					<div class:error={!!errorMessage}>{errorMessage || ''}</div>
 					<input
-						type="text"
 						placeholder="> name"
 						bind:value={newName}
 						use:autofocus


### PR DESCRIPTION
This removes `type="text"` from inputs. It's the default value so there's no need to include it; only seems to serve to make us uneasily wonder, "is this needed?"