### PR TITLE
increase nginx proxy timeout

### DIFF
--- a/src/infra/felt-server.conf
+++ b/src/infra/felt-server.conf
@@ -12,8 +12,8 @@ server {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header Host $host;
     proxy_pass http://localhost:3000;
-    proxy_read_timeout 360s;
-    proxy_send_timeout 360s;
+    proxy_read_timeout 63s;
+    proxy_send_timeout 63s;
   }
 
   location / {

--- a/src/infra/felt-server.conf
+++ b/src/infra/felt-server.conf
@@ -12,8 +12,8 @@ server {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header Host $host;
     proxy_pass http://localhost:3000;
-    proxy_read_timeout 63s;
-    proxy_send_timeout 63s;
+    proxy_read_timeout 360s;
+    proxy_send_timeout 360s;
   }
 
   location / {

--- a/src/infra/felt-server.conf
+++ b/src/infra/felt-server.conf
@@ -12,8 +12,8 @@ server {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header Host $host;
     proxy_pass http://localhost:3000;
-    proxy_read_timeout 86400s;
-    proxy_send_timeout 86400s;
+    proxy_read_timeout 360s;
+    proxy_send_timeout 360s;
   }
 
   location / {

--- a/src/infra/felt-server.conf
+++ b/src/infra/felt-server.conf
@@ -12,6 +12,8 @@ server {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header Host $host;
     proxy_pass http://localhost:3000;
+    proxy_read_timeout 86400s;
+    proxy_send_timeout 86400s;
   }
 
   location / {

--- a/src/infra/felt-server.gen.conf.ts
+++ b/src/infra/felt-server.gen.conf.ts
@@ -20,8 +20,8 @@ server {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header Host $host;
     proxy_pass http://${API_SERVER_HOST_PROD};
-    proxy_read_timeout 86400s;
-    proxy_send_timeout 86400s;
+    proxy_read_timeout 360s;
+    proxy_send_timeout 360s;
   }
 
   location / {

--- a/src/infra/felt-server.gen.conf.ts
+++ b/src/infra/felt-server.gen.conf.ts
@@ -20,6 +20,8 @@ server {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header Host $host;
     proxy_pass http://${API_SERVER_HOST_PROD};
+    proxy_read_timeout 86400s;
+    proxy_send_timeout 86400s;
   }
 
   location / {

--- a/src/infra/felt-server.gen.conf.ts
+++ b/src/infra/felt-server.gen.conf.ts
@@ -1,9 +1,11 @@
 import type {Gen} from '@feltcoop/gro/dist/gen/gen.js';
 
 import {DEPLOY_SERVER_HOST, API_SERVER_HOST_PROD, SVELTEKIT_SERVER_HOST} from '$lib/config';
+import {PINGER_INTERVAL} from '$lib/ui/pinger';
 
 // Outputs an nginx config with configured values.
 export const gen: Gen = async () => {
+	const websocketTimeout = `${PINGER_INTERVAL / 1000 + 60}s`; // 60 second padding
 	return `
 
 server {
@@ -20,8 +22,8 @@ server {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header Host $host;
     proxy_pass http://${API_SERVER_HOST_PROD};
-    proxy_read_timeout 360s;
-    proxy_send_timeout 360s;
+    proxy_read_timeout ${websocketTimeout};
+    proxy_send_timeout ${websocketTimeout};
   }
 
   location / {

--- a/src/lib/server/random.ts
+++ b/src/lib/server/random.ts
@@ -19,7 +19,7 @@ import {randomPersonaParams, randomCommunityParams, randomSpaceParams} from '$li
 export const randomEventParams = async (
 	event: EventInfo,
 	random: RandomVocabContext,
-	{account, persona, community, space}: RandomVocab,
+	{account, persona, community, space}: RandomVocab = {},
 ): Promise<any> => {
 	switch (event.name) {
 		case 'ping': {

--- a/src/lib/server/random.ts
+++ b/src/lib/server/random.ts
@@ -22,6 +22,9 @@ export const randomEventParams = async (
 	{account, persona, community, space}: RandomVocab,
 ): Promise<any> => {
 	switch (event.name) {
+		case 'ping': {
+			return null;
+		}
 		case 'log_in': {
 			return {
 				accountName: randomString(),

--- a/src/lib/server/serverServices.ts
+++ b/src/lib/server/serverServices.ts
@@ -1,0 +1,8 @@
+import type {Service} from '$lib/server/service';
+import type {ping_params_type, ping_response_type} from '$lib/ui/events';
+import {ping} from '$lib/ui/ui.events';
+
+export const pingService: Service<ping_params_type, ping_response_type> = {
+	event: ping,
+	perform: async () => ({ok: true, status: 200, value: undefined}),
+};

--- a/src/lib/server/serverServices.ts
+++ b/src/lib/server/serverServices.ts
@@ -4,5 +4,5 @@ import {ping} from '$lib/ui/ui.events';
 
 export const pingService: Service<ping_params_type, ping_response_type> = {
 	event: ping,
-	perform: async () => ({ok: true, status: 200, value: undefined}),
+	perform: async () => ({ok: true, status: 200, value: null}),
 };

--- a/src/lib/server/service.ts
+++ b/src/lib/server/service.ts
@@ -14,12 +14,12 @@ export type ServiceMethod =
 
 // A `Service` can be reused across both http and websocket handlers.
 // The generics are required to avoid mistakes with service definitions.
-export interface Service<TParams extends object, TResponse extends object> {
+export interface Service<TParams, TResponse extends object> {
 	event: ServiceEventInfo;
 	perform(request: ServiceRequest<TParams>): Promise<TResponse>;
 }
 
-export interface ServiceRequest<TParams extends object> {
+export interface ServiceRequest<TParams> {
 	server: ApiServer;
 	params: TParams;
 	account_id: number;

--- a/src/lib/server/services.ts
+++ b/src/lib/server/services.ts
@@ -1,4 +1,5 @@
 import type {Service} from '$lib/server/service';
+import {pingService} from '$lib/server/serverServices';
 import {createPersonaService} from '$lib/vocab/persona/personaServices';
 import {
 	readCommunityService,
@@ -14,8 +15,8 @@ import {
 } from '$lib/vocab/space/spaceServices';
 
 export const services: Map<string, Service<any, any>> = new Map(
-	// TODO verify no duplicate names?
 	[
+		pingService,
 		createPersonaService,
 		createCommunityService,
 		createMembershipService,

--- a/src/lib/server/websocketHandler.ts
+++ b/src/lib/server/websocketHandler.ts
@@ -49,18 +49,19 @@ export const websocketHandler: WebsocketHandler = async (
 		return;
 	}
 
-	if (!service.event.params.schema || !service.event.response.schema) {
-		console.error('[websocketHandler] unimplemented service schema');
-		return;
-	}
+	let result;
 
 	const validateParams = validateSchema(service.event.params.schema);
 	if (!validateParams(params)) {
 		console.error(red('Failed to validate params'), validateParams.errors);
-		return;
+		result = {
+			ok: false,
+			status: 400,
+			reason: 'invalid params', // TODO helper to stringify `validateParams.errors`
+		};
+	} else {
+		result = await service.perform({server, params, account_id});
 	}
-
-	const result = await service.perform({server, params, account_id});
 
 	const responseMessage: JsonRpcResponse = {
 		jsonrpc: '2.0',

--- a/src/lib/server/websocketHandler.ts
+++ b/src/lib/server/websocketHandler.ts
@@ -3,7 +3,7 @@ import {red} from '@feltcoop/felt/util/terminal.js';
 
 import {JsonRpcResponse, parseJsonRpcRequest} from '$lib/util/jsonRpc';
 import type {ApiServer} from '$lib/server/ApiServer';
-import {validateSchema} from '$lib/util/ajv';
+import {toValidationErrorMessage, validateSchema} from '$lib/util/ajv';
 
 export interface WebsocketHandler {
 	(server: ApiServer, socket: ws, rawMessage: ws.Data, account_id: number): Promise<void>;
@@ -53,11 +53,11 @@ export const websocketHandler: WebsocketHandler = async (
 
 	const validateParams = validateSchema(service.event.params.schema);
 	if (!validateParams(params)) {
-		console.error(red('Failed to validate params'), validateParams.errors);
+		console.error('[websocketHandler] failed to validate params', validateParams.errors);
 		result = {
 			ok: false,
 			status: 400,
-			reason: 'invalid params', // TODO helper to stringify `validateParams.errors`
+			reason: 'invalid params: ' + toValidationErrorMessage(validateParams.errors![0]),
 		};
 	} else {
 		result = await service.perform({server, params, account_id});

--- a/src/lib/ui/HttpApiClient.ts
+++ b/src/lib/ui/HttpApiClient.ts
@@ -34,7 +34,7 @@ export const toHttpApiClient = <
 				const res = await fetch(path, {
 					method,
 					headers: {'content-type': 'application/json'},
-					body: method === 'GET' || method === 'HEAD' ? null : JSON.stringify(params || null),
+					body: method === 'GET' || method === 'HEAD' ? null : JSON.stringify(params),
 				});
 				let json;
 				try {

--- a/src/lib/ui/HttpApiClient.ts
+++ b/src/lib/ui/HttpApiClient.ts
@@ -22,18 +22,19 @@ export const toHttpApiClient = <
 	const client: ApiClient<TParamsMap, TResultMap> = {
 		has: (name) => !!findService(name), // TODO maybe change the API to return the service, and optionally accept it to `invoke`
 		invoke: async (name, params) => {
+			params = params ?? null!;
 			console.log('[http api client] invoke', name, params);
 			const service = findService(name);
 			if (!service) {
 				return {ok: false, status: 400, reason: `Failed to invoke unknown service: ${name}`};
 			}
-			const path = inject(service.route.path, params);
+			const path = params ? inject(service.route.path, params) : service.route.path;
 			const {method} = service.route;
 			try {
 				const res = await fetch(path, {
 					method,
 					headers: {'content-type': 'application/json'},
-					body: method === 'GET' || method === 'HEAD' ? null : JSON.stringify(params),
+					body: method === 'GET' || method === 'HEAD' ? null : JSON.stringify(params || null),
 				});
 				let json;
 				try {

--- a/src/lib/ui/WebsocketApiClient.ts
+++ b/src/lib/ui/WebsocketApiClient.ts
@@ -49,6 +49,7 @@ export const toWebsocketApiClient = <
 	const client: WebsocketApiClient<TParamsMap, TResultMap> = {
 		has: (name) => !!findService(name), // TODO maybe change the API to return the service, and optionally accept it to `invoke`
 		invoke: async (name, params) => {
+			params = params ?? null!;
 			console.log('[websocket api client] invoke', name, params);
 			const request: JsonRpcRequest<typeof name, TParamsMap> = {
 				jsonrpc: '2.0',

--- a/src/lib/ui/events.ts
+++ b/src/lib/ui/events.ts
@@ -26,7 +26,7 @@ export interface EventsParams {
 	create_file: create_file_params_type;
 	read_files: read_files_params_type;
 	query_files: query_files_params_type;
-	heartbeat: heartbeat_params_type;
+	ping: ping_params_type;
 	toggle_main_nav: toggle_main_nav_params_type;
 	toggle_secondary_nav: toggle_secondary_nav_params_type;
 	set_main_nav_view: set_main_nav_view_params_type;
@@ -48,7 +48,7 @@ export interface EventsResponse {
 	read_spaces: read_spaces_response_type;
 	create_file: create_file_response_type;
 	read_files: read_files_response_type;
-	heartbeat: heartbeat_response_type;
+	ping: ping_response_type;
 }
 
 export type log_in_params_type = {
@@ -117,8 +117,8 @@ export type read_files_response_type = ApiResult<{files: File[]}>;
 
 export type query_files_params_type = {space_id: number};
 
-export type heartbeat_params_type = void;
-export type heartbeat_response_type = void;
+export type ping_params_type = void;
+export type ping_response_type = ApiResult<void>;
 
 export type toggle_main_nav_params_type = void;
 
@@ -207,7 +207,7 @@ export interface Dispatch {
 	): Promise<ApiResult<{file: File}>>;
 	(eventName: 'read_files', params: {space_id: number}): Promise<ApiResult<{files: File[]}>>;
 	(eventName: 'query_files', params: {space_id: number}): Readable<Readable<File>[]>;
-	(eventName: 'heartbeat', params: void): void;
+	(eventName: 'ping', params: void): Promise<ApiResult<void>>;
 	(eventName: 'toggle_main_nav', params: void): void;
 	(eventName: 'toggle_secondary_nav', params: void): void;
 	(eventName: 'set_main_nav_view', params: MainNavView): void;
@@ -322,7 +322,7 @@ export interface UiHandlers {
 		ctx: DispatchContext<{space_id: number}, ApiResult<{files: File[]}>>,
 	) => Promise<ApiResult<{files: File[]}>>;
 	query_files: (ctx: DispatchContext<{space_id: number}, void>) => Readable<Readable<File>[]>;
-	heartbeat: (ctx: DispatchContext<void, void>) => void;
+	ping: (ctx: DispatchContext<void, ApiResult<void>>) => Promise<ApiResult<void>>;
 	toggle_main_nav: (ctx: DispatchContext<void, void>) => void;
 	toggle_secondary_nav: (ctx: DispatchContext<void, void>) => void;
 	set_main_nav_view: (ctx: DispatchContext<MainNavView, void>) => void;

--- a/src/lib/ui/events.ts
+++ b/src/lib/ui/events.ts
@@ -26,6 +26,7 @@ export interface EventsParams {
 	create_file: create_file_params_type;
 	read_files: read_files_params_type;
 	query_files: query_files_params_type;
+	heartbeat: heartbeat_params_type;
 	toggle_main_nav: toggle_main_nav_params_type;
 	toggle_secondary_nav: toggle_secondary_nav_params_type;
 	set_main_nav_view: set_main_nav_view_params_type;
@@ -47,6 +48,7 @@ export interface EventsResponse {
 	read_spaces: read_spaces_response_type;
 	create_file: create_file_response_type;
 	read_files: read_files_response_type;
+	heartbeat: heartbeat_response_type;
 }
 
 export type log_in_params_type = {
@@ -114,6 +116,9 @@ export type read_files_params_type = {space_id: number};
 export type read_files_response_type = ApiResult<{files: File[]}>;
 
 export type query_files_params_type = {space_id: number};
+
+export type heartbeat_params_type = void;
+export type heartbeat_response_type = void;
 
 export type toggle_main_nav_params_type = void;
 
@@ -202,6 +207,7 @@ export interface Dispatch {
 	): Promise<ApiResult<{file: File}>>;
 	(eventName: 'read_files', params: {space_id: number}): Promise<ApiResult<{files: File[]}>>;
 	(eventName: 'query_files', params: {space_id: number}): Readable<Readable<File>[]>;
+	(eventName: 'heartbeat', params: void): void;
 	(eventName: 'toggle_main_nav', params: void): void;
 	(eventName: 'toggle_secondary_nav', params: void): void;
 	(eventName: 'set_main_nav_view', params: MainNavView): void;
@@ -316,6 +322,7 @@ export interface UiHandlers {
 		ctx: DispatchContext<{space_id: number}, ApiResult<{files: File[]}>>,
 	) => Promise<ApiResult<{files: File[]}>>;
 	query_files: (ctx: DispatchContext<{space_id: number}, void>) => Readable<Readable<File>[]>;
+	heartbeat: (ctx: DispatchContext<void, void>) => void;
 	toggle_main_nav: (ctx: DispatchContext<void, void>) => void;
 	toggle_secondary_nav: (ctx: DispatchContext<void, void>) => void;
 	set_main_nav_view: (ctx: DispatchContext<MainNavView, void>) => void;

--- a/src/lib/ui/events.ts
+++ b/src/lib/ui/events.ts
@@ -118,7 +118,7 @@ export type read_files_response_type = ApiResult<{files: File[]}>;
 export type query_files_params_type = {space_id: number};
 
 export type ping_params_type = void;
-export type ping_response_type = ApiResult<void>;
+export type ping_response_type = ApiResult<null>;
 
 export type toggle_main_nav_params_type = void;
 
@@ -207,7 +207,7 @@ export interface Dispatch {
 	): Promise<ApiResult<{file: File}>>;
 	(eventName: 'read_files', params: {space_id: number}): Promise<ApiResult<{files: File[]}>>;
 	(eventName: 'query_files', params: {space_id: number}): Readable<Readable<File>[]>;
-	(eventName: 'ping', params: void): Promise<ApiResult<void>>;
+	(eventName: 'ping', params: void): Promise<ApiResult<null>>;
 	(eventName: 'toggle_main_nav', params: void): void;
 	(eventName: 'toggle_secondary_nav', params: void): void;
 	(eventName: 'set_main_nav_view', params: MainNavView): void;
@@ -322,7 +322,7 @@ export interface UiHandlers {
 		ctx: DispatchContext<{space_id: number}, ApiResult<{files: File[]}>>,
 	) => Promise<ApiResult<{files: File[]}>>;
 	query_files: (ctx: DispatchContext<{space_id: number}, void>) => Readable<Readable<File>[]>;
-	ping: (ctx: DispatchContext<void, ApiResult<void>>) => Promise<ApiResult<void>>;
+	ping: (ctx: DispatchContext<void, ApiResult<null>>) => Promise<ApiResult<null>>;
 	toggle_main_nav: (ctx: DispatchContext<void, void>) => void;
 	toggle_secondary_nav: (ctx: DispatchContext<void, void>) => void;
 	set_main_nav_view: (ctx: DispatchContext<MainNavView, void>) => void;

--- a/src/lib/ui/pinger.ts
+++ b/src/lib/ui/pinger.ts
@@ -1,6 +1,6 @@
 import type {Dispatch} from '$lib/ui/events';
 
-export const PINGER_INTERVAL = 300000;
+export const PINGER_INTERVAL = 3000;
 
 export const createPinger = (dispatch: Dispatch) => {
 	const interval = setInterval(async () => {

--- a/src/lib/ui/pinger.ts
+++ b/src/lib/ui/pinger.ts
@@ -8,7 +8,7 @@ export const createPinger = (dispatch: Dispatch) => {
 	}, PINGER_INTERVAL);
 	return {
 		close: () => {
-			clearTimeout(interval);
+			clearInterval(interval);
 		},
 	};
 };

--- a/src/lib/ui/pinger.ts
+++ b/src/lib/ui/pinger.ts
@@ -4,12 +4,8 @@ export const PINGER_INTERVAL = 300000;
 
 export const createPinger = (dispatch: Dispatch) => {
 	const interval = setInterval(async () => {
-		const time = Date.now();
 		await dispatch('ping');
-		const duration = Date.now() - time;
-		console.log('[ping]', duration + 'ms');
 	}, PINGER_INTERVAL);
-
 	return {
 		close: () => {
 			clearTimeout(interval);

--- a/src/lib/ui/pinger.ts
+++ b/src/lib/ui/pinger.ts
@@ -1,0 +1,18 @@
+import type {Dispatch} from '$lib/ui/events';
+
+export const PINGER_INTERVAL = 3000;
+
+export const createPinger = (dispatch: Dispatch) => {
+	const interval = setInterval(async () => {
+		const time = Date.now();
+		await dispatch('ping');
+		const duration = Date.now() - time;
+		console.log('[ping]', duration + 'ms');
+	}, PINGER_INTERVAL);
+
+	return {
+		close: () => {
+			clearTimeout(interval);
+		},
+	};
+};

--- a/src/lib/ui/pinger.ts
+++ b/src/lib/ui/pinger.ts
@@ -1,6 +1,6 @@
 import type {Dispatch} from '$lib/ui/events';
 
-export const PINGER_INTERVAL = 3000;
+export const PINGER_INTERVAL = 300000;
 
 export const createPinger = (dispatch: Dispatch) => {
 	const interval = setInterval(async () => {

--- a/src/lib/ui/ui.events.ts
+++ b/src/lib/ui/ui.events.ts
@@ -11,13 +11,13 @@ export const ping: ServiceEventInfo = {
 		},
 	},
 	response: {
-		type: `ApiResult<void>`,
+		type: `ApiResult<null>`,
 		schema: {
 			$id: 'https://felt.social/vocab/ping_response.json',
 			type: 'null',
 		},
 	},
-	returns: `Promise<ApiResult<void>>`,
+	returns: `Promise<ApiResult<null>>`,
 	route: {
 		path: '/api/v1/ping',
 		method: 'GET',

--- a/src/lib/ui/ui.events.ts
+++ b/src/lib/ui/ui.events.ts
@@ -1,19 +1,31 @@
-import type {EventInfo} from '$lib/vocab/event/event';
+import type {EventInfo, ServiceEventInfo} from '$lib/vocab/event/event';
+
+export const ping: ServiceEventInfo = {
+	type: 'ServiceEvent',
+	name: 'ping',
+	params: {
+		type: 'void',
+		schema: {
+			$id: 'https://felt.social/vocab/ping_params.json',
+			type: 'null',
+		},
+	},
+	response: {
+		type: `ApiResult<void>`,
+		schema: {
+			$id: 'https://felt.social/vocab/ping_response.json',
+			type: 'null',
+		},
+	},
+	returns: `Promise<ApiResult<void>>`,
+	route: {
+		path: '/api/v1/ping',
+		method: 'GET',
+	},
+};
 
 export const events: EventInfo[] = [
-	{
-		type: 'RemoteEvent',
-		name: 'heartbeat',
-		params: {
-			type: 'void',
-			schema: false, // TODO inconsistent since this cannot be `null` like `ClientEvent`s, but is this even correct?
-		},
-		response: {
-			type: 'void',
-			schema: false, // TODO inconsistent since this cannot be `null` like `ClientEvent`s, but is this even correct?
-		},
-		returns: 'void',
-	},
+	ping,
 	{
 		type: 'ClientEvent',
 		name: 'toggle_main_nav',

--- a/src/lib/ui/ui.events.ts
+++ b/src/lib/ui/ui.events.ts
@@ -1,6 +1,19 @@
-import type {ClientEventInfo} from '$lib/vocab/event/event';
+import type {EventInfo} from '$lib/vocab/event/event';
 
-export const events: ClientEventInfo[] = [
+export const events: EventInfo[] = [
+	{
+		type: 'RemoteEvent',
+		name: 'heartbeat',
+		params: {
+			type: 'void',
+			schema: false, // TODO inconsistent since this cannot be `null` like `ClientEvent`s, but is this even correct?
+		},
+		response: {
+			type: 'void',
+			schema: false, // TODO inconsistent since this cannot be `null` like `ClientEvent`s, but is this even correct?
+		},
+		returns: 'void',
+	},
 	{
 		type: 'ClientEvent',
 		name: 'toggle_main_nav',

--- a/src/lib/ui/ui.ts
+++ b/src/lib/ui/ui.ts
@@ -250,6 +250,7 @@ export const toUi = (session: Writable<ClientSession>, initialMobile: boolean): 
 				console.warn('[ui] ignoring a dispatched event', ctx);
 			}
 		},
+		ping: async ({invoke}) => invoke(),
 		// TODO convert to a service (and use `invoke` instead of `fetch`)
 		log_in: async ({params}) => {
 			console.log('[log_in] logging in as', params.accountName); // TODO logging

--- a/src/lib/vocab/persona/personaService.test.ts
+++ b/src/lib/vocab/persona/personaService.test.ts
@@ -33,7 +33,6 @@ test__personaService('create a persona & test collisions', async ({server}) => {
 		account_id: account.account_id,
 	});
 
-	console.log('result', result);
 	assert.equal(result.ok, true);
 
 	result = await createPersonaService.perform({

--- a/src/lib/vocab/persona/personaService.test.ts
+++ b/src/lib/vocab/persona/personaService.test.ts
@@ -6,6 +6,8 @@ import {setupServer, teardownServer} from '$lib/util/testServerHelpers';
 import {toRandomVocabContext} from '$lib/vocab/random';
 import type {TestAppContext} from '$lib/util/testAppHelpers';
 import {createPersonaService} from '$lib/vocab/persona/personaServices';
+import {randomEventParams} from '$lib/server/random';
+import {create_persona} from './persona.events';
 
 // TODO this only depends on the database --
 // if we don't figure out a robust way to make a global reusable server,
@@ -18,13 +20,12 @@ const test__personaService = suite<TestServerContext & TestAppContext>('personaS
 test__personaService.before(setupServer);
 test__personaService.after(teardownServer);
 
-const personaName = 'jung';
-
 test__personaService('create a persona & test collisions', async ({server}) => {
 	//STEP 1: get a server, account, and event context lined up
 	const random = toRandomVocabContext(server.db);
 	const account = await random.account();
-	let params = {name: personaName};
+	const params = await randomEventParams(create_persona, random);
+	params.name = params.name.toLowerCase();
 
 	let result = await createPersonaService.perform({
 		server,
@@ -32,6 +33,7 @@ test__personaService('create a persona & test collisions', async ({server}) => {
 		account_id: account.account_id,
 	});
 
+	console.log('result', result);
 	assert.equal(result.ok, true);
 
 	result = await createPersonaService.perform({
@@ -42,7 +44,7 @@ test__personaService('create a persona & test collisions', async ({server}) => {
 
 	assert.equal(result.ok, false);
 
-	params = {name: personaName.toUpperCase()};
+	params.name = params.name.toUpperCase();
 	result = await createPersonaService.perform({
 		server,
 		params,


### PR DESCRIPTION
Every so often, the websocket disconnects. It seems likely caused by nginx having a 60 second timeout after no activity.

This change increases its timeout to 6 minutes per this answer: https://stackoverflow.com/a/57706152

And the client will send a `ping` event every 5 minutes to keep the connection alive. The linked answer demonstrates 24 hours but that means the server would hold onto dropped connections far too long.

- [x] decide nginx timeout duration: 6 minutes
- [x] add 5 minute interval client-initiated heartbeat

Future:

- move logic to websocket store