### PR TITLE
make main nav header sticky

### DIFF
--- a/src/lib/ui/MainNav.svelte
+++ b/src/lib/ui/MainNav.svelte
@@ -128,6 +128,8 @@
 		width: 0;
 	}
 	.header {
+		position: sticky;
+		top: 0;
 		display: flex;
 		height: calc(var(--navbar_size) + var(--border_width));
 		border-bottom: var(--border);


### PR DESCRIPTION
This makes the main nav header now sticky when scrolling, instead of scrolling off the top of the page:
![sticky-header](https://user-images.githubusercontent.com/2608646/135365616-433db659-c22f-4407-8e3b-d5269fe74d90.png)

previously:

![scroll2](https://user-images.githubusercontent.com/2608646/135380630-c1179d2d-2b3c-496b-84e5-2f0149d97362.png)

