### PR TITLE
add delete space tests

### DIFF
--- a/src/lib/vocab/persona/personaService.test.ts
+++ b/src/lib/vocab/persona/personaService.test.ts
@@ -14,7 +14,7 @@ import {create_persona} from './persona.events';
 // then change this module to setup and teardown only a `db` instance
 // instead of the whole server
 
-/* test__repos */
+/* test__personaService */
 const test__personaService = suite<TestServerContext & TestAppContext>('personaService');
 
 test__personaService.before(setupServer);

--- a/src/lib/vocab/persona/personaService.test.ts
+++ b/src/lib/vocab/persona/personaService.test.ts
@@ -14,7 +14,7 @@ import {create_persona} from './persona.events';
 // then change this module to setup and teardown only a `db` instance
 // instead of the whole server
 
-/* test__personaService */
+/* test__repos */
 const test__personaService = suite<TestServerContext & TestAppContext>('personaService');
 
 test__personaService.before(setupServer);

--- a/src/lib/vocab/space/spaceRepo.ts
+++ b/src/lib/vocab/space/spaceRepo.ts
@@ -87,7 +87,7 @@ export const spaceRepo = (db: Database) => ({
       DELETE FROM community_spaces WHERE ${space_id}=space_id
     `;
 
-		if (data_cs.count !== 1) {
+		if (data_cs.count === 0) {
 			return {
 				ok: false,
 				type: 'deletion_error',

--- a/src/lib/vocab/space/spaceServices.test.ts
+++ b/src/lib/vocab/space/spaceServices.test.ts
@@ -26,13 +26,16 @@ test__spaceServices('delete a space in multiple communities', async ({server}) =
 	await server.db.sql<any>`
     INSERT INTO community_spaces (space_id, community_id) VALUES (
       ${space.space_id},${community2.community_id}
-    )
-  `;
+		)`;
 	await server.db.sql<any>`
     INSERT INTO community_spaces (space_id, community_id) VALUES (
       ${space.space_id},${community3.community_id}
     )
-  `;
+	`;
+	let findCommunitySpacesResult = await server.db.sql<any>`
+		SELECT space_id FROM community_spaces WHERE space_id=${space.space_id}
+	`;
+	assert.is(findCommunitySpacesResult.count, 3);
 
 	const deleteResult = await deleteSpaceService.perform({
 		server,
@@ -44,8 +47,7 @@ test__spaceServices('delete a space in multiple communities', async ({server}) =
 	const findSpaceResult = await server.db.repos.space.findById(space.space_id);
 	assert.ok(!findSpaceResult.ok);
 
-	// TODO make an API for this, possibly a generic API ensuring the database is cleaned up
-	const findCommunitySpacesResult = await server.db.sql<any>`
+	findCommunitySpacesResult = await server.db.sql<any>`
 		SELECT space_id FROM community_spaces WHERE space_id=${space.space_id}
 	`;
 	assert.is(findCommunitySpacesResult.count, 0);

--- a/src/lib/vocab/space/spaceServices.test.ts
+++ b/src/lib/vocab/space/spaceServices.test.ts
@@ -7,7 +7,7 @@ import {toRandomVocabContext} from '$lib/vocab/random';
 import type {TestAppContext} from '$lib/util/testAppHelpers';
 import {deleteSpaceService} from '$lib/vocab/space/spaceServices';
 
-/* test__repos */
+/* test__spaceServices */
 const test__spaceServices = suite<TestServerContext & TestAppContext>('spaceServices');
 
 test__spaceServices.before(setupServer);

--- a/src/lib/vocab/space/spaceServices.test.ts
+++ b/src/lib/vocab/space/spaceServices.test.ts
@@ -41,8 +41,14 @@ test__spaceServices('delete a space in multiple communities', async ({server}) =
 	});
 	assert.ok(deleteResult.ok);
 
-	const findResult = await server.db.repos.space.findById(space.space_id);
-	assert.ok(!findResult.ok);
+	const findSpaceResult = await server.db.repos.space.findById(space.space_id);
+	assert.ok(!findSpaceResult.ok);
+
+	// TODO make an API for this, possibly a generic API ensuring the database is cleaned up
+	const findCommunitySpacesResult = await server.db.sql<any>`
+		SELECT space_id FROM community_spaces WHERE space_id=${space.space_id}
+	`;
+	assert.is(findCommunitySpacesResult.count, 0);
 });
 
 test__spaceServices.run();

--- a/src/lib/vocab/space/spaceServices.test.ts
+++ b/src/lib/vocab/space/spaceServices.test.ts
@@ -26,12 +26,11 @@ test__spaceServices('delete a space in multiple communities', async ({server}) =
 	await server.db.sql<any>`
     INSERT INTO community_spaces (space_id, community_id) VALUES (
       ${space.space_id},${community2.community_id}
-		)`;
+	)`;
 	await server.db.sql<any>`
     INSERT INTO community_spaces (space_id, community_id) VALUES (
       ${space.space_id},${community3.community_id}
-    )
-	`;
+	)`;
 	let findCommunitySpacesResult = await server.db.sql<any>`
 		SELECT space_id FROM community_spaces WHERE space_id=${space.space_id}
 	`;

--- a/src/lib/vocab/space/spaceServices.test.ts
+++ b/src/lib/vocab/space/spaceServices.test.ts
@@ -1,0 +1,49 @@
+import {suite} from 'uvu';
+import * as assert from 'uvu/assert';
+
+import type {TestServerContext} from '$lib/util/testServerHelpers';
+import {setupServer, teardownServer} from '$lib/util/testServerHelpers';
+import {toRandomVocabContext} from '$lib/vocab/random';
+import type {TestAppContext} from '$lib/util/testAppHelpers';
+import {deleteSpaceService} from '$lib/vocab/space/spaceServices';
+
+/* test__repos */
+const test__spaceServices = suite<TestServerContext & TestAppContext>('spaceServices');
+
+test__spaceServices.before(setupServer);
+test__spaceServices.after(teardownServer);
+
+test__spaceServices('delete a space in multiple communities', async ({server}) => {
+	const random = toRandomVocabContext(server.db);
+	const account = await random.account();
+	const community1 = await random.community();
+	const community2 = await random.community();
+	const community3 = await random.community();
+	const space = await random.space(undefined, account, community1);
+
+	// add the space to other communities
+	// TODO need a repo method for this
+	await server.db.sql<any>`
+    INSERT INTO community_spaces (space_id, community_id) VALUES (
+      ${space.space_id},${community2.community_id}
+    )
+  `;
+	await server.db.sql<any>`
+    INSERT INTO community_spaces (space_id, community_id) VALUES (
+      ${space.space_id},${community3.community_id}
+    )
+  `;
+
+	const deleteResult = await deleteSpaceService.perform({
+		server,
+		params: {space_id: space.space_id, community_id: 'TODO remove this' as any},
+		account_id: account.account_id,
+	});
+	assert.ok(deleteResult.ok);
+
+	const findResult = await server.db.repos.space.findById(space.space_id);
+	assert.ok(!findResult.ok);
+});
+
+test__spaceServices.run();
+/* test__spaceServices */


### PR DESCRIPTION
This adds a test for #182. We already have an automatic smoke test created for the service, but this adds a test with two additional checks:

- ensure the space is deleted in the db (along with the `community_spaces`)
- ensure deleting the space works when it's been added to multiple communities

We don't have an API for adding a space to a second community, but if we're going to commit to supporting that functionality we'll save ourselves a lot of headache making sure the code is compatible and APIs have the correct dependencies as we write it. The test uses a direct SQL statement to add multiple communities for now with a TODO.

I also included the 1-line fix it to handle multiple communities so CI passes on this PR.