### PR TITLE
upgrade deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@feltcoop/felt": "^0.12.0",
+        "@feltcoop/felt": "^0.13.0",
         "@polka/send-type": "^0.5.2",
         "ajv": "^8.6.2",
         "ajv-formats": "^2.1.1",
@@ -22,9 +22,9 @@
         "ws": "^7.5.4"
       },
       "devDependencies": {
-        "@feltcoop/gro": "^0.43.0",
-        "@sveltejs/adapter-node": "^1.0.0-next.44",
-        "@sveltejs/kit": "^1.0.0-next.161",
+        "@feltcoop/gro": "^0.44.0",
+        "@sveltejs/adapter-node": "^1.0.0-next.55",
+        "@sveltejs/kit": "^1.0.0-next.186",
         "@types/body-parser": "^1.19.1",
         "@types/node": "^16.7.13",
         "@types/ws": "^7.4.7",
@@ -32,7 +32,7 @@
         "prettier-plugin-svelte": "^2.4.0",
         "regexparam": "^2.0.0",
         "strict-event-emitter-types": "^2.0.0",
-        "svelte": "^3.38.3",
+        "svelte": "^3.44.0",
         "svelte-preprocess-esbuild": "^2.0.0",
         "tslib": "^2.3.1",
         "typescript": "^4.4.2"
@@ -46,9 +46,9 @@
       }
     },
     "node_modules/@feltcoop/felt": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@feltcoop/felt/-/felt-0.12.0.tgz",
-      "integrity": "sha512-/3KhBghjskWFTJAB1QY7zV5kxju+tBE9+WDUT3MSGax2nlNZnMB8DZvm/NVa0JNelVoYjr6g0Sl+qalG13oKoA==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@feltcoop/felt/-/felt-0.13.0.tgz",
+      "integrity": "sha512-cOdV0BQEmYsdTZalgwlIc56XaCigLkNHHFQPvLB+AEHToCSZkLMDg3MY3Awwp8NZQLFH79fGbFuJvDFNhQxnFg==",
       "dependencies": {
         "@lukeed/uuid": "^2.0.0",
         "dequal": "^2.0.2",
@@ -63,12 +63,11 @@
       }
     },
     "node_modules/@feltcoop/gro": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.43.0.tgz",
-      "integrity": "sha512-6bVJ32XdPjOsBLar963Ct6lT2JvOZQ8o4UXjDbO90QdHs8ApHGPEMQx7RTOlV+nuTccbL+xVDnJUa9RT0vNsDg==",
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.44.0.tgz",
+      "integrity": "sha512-xCuhYUA3GqYxxlk8udQGeefpC+RYaOgzFL0eWqpglLHhM9kygLsetwDHFeKRlhLcMkOUA0h4mKkkeffwJpSWcw==",
       "dev": true,
       "dependencies": {
-        "@feltcoop/felt": "^0.12.0",
         "@rollup/plugin-commonjs": "^20.0.0",
         "@rollup/plugin-node-resolve": "^13.0.4",
         "@rollup/pluginutils": "^4.1.1",
@@ -92,7 +91,7 @@
         "terser": "^5.7.2",
         "tslib": "^2.3.1",
         "typescript": "^4.4.3",
-        "uvu": "^0.5.1"
+        "uvu": "^0.5.2"
       },
       "bin": {
         "gro": "dist/cli/gro.js"
@@ -101,6 +100,7 @@
         "node": ">=16.6.0"
       },
       "peerDependencies": {
+        "@feltcoop/felt": "^0.13.0",
         "@types/source-map-support": "^0.5.4",
         "source-map-support": "^0.5.20"
       }
@@ -407,39 +407,68 @@
       }
     },
     "node_modules/@sveltejs/adapter-node": {
-      "version": "1.0.0-next.44",
-      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-node/-/adapter-node-1.0.0-next.44.tgz",
-      "integrity": "sha512-7kk5GU9GRLeOLeMLjvl1nRMPUpZjaKUwr5iCuS557lh/WGWX5YqThE+mbIZpx3g8goyzVO8Jdjnc51B3JHIRhw==",
+      "version": "1.0.0-next.55",
+      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-node/-/adapter-node-1.0.0-next.55.tgz",
+      "integrity": "sha512-Kmh8lx8kIY7W6rkqjC78y4dQTyjiAHD9D1WfmUTtYuDW1jAIG+YbZmPC9127kH5KOSGK4+tI8mpReDVB1lgf8g==",
       "dev": true,
       "dependencies": {
-        "esbuild": "^0.12.5",
+        "esbuild": "^0.13.4",
         "tiny-glob": "^0.2.9"
       }
     },
+    "node_modules/@sveltejs/adapter-node/node_modules/esbuild": {
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.13.8.tgz",
+      "integrity": "sha512-A4af7G7YZLfG5OnARJRMtlpEsCkq/zHZQXewgPA864l9D6VjjbH1SuFYK/OSV6BtHwDGkdwyRrX0qQFLnMfUcw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "optionalDependencies": {
+        "esbuild-android-arm64": "0.13.8",
+        "esbuild-darwin-64": "0.13.8",
+        "esbuild-darwin-arm64": "0.13.8",
+        "esbuild-freebsd-64": "0.13.8",
+        "esbuild-freebsd-arm64": "0.13.8",
+        "esbuild-linux-32": "0.13.8",
+        "esbuild-linux-64": "0.13.8",
+        "esbuild-linux-arm": "0.13.8",
+        "esbuild-linux-arm64": "0.13.8",
+        "esbuild-linux-mips64le": "0.13.8",
+        "esbuild-linux-ppc64le": "0.13.8",
+        "esbuild-netbsd-64": "0.13.8",
+        "esbuild-openbsd-64": "0.13.8",
+        "esbuild-sunos-64": "0.13.8",
+        "esbuild-windows-32": "0.13.8",
+        "esbuild-windows-64": "0.13.8",
+        "esbuild-windows-arm64": "0.13.8"
+      }
+    },
     "node_modules/@sveltejs/kit": {
-      "version": "1.0.0-next.166",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.166.tgz",
-      "integrity": "sha512-TQWtWbgyc5+eJY1/RZvCc4gHLssnW+PfKh0dGxbysR0r1vahBgLDUELNlc1dktg/jUJm4eEFl4cqDqKsvU84tQ==",
+      "version": "1.0.0-next.186",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.186.tgz",
+      "integrity": "sha512-LFv2q2cToreUcGp0B+5uVfu0qMvQiw3hsyELnUwxPP/lpUbcmYjgQmwivjRNTdudCqZt7ng3Ehy7UDILbBhExQ==",
       "dependencies": {
-        "@sveltejs/vite-plugin-svelte": "^1.0.0-next.23",
-        "cheap-watch": "^1.0.3",
+        "@sveltejs/vite-plugin-svelte": "^1.0.0-next.30",
+        "cheap-watch": "^1.0.4",
         "sade": "^1.7.4",
-        "vite": "^2.5.7"
+        "vite": "^2.6.10"
       },
       "bin": {
         "svelte-kit": "svelte-kit.js"
       },
       "engines": {
-        "node": "^12.20 || >=14.13"
+        "node": ">=14.13"
       },
       "peerDependencies": {
-        "svelte": "^3.39.0"
+        "svelte": "^3.44.0"
       }
     },
     "node_modules/@sveltejs/vite-plugin-svelte": {
-      "version": "1.0.0-next.23",
-      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.0-next.23.tgz",
-      "integrity": "sha512-zmguJ9OYYsvZUhzPA3ZeYana2qx/ORadI0LVjzDIuXEXcR7AKj9qJgGCWe5Wi2Z/xg9PsKMHTTCHgiiplphIYg==",
+      "version": "1.0.0-next.30",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.0-next.30.tgz",
+      "integrity": "sha512-YQqdMxjL1VgSFk4/+IY3yLwuRRapPafPiZTiaGEq1psbJYSNYUWx9F1zMm32GMsnogg3zn99mGJOqe3ld3HZSg==",
       "dependencies": {
         "@rollup/pluginutils": "^4.1.1",
         "debug": "^4.3.2",
@@ -449,12 +478,12 @@
         "svelte-hmr": "^0.14.7"
       },
       "engines": {
-        "node": "^12.20 || ^14.13.1 || >= 16"
+        "node": "^14.13.1 || >= 16"
       },
       "peerDependencies": {
         "diff-match-patch": "^1.0.5",
-        "svelte": "^3.34.0",
-        "vite": "^2.5.3"
+        "svelte": "^3.44.0",
+        "vite": "^2.6.0"
       },
       "peerDependenciesMeta": {
         "diff-match-patch": {
@@ -803,11 +832,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
-    "node_modules/colorette": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
-      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g=="
-    },
     "node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -965,10 +989,215 @@
       "version": "0.12.28",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.28.tgz",
       "integrity": "sha512-pZ0FrWZXlvQOATlp14lRSk1N9GkeJ3vLIwOcUoo3ICQn9WNR4rWoNi81pbn6sC1iYUy7QPqNzI3+AEzokwyVcA==",
+      "dev": true,
       "hasInstallScript": true,
       "bin": {
         "esbuild": "bin/esbuild"
       }
+    },
+    "node_modules/esbuild-android-arm64": {
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.13.8.tgz",
+      "integrity": "sha512-AilbChndywpk7CdKkNSZ9klxl+9MboLctXd9LwLo3b0dawmOF/i/t2U5d8LM6SbT1Xw36F8yngSUPrd8yPs2RA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/esbuild-darwin-64": {
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.13.8.tgz",
+      "integrity": "sha512-b6sdiT84zV5LVaoF+UoMVGJzR/iE2vNUfUDfFQGrm4LBwM/PWXweKpuu6RD9mcyCq18cLxkP6w/LD/w9DtX3ng==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/esbuild-darwin-arm64": {
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.13.8.tgz",
+      "integrity": "sha512-R8YuPiiJayuJJRUBG4H0VwkEKo6AvhJs2m7Tl0JaIer3u1FHHXwGhMxjJDmK+kXwTFPriSysPvcobXC/UrrZCQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/esbuild-freebsd-64": {
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.13.8.tgz",
+      "integrity": "sha512-zBn6urrn8FnKC+YSgDxdof9jhPCeU8kR/qaamlV4gI8R3KUaUK162WYM7UyFVAlj9N0MyD3AtB+hltzu4cysTw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/esbuild-freebsd-arm64": {
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.13.8.tgz",
+      "integrity": "sha512-pWW2slN7lGlkx0MOEBoUGwRX5UgSCLq3dy2c8RIOpiHtA87xAUpDBvZK10MykbT+aMfXc0NI2lu1X+6kI34xng==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/esbuild-linux-32": {
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.13.8.tgz",
+      "integrity": "sha512-T0I0ueeKVO/Is0CAeSEOG9s2jeNNb8jrrMwG9QBIm3UU18MRB60ERgkS2uV3fZ1vP2F8i3Z2e3Zju4lg9dhVmw==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/esbuild-linux-64": {
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.13.8.tgz",
+      "integrity": "sha512-Bm8SYmFtvfDCIu9sjKppFXzRXn2BVpuCinU1ChTuMtdKI/7aPpXIrkqBNOgPTOQO9AylJJc1Zw6EvtKORhn64w==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/esbuild-linux-arm": {
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.13.8.tgz",
+      "integrity": "sha512-4/HfcC40LJ4GPyboHA+db0jpFarTB628D1ifU+/5bunIgY+t6mHkJWyxWxAAE8wl/ZIuRYB9RJFdYpu1AXGPdg==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/esbuild-linux-arm64": {
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.13.8.tgz",
+      "integrity": "sha512-X4pWZ+SL+FJ09chWFgRNO3F+YtvAQRcWh0uxKqZSWKiWodAB20flsW/OWFYLXBKiVCTeoGMvENZS/GeVac7+tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/esbuild-linux-mips64le": {
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.13.8.tgz",
+      "integrity": "sha512-o7e0D+sqHKT31v+mwFircJFjwSKVd2nbkHEn4l9xQ1hLR+Bv8rnt3HqlblY3+sBdlrOTGSwz0ReROlKUMJyldA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/esbuild-linux-ppc64le": {
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.13.8.tgz",
+      "integrity": "sha512-eZSQ0ERsWkukJp2px/UWJHVNuy0lMoz/HZcRWAbB6reoaBw7S9vMzYNUnflfL3XA6WDs+dZn3ekHE4Y2uWLGig==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/esbuild-netbsd-64": {
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.13.8.tgz",
+      "integrity": "sha512-gZX4kP7gVvOrvX0ZwgHmbuHczQUwqYppxqtoyC7VNd80t5nBHOFXVhWo2Ad/Lms0E8b+wwgI/WjZFTCpUHOg9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "netbsd"
+      ]
+    },
+    "node_modules/esbuild-openbsd-64": {
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.13.8.tgz",
+      "integrity": "sha512-afzza308X4WmcebexbTzAgfEWt9MUkdTvwIa8xOu4CM2qGbl2LanqEl8/LUs8jh6Gqw6WsicEK52GPrS9wvkcw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/esbuild-sunos-64": {
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.13.8.tgz",
+      "integrity": "sha512-mWPZibmBbuMKD+LDN23LGcOZ2EawMYBONMXXHmbuxeT0XxCNwadbCVwUQ/2p5Dp5Kvf6mhrlIffcnWOiCBpiVw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "sunos"
+      ]
+    },
+    "node_modules/esbuild-windows-32": {
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.13.8.tgz",
+      "integrity": "sha512-QsZ1HnWIcnIEApETZWw8HlOhDSWqdZX2SylU7IzGxOYyVcX7QI06ety/aDcn437mwyO7Ph4RrbhB+2ntM8kX8A==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/esbuild-windows-64": {
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.13.8.tgz",
+      "integrity": "sha512-76Fb57B9eE/JmJi1QmUW0tRLQZfGo0it+JeYoCDTSlbTn7LV44ecOHIMJSSgZADUtRMWT9z0Kz186bnaB3amSg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/esbuild-windows-arm64": {
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.13.8.tgz",
+      "integrity": "sha512-HW6Mtq5eTudllxY2YgT62MrVcn7oq2o8TAoAvDUhyiEmRmDY8tPwAhb1vxw5/cdkbukM3KdMYtksnUhF/ekWeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/esinstall": {
       "version": "1.0.5",
@@ -1554,9 +1783,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/nanoid": {
-      "version": "3.1.25",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-      "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
+      "version": "3.1.30",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.30.tgz",
+      "integrity": "sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -1653,6 +1882,11 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
+    "node_modules/picocolors": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
+      "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA=="
+    },
     "node_modules/picomatch": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
@@ -1677,12 +1911,12 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.3.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.6.tgz",
-      "integrity": "sha512-wG1cc/JhRgdqB6WHEuyLTedf3KIRuD0hG6ldkFEZNCjRxiC+3i6kkWUUbiJQayP28iwG35cEmAbe98585BYV0A==",
+      "version": "8.3.9",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.9.tgz",
+      "integrity": "sha512-f/ZFyAKh9Dnqytx5X62jgjhhzttjZS7hMsohcI7HEI5tjELX/HxCy3EFhsRxyzGvrzFF+82XPvCS8T9TFleVJw==",
       "dependencies": {
-        "colorette": "^1.2.2",
-        "nanoid": "^3.1.23",
+        "nanoid": "^3.1.28",
+        "picocolors": "^0.2.1",
         "source-map-js": "^0.6.2"
       },
       "engines": {
@@ -2061,9 +2295,9 @@
       }
     },
     "node_modules/svelte": {
-      "version": "3.42.6",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.42.6.tgz",
-      "integrity": "sha512-lAcryr9Do2PeGtbodspX5I4kWj4yWYAa2WGpDCwzNkP3y8WZTxigMd4/TMO1rBZEOkMYGn4ZXrbAlSEGhK6q3w==",
+      "version": "3.44.0",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.44.0.tgz",
+      "integrity": "sha512-zWACSJBSncGiDvFfYOMFGNV5zDLOlyhftmO5yOZ0lEtQMptpElaRtl39MWz1+lYCpwUq4F3Q2lTzI9TrTL+eMA==",
       "engines": {
         "node": ">= 8"
       }
@@ -2360,9 +2594,9 @@
       "dev": true
     },
     "node_modules/uvu": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/uvu/-/uvu-0.5.1.tgz",
-      "integrity": "sha512-JGxttnOGDFs77FaZ0yMUHIzczzQ5R1IlDeNW6Wymw6gAscwMdAffVOP6TlxLIfReZyK8tahoGwWZaTCJzNFDkg==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/uvu/-/uvu-0.5.2.tgz",
+      "integrity": "sha512-m2hLe7I2eROhh+tm3WE5cTo/Cv3WQA7Oc9f7JB6uWv+/zVKvfAm53bMyOoGOSZeQ7Ov2Fu9pLhFr7p07bnT20w==",
       "dev": true,
       "dependencies": {
         "dequal": "^2.0.0",
@@ -2397,14 +2631,14 @@
       }
     },
     "node_modules/vite": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.5.7.tgz",
-      "integrity": "sha512-hyUoWmRPhjN1aI+ZSBqDINKdIq7aokHE2ZXiztOg4YlmtpeQtMwMeyxv6X9YxHZmvGzg/js/eATM9Z1nwyakxg==",
+      "version": "2.6.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.6.10.tgz",
+      "integrity": "sha512-XbevwpDJMs3lKiGEj0UQScsOCpwHIjFgfzPnFVkPgnxsF9oPv1uGyckLg58XkXv6LnO46KN9yZqJzINFmAxtUg==",
       "dependencies": {
-        "esbuild": "^0.12.17",
-        "postcss": "^8.3.6",
+        "esbuild": "^0.13.2",
+        "postcss": "^8.3.8",
         "resolve": "^1.20.0",
-        "rollup": "^2.38.5"
+        "rollup": "^2.57.0"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -2414,12 +2648,56 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "less": "*",
+        "sass": "*",
+        "stylus": "*"
+      },
+      "peerDependenciesMeta": {
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.13.8.tgz",
+      "integrity": "sha512-A4af7G7YZLfG5OnARJRMtlpEsCkq/zHZQXewgPA864l9D6VjjbH1SuFYK/OSV6BtHwDGkdwyRrX0qQFLnMfUcw==",
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "optionalDependencies": {
+        "esbuild-android-arm64": "0.13.8",
+        "esbuild-darwin-64": "0.13.8",
+        "esbuild-darwin-arm64": "0.13.8",
+        "esbuild-freebsd-64": "0.13.8",
+        "esbuild-freebsd-arm64": "0.13.8",
+        "esbuild-linux-32": "0.13.8",
+        "esbuild-linux-64": "0.13.8",
+        "esbuild-linux-arm": "0.13.8",
+        "esbuild-linux-arm64": "0.13.8",
+        "esbuild-linux-mips64le": "0.13.8",
+        "esbuild-linux-ppc64le": "0.13.8",
+        "esbuild-netbsd-64": "0.13.8",
+        "esbuild-openbsd-64": "0.13.8",
+        "esbuild-sunos-64": "0.13.8",
+        "esbuild-windows-32": "0.13.8",
+        "esbuild-windows-64": "0.13.8",
+        "esbuild-windows-arm64": "0.13.8"
       }
     },
     "node_modules/vm2": {
-      "version": "3.9.3",
-      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.3.tgz",
-      "integrity": "sha512-smLS+18RjXYMl9joyJxMNI9l4w7biW8ilSDaVRvFBDwOH8P0BK1ognFQTpg0wyQ6wIKLTblHJvROW692L/E53Q==",
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.5.tgz",
+      "integrity": "sha512-LuCAHZN75H9tdrAiLFf030oW7nJV5xwNMuk1ymOZwopmuK3d2H4L1Kv4+GFHgarKiLfXXLFU+7LDABHnwOkWng==",
       "dev": true,
       "bin": {
         "vm2": "bin/vm2"
@@ -2457,9 +2735,9 @@
   },
   "dependencies": {
     "@feltcoop/felt": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@feltcoop/felt/-/felt-0.12.0.tgz",
-      "integrity": "sha512-/3KhBghjskWFTJAB1QY7zV5kxju+tBE9+WDUT3MSGax2nlNZnMB8DZvm/NVa0JNelVoYjr6g0Sl+qalG13oKoA==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@feltcoop/felt/-/felt-0.13.0.tgz",
+      "integrity": "sha512-cOdV0BQEmYsdTZalgwlIc56XaCigLkNHHFQPvLB+AEHToCSZkLMDg3MY3Awwp8NZQLFH79fGbFuJvDFNhQxnFg==",
       "requires": {
         "@lukeed/uuid": "^2.0.0",
         "dequal": "^2.0.2",
@@ -2467,12 +2745,11 @@
       }
     },
     "@feltcoop/gro": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.43.0.tgz",
-      "integrity": "sha512-6bVJ32XdPjOsBLar963Ct6lT2JvOZQ8o4UXjDbO90QdHs8ApHGPEMQx7RTOlV+nuTccbL+xVDnJUa9RT0vNsDg==",
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.44.0.tgz",
+      "integrity": "sha512-xCuhYUA3GqYxxlk8udQGeefpC+RYaOgzFL0eWqpglLHhM9kygLsetwDHFeKRlhLcMkOUA0h4mKkkeffwJpSWcw==",
       "dev": true,
       "requires": {
-        "@feltcoop/felt": "^0.12.0",
         "@rollup/plugin-commonjs": "^20.0.0",
         "@rollup/plugin-node-resolve": "^13.0.4",
         "@rollup/pluginutils": "^4.1.1",
@@ -2496,7 +2773,7 @@
         "terser": "^5.7.2",
         "tslib": "^2.3.1",
         "typescript": "^4.4.3",
-        "uvu": "^0.5.1"
+        "uvu": "^0.5.2"
       }
     },
     "@lukeed/csprng": {
@@ -2744,30 +3021,57 @@
       }
     },
     "@sveltejs/adapter-node": {
-      "version": "1.0.0-next.44",
-      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-node/-/adapter-node-1.0.0-next.44.tgz",
-      "integrity": "sha512-7kk5GU9GRLeOLeMLjvl1nRMPUpZjaKUwr5iCuS557lh/WGWX5YqThE+mbIZpx3g8goyzVO8Jdjnc51B3JHIRhw==",
+      "version": "1.0.0-next.55",
+      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-node/-/adapter-node-1.0.0-next.55.tgz",
+      "integrity": "sha512-Kmh8lx8kIY7W6rkqjC78y4dQTyjiAHD9D1WfmUTtYuDW1jAIG+YbZmPC9127kH5KOSGK4+tI8mpReDVB1lgf8g==",
       "dev": true,
       "requires": {
-        "esbuild": "^0.12.5",
+        "esbuild": "^0.13.4",
         "tiny-glob": "^0.2.9"
+      },
+      "dependencies": {
+        "esbuild": {
+          "version": "0.13.8",
+          "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.13.8.tgz",
+          "integrity": "sha512-A4af7G7YZLfG5OnARJRMtlpEsCkq/zHZQXewgPA864l9D6VjjbH1SuFYK/OSV6BtHwDGkdwyRrX0qQFLnMfUcw==",
+          "dev": true,
+          "requires": {
+            "esbuild-android-arm64": "0.13.8",
+            "esbuild-darwin-64": "0.13.8",
+            "esbuild-darwin-arm64": "0.13.8",
+            "esbuild-freebsd-64": "0.13.8",
+            "esbuild-freebsd-arm64": "0.13.8",
+            "esbuild-linux-32": "0.13.8",
+            "esbuild-linux-64": "0.13.8",
+            "esbuild-linux-arm": "0.13.8",
+            "esbuild-linux-arm64": "0.13.8",
+            "esbuild-linux-mips64le": "0.13.8",
+            "esbuild-linux-ppc64le": "0.13.8",
+            "esbuild-netbsd-64": "0.13.8",
+            "esbuild-openbsd-64": "0.13.8",
+            "esbuild-sunos-64": "0.13.8",
+            "esbuild-windows-32": "0.13.8",
+            "esbuild-windows-64": "0.13.8",
+            "esbuild-windows-arm64": "0.13.8"
+          }
+        }
       }
     },
     "@sveltejs/kit": {
-      "version": "1.0.0-next.166",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.166.tgz",
-      "integrity": "sha512-TQWtWbgyc5+eJY1/RZvCc4gHLssnW+PfKh0dGxbysR0r1vahBgLDUELNlc1dktg/jUJm4eEFl4cqDqKsvU84tQ==",
+      "version": "1.0.0-next.186",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.186.tgz",
+      "integrity": "sha512-LFv2q2cToreUcGp0B+5uVfu0qMvQiw3hsyELnUwxPP/lpUbcmYjgQmwivjRNTdudCqZt7ng3Ehy7UDILbBhExQ==",
       "requires": {
-        "@sveltejs/vite-plugin-svelte": "^1.0.0-next.23",
-        "cheap-watch": "^1.0.3",
+        "@sveltejs/vite-plugin-svelte": "^1.0.0-next.30",
+        "cheap-watch": "^1.0.4",
         "sade": "^1.7.4",
-        "vite": "^2.5.7"
+        "vite": "^2.6.10"
       }
     },
     "@sveltejs/vite-plugin-svelte": {
-      "version": "1.0.0-next.23",
-      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.0-next.23.tgz",
-      "integrity": "sha512-zmguJ9OYYsvZUhzPA3ZeYana2qx/ORadI0LVjzDIuXEXcR7AKj9qJgGCWe5Wi2Z/xg9PsKMHTTCHgiiplphIYg==",
+      "version": "1.0.0-next.30",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.0-next.30.tgz",
+      "integrity": "sha512-YQqdMxjL1VgSFk4/+IY3yLwuRRapPafPiZTiaGEq1psbJYSNYUWx9F1zMm32GMsnogg3zn99mGJOqe3ld3HZSg==",
       "requires": {
         "@rollup/pluginutils": "^4.1.1",
         "debug": "^4.3.2",
@@ -3057,11 +3361,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
-    "colorette": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
-      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g=="
-    },
     "commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -3187,7 +3486,110 @@
     "esbuild": {
       "version": "0.12.28",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.28.tgz",
-      "integrity": "sha512-pZ0FrWZXlvQOATlp14lRSk1N9GkeJ3vLIwOcUoo3ICQn9WNR4rWoNi81pbn6sC1iYUy7QPqNzI3+AEzokwyVcA=="
+      "integrity": "sha512-pZ0FrWZXlvQOATlp14lRSk1N9GkeJ3vLIwOcUoo3ICQn9WNR4rWoNi81pbn6sC1iYUy7QPqNzI3+AEzokwyVcA==",
+      "dev": true
+    },
+    "esbuild-android-arm64": {
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.13.8.tgz",
+      "integrity": "sha512-AilbChndywpk7CdKkNSZ9klxl+9MboLctXd9LwLo3b0dawmOF/i/t2U5d8LM6SbT1Xw36F8yngSUPrd8yPs2RA==",
+      "optional": true
+    },
+    "esbuild-darwin-64": {
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.13.8.tgz",
+      "integrity": "sha512-b6sdiT84zV5LVaoF+UoMVGJzR/iE2vNUfUDfFQGrm4LBwM/PWXweKpuu6RD9mcyCq18cLxkP6w/LD/w9DtX3ng==",
+      "optional": true
+    },
+    "esbuild-darwin-arm64": {
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.13.8.tgz",
+      "integrity": "sha512-R8YuPiiJayuJJRUBG4H0VwkEKo6AvhJs2m7Tl0JaIer3u1FHHXwGhMxjJDmK+kXwTFPriSysPvcobXC/UrrZCQ==",
+      "optional": true
+    },
+    "esbuild-freebsd-64": {
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.13.8.tgz",
+      "integrity": "sha512-zBn6urrn8FnKC+YSgDxdof9jhPCeU8kR/qaamlV4gI8R3KUaUK162WYM7UyFVAlj9N0MyD3AtB+hltzu4cysTw==",
+      "optional": true
+    },
+    "esbuild-freebsd-arm64": {
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.13.8.tgz",
+      "integrity": "sha512-pWW2slN7lGlkx0MOEBoUGwRX5UgSCLq3dy2c8RIOpiHtA87xAUpDBvZK10MykbT+aMfXc0NI2lu1X+6kI34xng==",
+      "optional": true
+    },
+    "esbuild-linux-32": {
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.13.8.tgz",
+      "integrity": "sha512-T0I0ueeKVO/Is0CAeSEOG9s2jeNNb8jrrMwG9QBIm3UU18MRB60ERgkS2uV3fZ1vP2F8i3Z2e3Zju4lg9dhVmw==",
+      "optional": true
+    },
+    "esbuild-linux-64": {
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.13.8.tgz",
+      "integrity": "sha512-Bm8SYmFtvfDCIu9sjKppFXzRXn2BVpuCinU1ChTuMtdKI/7aPpXIrkqBNOgPTOQO9AylJJc1Zw6EvtKORhn64w==",
+      "optional": true
+    },
+    "esbuild-linux-arm": {
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.13.8.tgz",
+      "integrity": "sha512-4/HfcC40LJ4GPyboHA+db0jpFarTB628D1ifU+/5bunIgY+t6mHkJWyxWxAAE8wl/ZIuRYB9RJFdYpu1AXGPdg==",
+      "optional": true
+    },
+    "esbuild-linux-arm64": {
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.13.8.tgz",
+      "integrity": "sha512-X4pWZ+SL+FJ09chWFgRNO3F+YtvAQRcWh0uxKqZSWKiWodAB20flsW/OWFYLXBKiVCTeoGMvENZS/GeVac7+tQ==",
+      "optional": true
+    },
+    "esbuild-linux-mips64le": {
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.13.8.tgz",
+      "integrity": "sha512-o7e0D+sqHKT31v+mwFircJFjwSKVd2nbkHEn4l9xQ1hLR+Bv8rnt3HqlblY3+sBdlrOTGSwz0ReROlKUMJyldA==",
+      "optional": true
+    },
+    "esbuild-linux-ppc64le": {
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.13.8.tgz",
+      "integrity": "sha512-eZSQ0ERsWkukJp2px/UWJHVNuy0lMoz/HZcRWAbB6reoaBw7S9vMzYNUnflfL3XA6WDs+dZn3ekHE4Y2uWLGig==",
+      "optional": true
+    },
+    "esbuild-netbsd-64": {
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.13.8.tgz",
+      "integrity": "sha512-gZX4kP7gVvOrvX0ZwgHmbuHczQUwqYppxqtoyC7VNd80t5nBHOFXVhWo2Ad/Lms0E8b+wwgI/WjZFTCpUHOg9Q==",
+      "optional": true
+    },
+    "esbuild-openbsd-64": {
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.13.8.tgz",
+      "integrity": "sha512-afzza308X4WmcebexbTzAgfEWt9MUkdTvwIa8xOu4CM2qGbl2LanqEl8/LUs8jh6Gqw6WsicEK52GPrS9wvkcw==",
+      "optional": true
+    },
+    "esbuild-sunos-64": {
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.13.8.tgz",
+      "integrity": "sha512-mWPZibmBbuMKD+LDN23LGcOZ2EawMYBONMXXHmbuxeT0XxCNwadbCVwUQ/2p5Dp5Kvf6mhrlIffcnWOiCBpiVw==",
+      "optional": true
+    },
+    "esbuild-windows-32": {
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.13.8.tgz",
+      "integrity": "sha512-QsZ1HnWIcnIEApETZWw8HlOhDSWqdZX2SylU7IzGxOYyVcX7QI06ety/aDcn437mwyO7Ph4RrbhB+2ntM8kX8A==",
+      "optional": true
+    },
+    "esbuild-windows-64": {
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.13.8.tgz",
+      "integrity": "sha512-76Fb57B9eE/JmJi1QmUW0tRLQZfGo0it+JeYoCDTSlbTn7LV44ecOHIMJSSgZADUtRMWT9z0Kz186bnaB3amSg==",
+      "optional": true
+    },
+    "esbuild-windows-arm64": {
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.13.8.tgz",
+      "integrity": "sha512-HW6Mtq5eTudllxY2YgT62MrVcn7oq2o8TAoAvDUhyiEmRmDY8tPwAhb1vxw5/cdkbukM3KdMYtksnUhF/ekWeg==",
+      "optional": true
     },
     "esinstall": {
       "version": "1.0.5",
@@ -3645,9 +4047,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "nanoid": {
-      "version": "3.1.25",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-      "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q=="
+      "version": "3.1.30",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.30.tgz",
+      "integrity": "sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ=="
     },
     "node-gyp-build": {
       "version": "4.2.3",
@@ -3715,6 +4117,11 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
+    "picocolors": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
+      "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA=="
+    },
     "picomatch": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
@@ -3730,12 +4137,12 @@
       }
     },
     "postcss": {
-      "version": "8.3.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.6.tgz",
-      "integrity": "sha512-wG1cc/JhRgdqB6WHEuyLTedf3KIRuD0hG6ldkFEZNCjRxiC+3i6kkWUUbiJQayP28iwG35cEmAbe98585BYV0A==",
+      "version": "8.3.9",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.9.tgz",
+      "integrity": "sha512-f/ZFyAKh9Dnqytx5X62jgjhhzttjZS7hMsohcI7HEI5tjELX/HxCy3EFhsRxyzGvrzFF+82XPvCS8T9TFleVJw==",
       "requires": {
-        "colorette": "^1.2.2",
-        "nanoid": "^3.1.23",
+        "nanoid": "^3.1.28",
+        "picocolors": "^0.2.1",
         "source-map-js": "^0.6.2"
       }
     },
@@ -3999,9 +4406,9 @@
       }
     },
     "svelte": {
-      "version": "3.42.6",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.42.6.tgz",
-      "integrity": "sha512-lAcryr9Do2PeGtbodspX5I4kWj4yWYAa2WGpDCwzNkP3y8WZTxigMd4/TMO1rBZEOkMYGn4ZXrbAlSEGhK6q3w=="
+      "version": "3.44.0",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.44.0.tgz",
+      "integrity": "sha512-zWACSJBSncGiDvFfYOMFGNV5zDLOlyhftmO5yOZ0lEtQMptpElaRtl39MWz1+lYCpwUq4F3Q2lTzI9TrTL+eMA=="
     },
     "svelte-check": {
       "version": "2.2.6",
@@ -4190,9 +4597,9 @@
       }
     },
     "uvu": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/uvu/-/uvu-0.5.1.tgz",
-      "integrity": "sha512-JGxttnOGDFs77FaZ0yMUHIzczzQ5R1IlDeNW6Wymw6gAscwMdAffVOP6TlxLIfReZyK8tahoGwWZaTCJzNFDkg==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/uvu/-/uvu-0.5.2.tgz",
+      "integrity": "sha512-m2hLe7I2eROhh+tm3WE5cTo/Cv3WQA7Oc9f7JB6uWv+/zVKvfAm53bMyOoGOSZeQ7Ov2Fu9pLhFr7p07bnT20w==",
       "dev": true,
       "requires": {
         "dequal": "^2.0.0",
@@ -4220,21 +4627,47 @@
       }
     },
     "vite": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.5.7.tgz",
-      "integrity": "sha512-hyUoWmRPhjN1aI+ZSBqDINKdIq7aokHE2ZXiztOg4YlmtpeQtMwMeyxv6X9YxHZmvGzg/js/eATM9Z1nwyakxg==",
+      "version": "2.6.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.6.10.tgz",
+      "integrity": "sha512-XbevwpDJMs3lKiGEj0UQScsOCpwHIjFgfzPnFVkPgnxsF9oPv1uGyckLg58XkXv6LnO46KN9yZqJzINFmAxtUg==",
       "requires": {
-        "esbuild": "^0.12.17",
+        "esbuild": "^0.13.2",
         "fsevents": "~2.3.2",
-        "postcss": "^8.3.6",
+        "postcss": "^8.3.8",
         "resolve": "^1.20.0",
-        "rollup": "^2.38.5"
+        "rollup": "^2.57.0"
+      },
+      "dependencies": {
+        "esbuild": {
+          "version": "0.13.8",
+          "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.13.8.tgz",
+          "integrity": "sha512-A4af7G7YZLfG5OnARJRMtlpEsCkq/zHZQXewgPA864l9D6VjjbH1SuFYK/OSV6BtHwDGkdwyRrX0qQFLnMfUcw==",
+          "requires": {
+            "esbuild-android-arm64": "0.13.8",
+            "esbuild-darwin-64": "0.13.8",
+            "esbuild-darwin-arm64": "0.13.8",
+            "esbuild-freebsd-64": "0.13.8",
+            "esbuild-freebsd-arm64": "0.13.8",
+            "esbuild-linux-32": "0.13.8",
+            "esbuild-linux-64": "0.13.8",
+            "esbuild-linux-arm": "0.13.8",
+            "esbuild-linux-arm64": "0.13.8",
+            "esbuild-linux-mips64le": "0.13.8",
+            "esbuild-linux-ppc64le": "0.13.8",
+            "esbuild-netbsd-64": "0.13.8",
+            "esbuild-openbsd-64": "0.13.8",
+            "esbuild-sunos-64": "0.13.8",
+            "esbuild-windows-32": "0.13.8",
+            "esbuild-windows-64": "0.13.8",
+            "esbuild-windows-arm64": "0.13.8"
+          }
+        }
       }
     },
     "vm2": {
-      "version": "3.9.3",
-      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.3.tgz",
-      "integrity": "sha512-smLS+18RjXYMl9joyJxMNI9l4w7biW8ilSDaVRvFBDwOH8P0BK1ognFQTpg0wyQ6wIKLTblHJvROW692L/E53Q==",
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.5.tgz",
+      "integrity": "sha512-LuCAHZN75H9tdrAiLFf030oW7nJV5xwNMuk1ymOZwopmuK3d2H4L1Kv4+GFHgarKiLfXXLFU+7LDABHnwOkWng==",
       "dev": true
     },
     "wrappy": {

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
     "node": ">=16.6.0"
   },
   "devDependencies": {
-    "@feltcoop/gro": "^0.43.0",
-    "@sveltejs/adapter-node": "^1.0.0-next.44",
-    "@sveltejs/kit": "^1.0.0-next.161",
+    "@feltcoop/gro": "^0.44.0",
+    "@sveltejs/adapter-node": "^1.0.0-next.55",
+    "@sveltejs/kit": "^1.0.0-next.186",
     "@types/body-parser": "^1.19.1",
     "@types/node": "^16.7.13",
     "@types/ws": "^7.4.7",
@@ -29,13 +29,13 @@
     "prettier-plugin-svelte": "^2.4.0",
     "regexparam": "^2.0.0",
     "strict-event-emitter-types": "^2.0.0",
-    "svelte": "^3.38.3",
+    "svelte": "^3.44.0",
     "svelte-preprocess-esbuild": "^2.0.0",
     "tslib": "^2.3.1",
     "typescript": "^4.4.2"
   },
   "dependencies": {
-    "@feltcoop/felt": "^0.12.0",
+    "@feltcoop/felt": "^0.13.0",
     "@polka/send-type": "^0.5.2",
     "ajv": "^8.6.2",
     "ajv-formats": "^2.1.1",

--- a/src/lib/ui/BoardItem.svelte
+++ b/src/lib/ui/BoardItem.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import Markup from '@feltcoop/felt/ui/Markup.svelte';
 	import type {Readable} from 'svelte/store';
 
 	import type {File} from '$lib/vocab/file/file.js';
@@ -21,11 +20,11 @@
 </script>
 
 <li style="--hue: {hue}">
-	<Markup>
+	<div class="markup">
 		<p>
 			{$file.content}
 		</p>
-	</Markup>
+	</div>
 	<Avatar name={toName($persona)} icon={toIcon($persona)} />
 </li>
 

--- a/src/lib/ui/CommunityInput.svelte
+++ b/src/lib/ui/CommunityInput.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import Dialog from '@feltcoop/felt/ui/Dialog.svelte';
-	import Markup from '@feltcoop/felt/ui/Markup.svelte';
 	import PendingButton from '@feltcoop/felt/ui/PendingButton.svelte';
 	import Message from '@feltcoop/felt/ui/Message.svelte';
 
@@ -47,7 +46,7 @@
 </button>
 {#if opened}
 	<Dialog on:close={() => (opened = false)}>
-		<Markup>
+		<div class="markup">
 			<h1>Create a new community</h1>
 			<form>
 				<input placeholder="> name" on:keydown={onKeydown} bind:value={name} use:autofocus />
@@ -58,7 +57,7 @@
 			{#if errorMessage}
 				<Message status="error">{errorMessage}</Message>
 			{/if}
-		</Markup>
+		</div>
 	</Dialog>
 {/if}
 

--- a/src/lib/ui/Home.svelte
+++ b/src/lib/ui/Home.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import Markup from '@feltcoop/felt/ui/Markup.svelte';
 	import type {Readable} from 'svelte/store';
 
 	import type {Space} from '$lib/vocab/space/space.js';
@@ -23,7 +22,7 @@
 	$: communitySpaces = $spacesByCommunityId.get($community.community_id)!;
 </script>
 
-<Markup>
+<div class="markup">
 	<section>
 		<h2>members</h2>
 		<!-- TODO display other meta info about the community -->
@@ -49,7 +48,7 @@
 		<div>This community was created at {$community.created}</div>
 		<code>TODO</code>
 	</section>
-</Markup>
+</div>
 
 <style>
 	section {

--- a/src/lib/ui/MainNav.svelte
+++ b/src/lib/ui/MainNav.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import Markup from '@feltcoop/felt/ui/Markup.svelte';
 	import {icons} from '@feltcoop/felt';
 	import {session} from '$app/stores';
 
@@ -71,12 +70,12 @@
 				{/if}
 			</div>
 		{:else if $mainNavView === 'account'}
-			<Markup>
+			<div class="markup">
 				<AccountForm guest={$session.guest} />
 				{#if $devmode}
 					<a class="menu-link" href="/docs">/docs</a>
 				{/if}
-			</Markup>
+			</div>
 			<SocketConnection />
 		{/if}
 	</div>

--- a/src/lib/ui/MembershipInput.svelte
+++ b/src/lib/ui/MembershipInput.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import Dialog from '@feltcoop/felt/ui/Dialog.svelte';
-	import Markup from '@feltcoop/felt/ui/Markup.svelte';
 	import {get} from 'svelte/store';
 	import type {Readable} from 'svelte/store';
 
@@ -35,14 +34,14 @@
 </button>
 {#if opened}
 	<Dialog on:close={() => (opened = false)}>
-		<Markup>
+		<div class="markup">
 			<h1>Invite users to {$community.name}</h1>
 			{#each invitableMembers as persona (persona)}
 				<MembershipInputItem {persona} {community} />
 			{:else}
 				<p>There's no one new to invite</p>
 			{/each}
-		</Markup>
+		</div>
 	</Dialog>
 {/if}
 

--- a/src/lib/ui/Onboard.svelte
+++ b/src/lib/ui/Onboard.svelte
@@ -1,14 +1,13 @@
 <script lang="ts">
-	import Markup from '@feltcoop/felt/ui/Markup.svelte';
 	import {icons} from '@feltcoop/felt';
 
 	import PersonaInput from '$lib/ui/PersonaInput.svelte';
 </script>
 
-<Markup>
+<div class="markup">
 	<div class="welcome">{icons.waving}</div>
 	<PersonaInput />
-</Markup>
+</div>
 
 <style>
 	.welcome {

--- a/src/lib/ui/PersonaInput.svelte
+++ b/src/lib/ui/PersonaInput.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import Markup from '@feltcoop/felt/ui/Markup.svelte';
 	import type {AsyncStatus} from '@feltcoop/felt';
 	import Message from '@feltcoop/felt/ui/Message.svelte';
 
@@ -35,7 +34,7 @@
 	};
 </script>
 
-<Markup>
+<div class="markup">
 	<h2>Create a persona</h2>
 	<form>
 		<input
@@ -50,7 +49,7 @@
 			Create persona
 		</button>
 	</form>
-</Markup>
+</div>
 <div class="centered-block">
 	<div>
 		<Message icon="‼">your persona name is visible to others</Message>

--- a/src/lib/ui/SpaceInput.svelte
+++ b/src/lib/ui/SpaceInput.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import Dialog from '@feltcoop/felt/ui/Dialog.svelte';
-	import Markup from '@feltcoop/felt/ui/Markup.svelte';
 	import type {Readable} from 'svelte/store';
 
 	import type {Community} from '$lib/vocab/community/community.js';
@@ -64,29 +63,27 @@
 </button>
 {#if opened}
 	<Dialog on:close={() => (opened = false)}>
-		<div>
-			<Markup>
-				<h1>Create a new space</h1>
-				<form>
-					<div class:error={!!errorMessage}>{errorMessage || ''}</div>
-					<input
-						placeholder="> name"
-						bind:value={newName}
-						use:autofocus
-						bind:this={nameEl}
-						on:keydown={onKeydown}
-					/>
-					<label>
-						Select Type:
-						<select class="type-selector" bind:value={newType}>
-							{#each spaceTypes as type (type)}
-								<option value={type}>{type}</option>
-							{/each}
-						</select>
-					</label>
-					<button type="button" on:click={create}> Create space </button>
-				</form>
-			</Markup>
+		<div class="markup">
+			<h1>Create a new space</h1>
+			<form>
+				<div class:error={!!errorMessage}>{errorMessage || ''}</div>
+				<input
+					placeholder="> name"
+					bind:value={newName}
+					use:autofocus
+					bind:this={nameEl}
+					on:keydown={onKeydown}
+				/>
+				<label>
+					Select Type:
+					<select class="type-selector" bind:value={newType}>
+						{#each spaceTypes as type (type)}
+							<option value={type}>{type}</option>
+						{/each}
+					</select>
+				</label>
+				<button type="button" on:click={create}> Create space </button>
+			</form>
 		</div>
 	</Dialog>
 {/if}

--- a/src/lib/ui/SpaceInput.svelte
+++ b/src/lib/ui/SpaceInput.svelte
@@ -5,13 +5,17 @@
 	import type {Community} from '$lib/vocab/community/community.js';
 	import {autofocus} from '$lib/ui/actions';
 	import {getApp} from '$lib/ui/app';
-	import {spaceTypes} from '$lib/vocab/space/space';
+	import {SpaceType, spaceTypes as allSpaceTypes} from '$lib/vocab/space/space';
 
 	const {
 		api: {dispatch},
 	} = getApp();
 
 	export let community: Readable<Community>;
+
+	// TODO instead of filtering here, this should probably be determined by metadata on space types,
+	// alongside additional information like their props schemas (which don't exist yet)
+	const spaceTypes = allSpaceTypes.filter((s) => s !== SpaceType.Home);
 
 	let opened = false;
 	let newName = '';

--- a/src/lib/ui/SpaceInput.svelte
+++ b/src/lib/ui/SpaceInput.svelte
@@ -13,8 +13,7 @@
 
 	export let community: Readable<Community>;
 
-	// TODO instead of filtering here, this should probably be determined by metadata on space types,
-	// alongside additional information like their props schemas (which don't exist yet)
+	// TODO instead of filtering here, this perhaps should be determined by metadata on space types
 	const spaceTypes = allSpaceTypes.filter((s) => s !== SpaceType.Home);
 
 	let opened = false;

--- a/src/lib/vocab/persona/personaService.test.ts
+++ b/src/lib/vocab/persona/personaService.test.ts
@@ -5,7 +5,6 @@ import type {TestServerContext} from '$lib/util/testServerHelpers';
 import {setupServer, teardownServer} from '$lib/util/testServerHelpers';
 import {toRandomVocabContext} from '$lib/vocab/random';
 import type {TestAppContext} from '$lib/util/testAppHelpers';
-import {setupApp, teardownApp} from '$lib/util/testAppHelpers';
 import {createPersonaService} from '$lib/vocab/persona/personaServices';
 
 // TODO this only depends on the database --
@@ -18,8 +17,6 @@ const test__personaService = suite<TestServerContext & TestAppContext>('personaS
 
 test__personaService.before(setupServer);
 test__personaService.after(teardownServer);
-test__personaService.before(setupApp((() => {}) as any)); // TODO either use `node-fetch` or mock
-test__personaService.after(teardownApp);
 
 const personaName = 'jung';
 

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -6,7 +6,6 @@
 	import FeltWindowHost from '@feltcoop/felt/ui/FeltWindowHost.svelte';
 	import {onMount} from 'svelte';
 	import {session} from '$app/stores';
-	import Markup from '@feltcoop/felt/ui/Markup.svelte';
 	import {page} from '$app/stores';
 	import {browser} from '$app/env';
 	import type {Readable} from 'svelte/store';
@@ -179,10 +178,8 @@
 	{/if}
 	<main>
 		{#if guest}
-			<div class="column">
-				<Markup>
-					<AccountForm {guest} />
-				</Markup>
+			<div class="column markup">
+				<AccountForm {guest} />
 			</div>
 		{:else if onboarding}
 			<div class="column">

--- a/src/routes/docs/index.svelte
+++ b/src/routes/docs/index.svelte
@@ -2,7 +2,6 @@
 	import SchemaInfo from '$lib/ui/SchemaInfo.svelte';
 	import {eventInfos} from '$lib/app/events';
 	import {entities} from '$lib/app/entities';
-	import Markup from '@feltcoop/felt/ui/Markup.svelte';
 
 	const title = 'docs';
 </script>
@@ -11,7 +10,7 @@
 
 <div class="wrapper">
 	<div class="column">
-		<Markup>
+		<div class="markup">
 			<h1 id="docs">docs</h1>
 			<ul>
 				<li><a href="#vocab">vocab</a></li>
@@ -19,7 +18,7 @@
 			</ul>
 			<hr />
 			<h2 id="vocab">vocab</h2>
-		</Markup>
+		</div>
 		<ul>
 			{#each entities as schema (schema)}
 				<li>
@@ -28,9 +27,9 @@
 			{/each}
 		</ul>
 		<hr />
-		<Markup>
+		<div class="markup">
 			<h2 id="events">events</h2>
-		</Markup>
+		</div>
 		<ul>
 			{#each eventInfos as eventInfo (eventInfo.name)}
 				<li>
@@ -62,7 +61,7 @@
 			{/each}
 		</ul>
 		<hr />
-		<Markup>
+		<div class="markup">
 			<ul>
 				<li>
 					<a href="#docs">docs</a>
@@ -72,7 +71,7 @@
 					</ul>
 				</li>
 			</ul>
-		</Markup>
+		</div>
 	</div>
 </div>
 


### PR DESCRIPTION
Upgrades the primary dependencies, mainly SvelteKit and [@sveltejs/adapter-node](https://github.com/sveltejs/kit/tree/master/packages/adapter-node). In a followup I'll use the adapter's new middleware in production builds instead of running two separate servers.

Also removes some unused code in a test, and filters out the `Home` space type from the space input. I left a comment about implementing something more robust and configurable in the future -- for now it seems fine to just one-off hardcode this, but we'll eventually accumulate more of these details that should probably be configurable and handled generically. Following the current events pattern this could be a `SpaceInfo` object, which could have both their props schemas and this hypothetical property to disallow users creating spaces of the type -- but now that I've written that out, it does seem strange to lock down certain space types. In this case the `Home` space was conceived as a hardcoded singleton per community with a distinct purpose, but it also overlaps with our idea of "an empty space to fill with the things you want". So perhaps `Home` isn't a type at all, it's could be the default data for a more generic space type, with the default instance named "Home" with a home-appropriate icon.