### PR TITLE
add initial event docs

### DIFF
--- a/src/routes/docs/index.svelte
+++ b/src/routes/docs/index.svelte
@@ -80,7 +80,7 @@
 		padding: var(--spacing_md) var(--spacing_md) var(--spacing_md) var(--spacing_xl4);
 		background-color: var(--tint_dark_1);
 	}
-	.property:nth-child(2n) {
+	.property:nth-child(2n + 1) {
 		background-color: var(--tint_dark_0);
 	}
 	.property > span {

--- a/src/routes/docs/index.svelte
+++ b/src/routes/docs/index.svelte
@@ -1,0 +1,65 @@
+<script lang="ts">
+	import {eventsInfo} from '$lib/vocab/event/eventsInfo';
+
+	const title = 'docs';
+</script>
+
+<svelte:head><title>{title}</title></svelte:head>
+
+<div class="column">
+	<ul>
+		{#each eventsInfo as eventInfo (eventInfo.name)}
+			<li>
+				<code class="name">{eventInfo.name}</code>
+				<div class="property">
+					<span>params</span>
+					<pre>
+            {eventInfo.params.type}
+          </pre>
+				</div>
+				{#if eventInfo.type !== 'ClientEvent'}
+					<div class="property">
+						<span>response</span>
+						<pre>
+              {eventInfo.response.type}
+            </pre>
+					</div>
+				{/if}
+				<div class="property">
+					<span>returns</span>
+					<pre>
+            {eventInfo.returns}
+          </pre>
+				</div>
+			</li>
+		{/each}
+	</ul>
+</div>
+
+<style>
+	.column {
+		overflow: auto;
+	}
+	li {
+		display: flex;
+		flex-direction: column;
+		padding: var(--spacing_lg) 0;
+	}
+	.name {
+		font-size: var(--font_size_lg);
+		padding: var(--spacing_md);
+	}
+	.property {
+		display: flex;
+		align-items: center;
+		padding: var(--spacing_md) var(--spacing_md) var(--spacing_md) var(--spacing_xl4);
+		background-color: var(--tint_dark_1);
+	}
+	.property:nth-child(2n) {
+		background-color: var(--tint_dark_0);
+	}
+	.property > span {
+		display: flex;
+		width: 100px;
+	}
+</style>

--- a/src/routes/docs/index.svelte
+++ b/src/routes/docs/index.svelte
@@ -1,42 +1,57 @@
 <script lang="ts">
 	import {eventsInfo} from '$lib/vocab/event/eventsInfo';
+	import Markup from '@feltcoop/felt/ui/Markup.svelte';
 
 	const title = 'docs';
 </script>
 
 <svelte:head><title>{title}</title></svelte:head>
 
-<div class="column">
-	<ul>
-		{#each eventsInfo as eventInfo (eventInfo.name)}
-			<li>
-				<code class="name">{eventInfo.name}</code>
-				<div class="property">
-					<span>params</span>
-					<pre>
+<div class="wrapper">
+	<div class="column">
+		<Markup>
+			<h1>docs</h1>
+			<hr />
+			<h2>events</h2>
+		</Markup>
+		<ul>
+			{#each eventsInfo as eventInfo (eventInfo.name)}
+				<li>
+					<div class="title">
+						<code class="name">{eventInfo.name}</code>
+						<small class="type">{eventInfo.type}</small>
+					</div>
+					<div class="property">
+						<span>params</span>
+						<pre>
             {eventInfo.params.type}
           </pre>
-				</div>
-				{#if eventInfo.type !== 'ClientEvent'}
-					<div class="property">
-						<span>response</span>
-						<pre>
-              {eventInfo.response.type}
-            </pre>
 					</div>
-				{/if}
-				<div class="property">
-					<span>returns</span>
-					<pre>
+					{#if eventInfo.type !== 'ClientEvent'}
+						<div class="property">
+							<span>response</span>
+							<pre>
+            {eventInfo.response.type}
+          </pre>
+						</div>
+					{/if}
+					<div class="property">
+						<span>returns</span>
+						<pre>
             {eventInfo.returns}
           </pre>
-				</div>
-			</li>
-		{/each}
-	</ul>
+					</div>
+				</li>
+			{/each}
+		</ul>
+	</div>
 </div>
 
 <style>
+	.wrapper {
+		width: 100%;
+		height: 100%;
+	}
 	.column {
 		overflow: auto;
 	}
@@ -45,9 +60,19 @@
 		flex-direction: column;
 		padding: var(--spacing_lg) 0;
 	}
+	.title {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+	}
 	.name {
 		font-size: var(--font_size_lg);
 		padding: var(--spacing_md);
+	}
+	.type {
+		padding: var(--spacing_lg);
+		background: none;
+		font-family: var(--font_family_mono);
 	}
 	.property {
 		display: flex;


### PR DESCRIPTION
Adds a new route at `src/routes/docs/index.svelte`, which translates to `/docs` aka `localhost:3000/docs`. This route has a basic skeleton for generated docs - not even components yet, just some svelte as a proof of concept. Might want to extract some things in this PR, or just wait.

We may want to put this at `/docs/events`, but I think a single docs page is a good place to start. Maybe we'll want to do some events docs at `/docs` and more but different ones at `/docs/events`.

future:

- controls to sort/filter the data (as a table?)
- add more useful information
- make the information interactive (civiclopedia style)
- improve styles
- extract components