### PR TITLE
fix json rpc type and use number ids instead of string

### DIFF
--- a/src/lib/ui/WebsocketApiClient.ts
+++ b/src/lib/ui/WebsocketApiClient.ts
@@ -2,15 +2,14 @@
 // It implements a request/response pattern over websockets instead of fire-and-forget
 // using JSON-RPC 2.0: https://www.jsonrpc.org/specification
 
-import {toToClientId} from '@feltcoop/felt/util/id.js';
-
 import type {ApiClient} from '$lib/ui/ApiClient';
 import type {ServiceEventInfo} from '$lib/vocab/event/event';
 import type {JsonRpcRequest, JsonRpcResponse} from '$lib/util/jsonRpc';
 import {parseJsonRpcResponse} from '$lib/util/jsonRpc';
 import type {BroadcastMessage} from '$lib/server/websocketHandler';
 
-const toId = toToClientId('', undefined, '');
+let _id = 0;
+const toId = () => ++_id;
 
 // TODO doesn't handle the case where the client never hears back from the server,
 // might want a timeout on each request

--- a/src/lib/ui/WebsocketApiClient.ts
+++ b/src/lib/ui/WebsocketApiClient.ts
@@ -10,7 +10,7 @@ import type {JsonRpcRequest, JsonRpcResponse} from '$lib/util/jsonRpc';
 import {parseJsonRpcResponse} from '$lib/util/jsonRpc';
 import type {BroadcastMessage} from '$lib/server/websocketHandler';
 
-const toId = toCounter();
+const toId = toCounter(1);
 
 // TODO doesn't handle the case where the client never hears back from the server,
 // might want a timeout on each request

--- a/src/lib/ui/WebsocketApiClient.ts
+++ b/src/lib/ui/WebsocketApiClient.ts
@@ -10,7 +10,7 @@ import type {JsonRpcId, JsonRpcRequest, JsonRpcResponse} from '$lib/util/jsonRpc
 import {parseJsonRpcResponse} from '$lib/util/jsonRpc';
 import type {BroadcastMessage} from '$lib/server/websocketHandler';
 
-const toId = toCounter(1); // start counting from 1 to enable falsy checks
+const toId = toCounter();
 
 // TODO doesn't handle the case where the client never hears back from the server,
 // might want a timeout on each request

--- a/src/lib/ui/WebsocketApiClient.ts
+++ b/src/lib/ui/WebsocketApiClient.ts
@@ -10,7 +10,7 @@ import type {JsonRpcRequest, JsonRpcResponse} from '$lib/util/jsonRpc';
 import {parseJsonRpcResponse} from '$lib/util/jsonRpc';
 import type {BroadcastMessage} from '$lib/server/websocketHandler';
 
-const toId = toCounter(1);
+const toId = toCounter(1); // start counting from 1 to enable falsy checks
 
 // TODO doesn't handle the case where the client never hears back from the server,
 // might want a timeout on each request

--- a/src/lib/ui/WebsocketApiClient.ts
+++ b/src/lib/ui/WebsocketApiClient.ts
@@ -10,7 +10,7 @@ import type {JsonRpcRequest, JsonRpcResponse} from '$lib/util/jsonRpc';
 import {parseJsonRpcResponse} from '$lib/util/jsonRpc';
 import type {BroadcastMessage} from '$lib/server/websocketHandler';
 
-const toId = toCounter(1);
+const toId = toCounter();
 
 // TODO doesn't handle the case where the client never hears back from the server,
 // might want a timeout on each request

--- a/src/lib/ui/WebsocketApiClient.ts
+++ b/src/lib/ui/WebsocketApiClient.ts
@@ -6,7 +6,7 @@ import {toCounter} from '@feltcoop/felt/util/counter.js';
 
 import type {ApiClient} from '$lib/ui/ApiClient';
 import type {ServiceEventInfo} from '$lib/vocab/event/event';
-import type {JsonRpcRequest, JsonRpcResponse} from '$lib/util/jsonRpc';
+import type {JsonRpcId, JsonRpcRequest, JsonRpcResponse} from '$lib/util/jsonRpc';
 import {parseJsonRpcResponse} from '$lib/util/jsonRpc';
 import type {BroadcastMessage} from '$lib/server/websocketHandler';
 
@@ -36,7 +36,7 @@ export const toWebsocketApiClient = <
 	send: (request: JsonRpcRequest) => void,
 ): WebsocketApiClient<TParamsMap, TResultMap> => {
 	// TODO maybe extract a `WebsocketRequests` interface, with `add`/`remove` functions (and `pending` items?)
-	const websocketRequests: Map<string, WebsocketRequest> = new Map();
+	const websocketRequests: Map<JsonRpcId, WebsocketRequest> = new Map();
 	const toWebsocketRequest = <T>(request: JsonRpcRequest): WebsocketRequest<T> => {
 		const websocketRequest: WebsocketRequest<T> = {request} as any;
 		websocketRequest.promise = new Promise((resolve) => {

--- a/src/lib/ui/WebsocketApiClient.ts
+++ b/src/lib/ui/WebsocketApiClient.ts
@@ -2,14 +2,15 @@
 // It implements a request/response pattern over websockets instead of fire-and-forget
 // using JSON-RPC 2.0: https://www.jsonrpc.org/specification
 
+import {toCounter} from '@feltcoop/felt/util/counter.js';
+
 import type {ApiClient} from '$lib/ui/ApiClient';
 import type {ServiceEventInfo} from '$lib/vocab/event/event';
 import type {JsonRpcRequest, JsonRpcResponse} from '$lib/util/jsonRpc';
 import {parseJsonRpcResponse} from '$lib/util/jsonRpc';
 import type {BroadcastMessage} from '$lib/server/websocketHandler';
 
-let _id = 0;
-const toId = () => ++_id;
+const toId = toCounter(1);
 
 // TODO doesn't handle the case where the client never hears back from the server,
 // might want a timeout on each request

--- a/src/lib/util/jsonRpc.ts
+++ b/src/lib/util/jsonRpc.ts
@@ -3,7 +3,7 @@ export interface JsonRpcRequest<
 	TParams extends Record<TMethod, object> = any, // TODO defaults?
 > {
 	jsonrpc: '2.0';
-	id: string;
+	id: number;
 	method: TMethod;
 	params: TParams[TMethod];
 }
@@ -12,7 +12,7 @@ export interface JsonRpcRequest<
 // or do we want to support multiple kinds of messages?
 export interface JsonRpcResponse<TResult = any> {
 	jsonrpc: '2.0';
-	id: string;
+	id: number;
 	result: TResult;
 }
 

--- a/src/lib/util/jsonRpc.ts
+++ b/src/lib/util/jsonRpc.ts
@@ -3,7 +3,7 @@ export interface JsonRpcRequest<
 	TParams extends Record<TMethod, object> = any, // TODO defaults?
 > {
 	jsonrpc: '2.0';
-	id: number;
+	id: string | number;
 	method: TMethod;
 	params: TParams[TMethod];
 }
@@ -12,7 +12,7 @@ export interface JsonRpcRequest<
 // or do we want to support multiple kinds of messages?
 export interface JsonRpcResponse<TResult = any> {
 	jsonrpc: '2.0';
-	id: number;
+	id: string | number;
 	result: TResult;
 }
 

--- a/src/lib/util/jsonRpc.ts
+++ b/src/lib/util/jsonRpc.ts
@@ -3,7 +3,7 @@ export interface JsonRpcRequest<
 	TParams extends Record<TMethod, object> = any, // TODO defaults?
 > {
 	jsonrpc: '2.0';
-	id: string | number;
+	id: JsonRpcId;
 	method: TMethod;
 	params: TParams[TMethod];
 }
@@ -12,9 +12,11 @@ export interface JsonRpcRequest<
 // or do we want to support multiple kinds of messages?
 export interface JsonRpcResponse<TResult = any> {
 	jsonrpc: '2.0';
-	id: string | number;
+	id: JsonRpcId;
 	result: TResult;
 }
+
+export type JsonRpcId = string | number;
 
 // TODO should these check every property?
 export const parseJsonRpcRequest = (msg: any): JsonRpcRequest | null =>

--- a/src/lib/util/jsonRpc.ts
+++ b/src/lib/util/jsonRpc.ts
@@ -1,3 +1,8 @@
+// JSON-RPC 2.0: https://www.jsonrpc.org/specification
+
+// TODO the `id` is optional in the spec, and omitting it signals a "Notification",
+// to which the server does not reply
+
 export interface JsonRpcRequest<
 	TMethod extends string = string, // TODO defaults?
 	TParams extends Record<TMethod, object> = any, // TODO defaults?


### PR DESCRIPTION
Makes the JSON RPC `id` type correctly `string | number` and changes our code to use numbers, since there's mainly downsides to strings.