### PR TITLE
add initial vocab docs

### DIFF
--- a/src/lib/ui/MainNav.svelte
+++ b/src/lib/ui/MainNav.svelte
@@ -22,6 +22,7 @@
 			selectedPersona: selectedPersonaStore,
 			selectedCommunity: selectedCommunityStore,
 		},
+		devmode,
 	} = getApp();
 
 	$: selectedPersona = $selectedPersonaStore!; // TODO type?
@@ -71,6 +72,9 @@
 		{:else if $mainNavView === 'account'}
 			<Markup>
 				<AccountForm guest={$session.guest} />
+				{#if $devmode}
+					<a class="menu-link" href="/docs">/docs</a>
+				{/if}
 			</Markup>
 			<SocketConnection />
 		{/if}
@@ -147,5 +151,8 @@
 	.account-button {
 		height: var(--navbar_size);
 		width: var(--navbar_size);
+	}
+	.menu-link {
+		padding: var(--spacing_xs) var(--spacing_sm);
 	}
 </style>

--- a/src/lib/ui/SchemaInfo.svelte
+++ b/src/lib/ui/SchemaInfo.svelte
@@ -1,0 +1,75 @@
+<script lang="ts">
+	import type {AnySchema} from 'ajv';
+
+	export let schema: AnySchema;
+
+	let properties: undefined | [string, AnySchema][];
+	$: properties =
+		typeof schema !== 'boolean' &&
+		schema.properties &&
+		Array.from(Object.entries(schema.properties));
+</script>
+
+<div>
+	{#if typeof schema === 'boolean'}
+		<div class="title">
+			<code class="name">{schema}</code>
+		</div>
+	{:else}
+		<div class="title">
+			{#if schema.$id}
+				<code class="name">{schema.$id}</code>
+			{/if}
+			<small class="type">{schema.type || 'unknown'}</small>
+		</div>
+		{#if properties}
+			{#each properties as [propertyName, propertySchema]}
+				<div class="property">
+					<span class="name">{propertyName}</span>
+					<small class="required">
+						{#if schema.required && schema.required.includes(propertyName)}
+							<!-- leave blank? -->
+						{:else}
+							optional
+						{/if}
+					</small>
+					<svelte:self schema={propertySchema} />
+				</div>
+			{/each}
+		{/if}
+	{/if}
+</div>
+
+<style>
+	.title {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+	}
+	.title .name {
+		font-size: var(--font_size_lg);
+		padding: var(--spacing_md);
+	}
+	.type {
+		padding: var(--spacing_lg);
+		background: none;
+		font-family: var(--font_family_mono);
+	}
+	.property {
+		display: flex;
+		align-items: center;
+		padding: var(--spacing_md) var(--spacing_md) var(--spacing_md) var(--spacing_xl4);
+		background-color: var(--tint_dark_1);
+	}
+	.property:nth-child(2n + 1) {
+		background-color: var(--tint_dark_0);
+	}
+	.property .name {
+		display: flex;
+		width: 180px;
+	}
+	.required {
+		display: flex;
+		width: 60px;
+	}
+</style>

--- a/src/lib/ui/SchemaInfo.svelte
+++ b/src/lib/ui/SchemaInfo.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import type {AnySchema} from 'ajv';
 
+	import {toSchemaName} from '$lib/vocab/schema/schema';
+
 	export let schema: AnySchema;
 
 	let properties: undefined | [string, AnySchema][];
@@ -18,7 +20,7 @@
 	{:else}
 		<div class="title">
 			{#if schema.$id}
-				<code class="name">{schema.$id}</code>
+				<code class="name">{toSchemaName(schema.$id)}</code>
 			{/if}
 			<small class="type">{schema.type || 'unknown'}</small>
 		</div>
@@ -27,10 +29,11 @@
 				<div class="property">
 					<span class="name">{propertyName}</span>
 					<small class="required">
+						<!-- TODO cache this on a viewmodel? -->
 						{#if schema.required && schema.required.includes(propertyName)}
 							<!-- leave blank? -->
 						{:else}
-							optional
+							<span title="{propertyName} is optional">?</span>
 						{/if}
 					</small>
 					<svelte:self schema={propertySchema} />
@@ -49,6 +52,7 @@
 	.title .name {
 		font-size: var(--font_size_lg);
 		padding: var(--spacing_md);
+		font-family: var(--font_family_mono);
 	}
 	.type {
 		padding: var(--spacing_lg);
@@ -70,6 +74,6 @@
 	}
 	.required {
 		display: flex;
-		width: 60px;
+		width: 30px;
 	}
 </style>

--- a/src/lib/util/ajv.ts
+++ b/src/lib/util/ajv.ts
@@ -1,7 +1,7 @@
 import Ajv from 'ajv';
 import type {ErrorObject, ValidateFunction, AnySchema} from 'ajv';
 
-import {schemas} from '$lib/vocab/schemas';
+import {schemas} from '$lib/vocab/schema/schemas';
 
 let ajvInstance: Ajv | null = null;
 

--- a/src/lib/vocab/schema/schema.ts
+++ b/src/lib/vocab/schema/schema.ts
@@ -1,0 +1,2 @@
+export const ID_PREFIX = 'https://felt.social';
+export const ID_VOCAB_PREFIX = ID_PREFIX + '/vocab/';

--- a/src/lib/vocab/schema/schema.ts
+++ b/src/lib/vocab/schema/schema.ts
@@ -1,2 +1,11 @@
+import {stripEnd, stripStart} from '@feltcoop/felt/util/string.js';
+
 export const ID_PREFIX = 'https://felt.social';
 export const ID_VOCAB_PREFIX = ID_PREFIX + '/vocab/';
+export const ID_SUFFIX = '.json';
+
+const names: Record<string, string | undefined> = {};
+
+// TODO should schemas have a `name`? (check the spec - maybe we generate one, maybe we manually do it, or just at runtime)
+export const toSchemaName = ($id: string): string =>
+	names[$id] || (names[$id] = stripEnd(stripStart($id, ID_VOCAB_PREFIX), ID_SUFFIX));

--- a/src/lib/vocab/schema/schemas.test.ts
+++ b/src/lib/vocab/schema/schemas.test.ts
@@ -1,0 +1,18 @@
+import {suite} from 'uvu';
+import * as t from 'uvu/assert';
+
+import {schemas} from '$lib/vocab/schema/schemas';
+import {ID_VOCAB_PREFIX} from '$lib/vocab/schema/schema';
+
+const test__schemas = suite('schemas');
+
+test__schemas('ensure schemas are valid', async () => {
+	for (const schema of schemas) {
+		t.ok(typeof schema !== 'boolean'); // compared to using `t.type`, this makes TypeScript understand
+		t.ok(schema.$id);
+		t.ok(schema.$id.startsWith(ID_VOCAB_PREFIX));
+	}
+});
+
+test__schemas.run();
+/* test__schemas */

--- a/src/lib/vocab/schema/schemas.ts
+++ b/src/lib/vocab/schema/schemas.ts
@@ -1,3 +1,5 @@
+import type {AnySchema} from 'ajv';
+
 import {AccountSchema} from '$lib/vocab/account/account';
 import {PersonaSchema} from '$lib/vocab/persona/persona';
 import {CommunitySchema} from '$lib/vocab/community/community';
@@ -12,7 +14,7 @@ import {FileSchema} from '$lib/vocab/file/file';
 
 // TODO generate this file?
 
-export const schemas = [
+export const schemas: AnySchema[] = [
 	AccountSchema,
 	PersonaSchema,
 	CommunitySchema,

--- a/src/lib/vocab/schema/schemas.ts
+++ b/src/lib/vocab/schema/schemas.ts
@@ -7,11 +7,6 @@ import {MembershipSchema} from '$lib/vocab/membership/membership';
 import {SpaceSchema} from '$lib/vocab/space/space';
 import {FileSchema} from '$lib/vocab/file/file';
 
-// TODO params schemas are duplicated from events -- should use them?
-// or is there no such thing as these params schemas? always contextual to an event?
-
-// TODO what about other schemas like for events?
-
 // TODO generate this file?
 
 export const schemas: AnySchema[] = [

--- a/src/routes/docs/index.svelte
+++ b/src/routes/docs/index.svelte
@@ -80,7 +80,7 @@
 		padding: var(--spacing_md) var(--spacing_md) var(--spacing_md) var(--spacing_xl4);
 		background-color: var(--tint_dark_1);
 	}
-	.property:nth-child(2n) {
+	.property:nth-child(2n + 1) {
 		background-color: var(--tint_dark_0);
 	}
 	.property > span {

--- a/src/routes/docs/index.svelte
+++ b/src/routes/docs/index.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
+	import SchemaInfo from '$lib/ui/SchemaInfo.svelte';
 	import {eventsInfo} from '$lib/vocab/event/eventsInfo';
+	import {schemas} from '$lib/vocab/schema/schemas';
 	import Markup from '@feltcoop/felt/ui/Markup.svelte';
 
 	const title = 'docs';
@@ -12,6 +14,16 @@
 		<Markup>
 			<h1>docs</h1>
 			<hr />
+			<h2>vocab</h2>
+		</Markup>
+		<ul>
+			{#each schemas as vocabSchema (vocabSchema)}
+				<li>
+					<SchemaInfo schema={vocabSchema} />
+				</li>
+			{/each}
+		</ul>
+		<Markup>
 			<h2>events</h2>
 		</Markup>
 		<ul>

--- a/src/routes/docs/index.svelte
+++ b/src/routes/docs/index.svelte
@@ -12,9 +12,13 @@
 <div class="wrapper">
 	<div class="column">
 		<Markup>
-			<h1>docs</h1>
+			<h1 id="docs">docs</h1>
+			<ul>
+				<li><a href="#vocab">vocab</a></li>
+				<li><a href="#events">events</a></li>
+			</ul>
 			<hr />
-			<h2>vocab</h2>
+			<h2 id="vocab">vocab</h2>
 		</Markup>
 		<ul>
 			{#each schemas as vocabSchema (vocabSchema)}
@@ -23,8 +27,9 @@
 				</li>
 			{/each}
 		</ul>
+		<hr />
 		<Markup>
-			<h2>events</h2>
+			<h2 id="events">events</h2>
 		</Markup>
 		<ul>
 			{#each eventsInfo as eventInfo (eventInfo.name)}
@@ -56,6 +61,18 @@
 				</li>
 			{/each}
 		</ul>
+		<hr />
+		<Markup>
+			<ul>
+				<li>
+					<a href="#docs">docs</a>
+					<ul>
+						<li><a href="#vocab">vocab</a></li>
+						<li><a href="#events">events</a></li>
+					</ul>
+				</li>
+			</ul>
+		</Markup>
 	</div>
 </div>
 

--- a/src/routes/docs/index.svelte
+++ b/src/routes/docs/index.svelte
@@ -1,0 +1,65 @@
+<script lang="ts">
+	import {eventsInfo} from '$lib/vocab/event/eventsInfo';
+
+	const title = 'docs';
+</script>
+
+<svelte:head><title>{title}</title></svelte:head>
+
+<div class="column">
+	<ul>
+		{#each eventsInfo as eventInfo (eventInfo.name)}
+			<li>
+				<code class="name">{eventInfo.name}</code>
+				<div class="property">
+					<span>params</span>
+					<pre>
+            {eventInfo.params.type}
+          </pre>
+				</div>
+				{#if eventInfo.type !== 'ClientEvent'}
+					<div class="property">
+						<span>response</span>
+						<pre>
+              {eventInfo.response.type}
+            </pre>
+					</div>
+				{/if}
+				<div class="property">
+					<span>returns</span>
+					<pre>
+            {eventInfo.returns}
+          </pre>
+				</div>
+			</li>
+		{/each}
+	</ul>
+</div>
+
+<style>
+	.column {
+		overflow: auto;
+	}
+	li {
+		display: flex;
+		flex-direction: column;
+		padding: var(--spacing_lg) 0;
+	}
+	.name {
+		font-size: var(--font_size_lg);
+		padding: var(--spacing_md);
+	}
+	.property {
+		display: flex;
+		align-items: center;
+		padding: var(--spacing_md) var(--spacing_md) var(--spacing_md) var(--spacing_xl4);
+		background-color: var(--tint_dark_1);
+	}
+	.property:nth-child(2n) {
+		background-color: var(--tint_dark_0);
+	}
+	.property > span {
+		display: flex;
+		width: 100px;
+	}
+</style>

--- a/src/routes/docs/index.svelte
+++ b/src/routes/docs/index.svelte
@@ -1,42 +1,57 @@
 <script lang="ts">
 	import {eventsInfo} from '$lib/vocab/event/eventsInfo';
+	import Markup from '@feltcoop/felt/ui/Markup.svelte';
 
 	const title = 'docs';
 </script>
 
 <svelte:head><title>{title}</title></svelte:head>
 
-<div class="column">
-	<ul>
-		{#each eventsInfo as eventInfo (eventInfo.name)}
-			<li>
-				<code class="name">{eventInfo.name}</code>
-				<div class="property">
-					<span>params</span>
-					<pre>
+<div class="wrapper">
+	<div class="column">
+		<Markup>
+			<h1>docs</h1>
+			<hr />
+			<h2>events</h2>
+		</Markup>
+		<ul>
+			{#each eventsInfo as eventInfo (eventInfo.name)}
+				<li>
+					<div class="title">
+						<code class="name">{eventInfo.name}</code>
+						<small class="type">{eventInfo.type}</small>
+					</div>
+					<div class="property">
+						<span>params</span>
+						<pre>
             {eventInfo.params.type}
           </pre>
-				</div>
-				{#if eventInfo.type !== 'ClientEvent'}
-					<div class="property">
-						<span>response</span>
-						<pre>
-              {eventInfo.response.type}
-            </pre>
 					</div>
-				{/if}
-				<div class="property">
-					<span>returns</span>
-					<pre>
+					{#if eventInfo.type !== 'ClientEvent'}
+						<div class="property">
+							<span>response</span>
+							<pre>
+            {eventInfo.response.type}
+          </pre>
+						</div>
+					{/if}
+					<div class="property">
+						<span>returns</span>
+						<pre>
             {eventInfo.returns}
           </pre>
-				</div>
-			</li>
-		{/each}
-	</ul>
+					</div>
+				</li>
+			{/each}
+		</ul>
+	</div>
 </div>
 
 <style>
+	.wrapper {
+		width: 100%;
+		height: 100%;
+	}
 	.column {
 		overflow: auto;
 	}
@@ -45,9 +60,19 @@
 		flex-direction: column;
 		padding: var(--spacing_lg) 0;
 	}
+	.title {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+	}
 	.name {
 		font-size: var(--font_size_lg);
 		padding: var(--spacing_md);
+	}
+	.type {
+		padding: var(--spacing_lg);
+		background: none;
+		font-family: var(--font_family_mono);
 	}
 	.property {
 		display: flex;


### PR DESCRIPTION
Extends #156 with docs for the vocab schemas. Adds the `ui/SchemaInfo.svelte` component for displaying basic schema info. 

Also adds the `$lib/vocab/schema` directory and relocates the `schemas` module here from `$lib/vocab/schemas.ts`. I added tests to make sure the `$id` property of each vocab schema has the expected prefix. (currently, `'https://felt.social/vocab'`)