### PR TITLE
fix production task env

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "ws": "^7.5.4"
       },
       "devDependencies": {
-        "@feltcoop/gro": "^0.45.1",
+        "@feltcoop/gro": "^0.46.0",
         "@sveltejs/adapter-node": "^1.0.0-next.55",
         "@sveltejs/kit": "^1.0.0-next.186",
         "@types/body-parser": "^1.19.1",
@@ -76,9 +76,9 @@
       }
     },
     "node_modules/@feltcoop/gro": {
-      "version": "0.45.1",
-      "resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.45.1.tgz",
-      "integrity": "sha512-ZsvyliThEvbocwvGQe44fANIhLN7QimPFMWyd+cpCm3WeqaL7wpTAEDs9f0QmRNcEokWnL0xnpScyrASRJm5xg==",
+      "version": "0.46.0",
+      "resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.46.0.tgz",
+      "integrity": "sha512-61x9WdQ6zgrzU//QoQTeLoC4FxUoEYYEQerOZaDdxUADG3oMYVlh3liXOPoCPgpfbgs+vL5+EnAn8r/asIdQug==",
       "dev": true,
       "dependencies": {
         "@rollup/plugin-commonjs": "^20.0.0",
@@ -2498,9 +2498,9 @@
       }
     },
     "@feltcoop/gro": {
-      "version": "0.45.1",
-      "resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.45.1.tgz",
-      "integrity": "sha512-ZsvyliThEvbocwvGQe44fANIhLN7QimPFMWyd+cpCm3WeqaL7wpTAEDs9f0QmRNcEokWnL0xnpScyrASRJm5xg==",
+      "version": "0.46.0",
+      "resolved": "https://registry.npmjs.org/@feltcoop/gro/-/gro-0.46.0.tgz",
+      "integrity": "sha512-61x9WdQ6zgrzU//QoQTeLoC4FxUoEYYEQerOZaDdxUADG3oMYVlh3liXOPoCPgpfbgs+vL5+EnAn8r/asIdQug==",
       "dev": true,
       "requires": {
         "@rollup/plugin-commonjs": "^20.0.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "node": ">=16.6.0"
   },
   "devDependencies": {
-    "@feltcoop/gro": "^0.45.1",
+    "@feltcoop/gro": "^0.46.0",
     "@sveltejs/adapter-node": "^1.0.0-next.55",
     "@sveltejs/kit": "^1.0.0-next.186",
     "@types/body-parser": "^1.19.1",

--- a/src/infra/restartProd.task.ts
+++ b/src/infra/restartProd.task.ts
@@ -1,14 +1,11 @@
 import type {Task} from '@feltcoop/gro';
 import {spawn} from '@feltcoop/felt/util/process.js';
+import {fromEnv} from '$lib/server/env';
 
 export const task: Task = {
 	summary: 'restart felt prod server',
 	dev: false,
 	run: async () => {
-		//TODO gro dev workaround
-		process.env.NODE_ENV = 'production';
-		const {fromEnv} = await import('$lib/server/env');
-
 		const DEPLOY_IP = fromEnv('DEPLOY_IP');
 		const DEPLOY_USER = fromEnv('DEPLOY_USER');
 		const deployLogin = `${DEPLOY_USER}@${DEPLOY_IP}`;

--- a/src/infra/restartProd.task.ts
+++ b/src/infra/restartProd.task.ts
@@ -4,7 +4,7 @@ import {fromEnv} from '$lib/server/env';
 
 export const task: Task = {
 	summary: 'restart felt prod server',
-	dev: false,
+	production: true,
 	run: async () => {
 		const DEPLOY_IP = fromEnv('DEPLOY_IP');
 		const DEPLOY_USER = fromEnv('DEPLOY_USER');

--- a/src/infra/serverDeploy.task.ts
+++ b/src/infra/serverDeploy.task.ts
@@ -16,7 +16,8 @@ export const task: Task = {
 		);
 		await fs.writeFile(ENV_PROD, updatedEnvContents, 'utf8');
 
-		//build the actual tar deployment artifact
+		//build the actual tar deployment artifact,
+		//using `spawn` instead of `invokeTask` to ensure the environment modified above is updated
 		const buildResult = await spawn('npx', ['gro', 'build']);
 		if (!buildResult.ok) throw Error('gro build failed');
 

--- a/src/infra/serverDeploy.task.ts
+++ b/src/infra/serverDeploy.task.ts
@@ -5,7 +5,7 @@ import {ENV_PROD, fromEnv} from '$lib/server/env';
 
 export const task: Task = {
 	summary: 'deploy felt server to prod',
-	dev: false,
+	production: true,
 	run: async ({invokeTask, fs}) => {
 		//set git version in the .env.production file
 		const branch = (await fs.readFile('.git/HEAD', 'utf8')).trim().substring(5);

--- a/src/infra/serverDeploy.task.ts
+++ b/src/infra/serverDeploy.task.ts
@@ -1,17 +1,12 @@
 import type {Task} from '@feltcoop/gro';
 import {spawn} from '@feltcoop/felt/util/process.js';
 import {DIST_DIRNAME} from '@feltcoop/gro/dist/paths.js';
+import {ENV_PROD, fromEnv} from '$lib/server/env';
 
 export const task: Task = {
 	summary: 'deploy felt server to prod',
 	dev: false,
 	run: async ({invokeTask, fs}) => {
-		console.log('setting serverDeploy');
-		//TODO gro dev workaround
-		process.env.NODE_ENV = 'production';
-
-		const {ENV_PROD} = await import('$lib/server/env');
-
 		//set git version in the .env.production file
 		const branch = (await fs.readFile('.git/HEAD', 'utf8')).trim().substring(5);
 		const gitVersion = (await fs.readFile('.git/' + branch, 'utf8')).trim().substring(0, 7);
@@ -19,8 +14,6 @@ export const task: Task = {
 		const data = await fs.readFile(ENV_PROD, 'utf8');
 		const result = data.replace(/VITE_GIT_HASH=.*/g, `VITE_GIT_HASH=${gitVersion}`);
 		await fs.writeFile(ENV_PROD, result, 'utf8');
-
-		const {fromEnv} = await import('$lib/server/env');
 
 		const DEPLOY_IP = fromEnv('DEPLOY_IP');
 		const DEPLOY_USER = fromEnv('DEPLOY_USER');

--- a/src/infra/setup.task.ts
+++ b/src/infra/setup.task.ts
@@ -1,14 +1,11 @@
 import type {Task} from '@feltcoop/gro';
 import {spawn} from '@feltcoop/felt/util/process.js';
+import {fromEnv} from '$lib/server/env';
 
 export const task: Task = {
 	summary: 'setup a clean server to prepare for a felt-server deploy',
 	dev: false,
 	run: async () => {
-		//TODO gro dev workaround
-		process.env.NODE_ENV = 'production';
-		const {fromEnv} = await import('$lib/server/env');
-
 		const DEPLOY_IP = fromEnv('DEPLOY_IP');
 		const DEPLOY_USER = fromEnv('DEPLOY_USER');
 		const VITE_DEPLOY_SERVER_HOST = fromEnv('VITE_DEPLOY_SERVER_HOST');

--- a/src/infra/setup.task.ts
+++ b/src/infra/setup.task.ts
@@ -4,7 +4,7 @@ import {fromEnv} from '$lib/server/env';
 
 export const task: Task = {
 	summary: 'setup a clean server to prepare for a felt-server deploy',
-	dev: false,
+	production: true,
 	run: async () => {
 		const DEPLOY_IP = fromEnv('DEPLOY_IP');
 		const DEPLOY_USER = fromEnv('DEPLOY_USER');


### PR DESCRIPTION
Fixes the env usage (fixing [these hacks](https://github.com/feltcoop/felt-server/pull/177/files/b9eebf69628870a8673209159ce6cc854a1b1015..38808b937001bbc10d5a671f74c71ef6ceff5a6b)) for production tasks by upgrading Gro. (be sure to `npm i`) Removes the hacks we had in place and should hopefully work as expected! I *think* things should work but I could very well be wrong, and I may have forgotten to make some related changes.

Also uses `spawn('npx', ['gro', 'build'])` instead of `invokeTask('build')` to more robustly ensure the environment is correctly set up. The code was somewhat hackily relying on `fromEnv` not being called before build, which is not an assumption we want to make. (this is my mistake, was my suggestion, and a lesson I learned refactoring `gro publish` and `gro deploy` internals)