### PR TITLE
Refactor space to community relation to be many to 1

### DIFF
--- a/src/lib/db/migrations/00006-refactor-space-communities.js
+++ b/src/lib/db/migrations/00006-refactor-space-communities.js
@@ -11,4 +11,8 @@ export const up = async (sql) => {
 	FROM community_spaces CS 
 	WHERE S.space_id = CS.space_id;
 	`;
+
+	await sql`
+	DROP TABLE community_spaces;
+	`;
 };

--- a/src/lib/db/migrations/00006-refactor-space-communities.js
+++ b/src/lib/db/migrations/00006-refactor-space-communities.js
@@ -1,0 +1,14 @@
+/** @param {import('postgres').Sql<any>} sql */
+export const up = async (sql) => {
+	await sql`
+		ALTER TABLE spaces
+		ADD community_id int REFERENCES communities (community_id) ON UPDATE CASCADE ON DELETE CASCADE;
+	`;
+
+	await sql`
+	UPDATE spaces S 
+	SET community_id = CS.community_id 
+	FROM community_spaces CS 
+	WHERE S.space_id = CS.space_id;
+	`;
+};

--- a/src/lib/vocab/community/communityRepo.ts
+++ b/src/lib/vocab/community/communityRepo.ts
@@ -52,7 +52,7 @@ export const communityRepo = (db: Database) => ({
 				(
 					SELECT array_to_json(coalesce(array_agg(row_to_json(d)), '{}'))
 					FROM (
-						SELECT s.space_id, s.name, s.url, s.media_type, s.content, s.created, s.updated FROM spaces s JOIN community_spaces cs ON s.space_id=cs.space_id AND cs.community_id=c.community_id
+						SELECT s.space_id, s.name, s.url, s.media_type, s.content, s.created, s.updated FROM spaces s WHERE s.community_id = c.community_id
 					) d
 				) as spaces,
 				(

--- a/src/lib/vocab/space/space.ts
+++ b/src/lib/vocab/space/space.ts
@@ -6,6 +6,7 @@ export interface Space {
 	content: string;
 	created: Date;
 	updated: Date | null;
+	community_id: number;
 }
 export const SpaceSchema = {
 	$id: 'https://felt.social/vocab/Space.json',
@@ -18,8 +19,18 @@ export const SpaceSchema = {
 		content: {type: 'string'},
 		created: {type: 'object', format: 'date-time', tsType: 'Date'},
 		updated: {type: ['object', 'null'], format: 'date-time', tsType: 'Date | null'},
+		community_id: {type: 'number'},
 	},
-	required: ['space_id', 'name', 'url', 'media_type', 'content', 'created', 'updated'],
+	required: [
+		'space_id',
+		'name',
+		'url',
+		'media_type',
+		'content',
+		'created',
+		'updated',
+		'community_id',
+	],
 	additionalProperties: false,
 };
 

--- a/src/lib/vocab/space/spaceRepo.ts
+++ b/src/lib/vocab/space/spaceRepo.ts
@@ -13,7 +13,7 @@ export const spaceRepo = (db: Database) => ({
 	): Promise<Result<{value: Space}, {type: 'no_space_found'} & ErrorResponse>> => {
 		console.log(`[db] preparing to query for space id: ${space_id}`);
 		const data = await db.sql<Space[]>`
-      select space_id, name, url, media_type, content, updated, created from spaces where space_id = ${space_id}
+      select space_id, name, url, media_type, content, updated, created, community_id from spaces where space_id = ${space_id}
     `;
 		console.log('[db] space data', data);
 		if (data.length) {
@@ -28,7 +28,7 @@ export const spaceRepo = (db: Database) => ({
 	filterByCommunity: async (community_id: number): Promise<Result<{value: Space[]}>> => {
 		console.log(`[spaceRepo] preparing to query for community spaces: ${community_id}`);
 		const data = await db.sql<Space[]>`
-      SELECT s.space_id, s.name, s.url, s.media_type, s.content, s.updated, s.created FROM spaces s WHERE s.community_id= ${community_id}
+      SELECT s.space_id, s.name, s.url, s.media_type, s.content, s.updated, s.created, s.community_id FROM spaces s WHERE s.community_id= ${community_id}
     `;
 		// console.log('[db] spaces data', data);
 		return {ok: true, value: data};
@@ -41,7 +41,7 @@ export const spaceRepo = (db: Database) => ({
 			`[spaceRepo] preparing to query for community space by url: ${community_id} ${url}`,
 		);
 		const data = await db.sql<Space[]>`
-			SELECT s.space_id, s.name, s.url, s.media_type, s.content, s.updated, s.created FROM spaces s WHERE s.community_id= ${community_id} AND s.url = ${url}
+			SELECT s.space_id, s.name, s.url, s.media_type, s.content, s.updated, s.created, s.community_id FROM spaces s WHERE s.community_id= ${community_id} AND s.url = ${url}
 		`;
 		console.log('[spaceRepo] space data', data);
 		return {ok: true, value: data[0]};

--- a/src/lib/vocab/space/spaceRepo.ts
+++ b/src/lib/vocab/space/spaceRepo.ts
@@ -28,7 +28,7 @@ export const spaceRepo = (db: Database) => ({
 	filterByCommunity: async (community_id: number): Promise<Result<{value: Space[]}>> => {
 		console.log(`[spaceRepo] preparing to query for community spaces: ${community_id}`);
 		const data = await db.sql<Space[]>`
-      SELECT s.space_id, s.name, s.url, s.media_type, s.content, s.updated, s.created FROM spaces s JOIN community_spaces cs ON s.space_id=cs.space_id AND cs.community_id= ${community_id}
+      SELECT s.space_id, s.name, s.url, s.media_type, s.content, s.updated, s.created FROM spaces s WHERE s.community_id= ${community_id}
     `;
 		// console.log('[db] spaces data', data);
 		return {ok: true, value: data};
@@ -41,7 +41,7 @@ export const spaceRepo = (db: Database) => ({
 			`[spaceRepo] preparing to query for community space by url: ${community_id} ${url}`,
 		);
 		const data = await db.sql<Space[]>`
-			SELECT s.space_id, s.name, s.url, s.media_type, s.content, s.updated, s.created FROM spaces s JOIN community_spaces cs ON s.space_id=cs.space_id AND cs.community_id= ${community_id} AND s.url = ${url}
+			SELECT s.space_id, s.name, s.url, s.media_type, s.content, s.updated, s.created FROM spaces s WHERE s.community_id= ${community_id} AND s.url = ${url}
 		`;
 		console.log('[spaceRepo] space data', data);
 		return {ok: true, value: data[0]};
@@ -54,17 +54,9 @@ export const spaceRepo = (db: Database) => ({
 		community_id,
 	}: CreateSpaceParams): Promise<Result<{value: Space}>> => {
 		const data = await db.sql<Space[]>`
-      INSERT INTO spaces (name, url, media_type, content) VALUES (
-        ${name},${url},${media_type},${content}
+      INSERT INTO spaces (name, url, media_type, content, community_id) VALUES (
+        ${name},${url},${media_type},${content},${community_id}
       ) RETURNING *
-    `;
-		// console.log('[db] created space', data);
-		const space_id: number = data[0].space_id;
-		// TODO more robust error handling or condense into single query
-		await db.sql<any>`
-      INSERT INTO community_spaces (space_id, community_id) VALUES (
-        ${space_id},${community_id}
-      )
     `;
 		// console.log('[db] created communitySpace', communitySpace);
 		return {ok: true, value: data[0]};
@@ -84,18 +76,6 @@ export const spaceRepo = (db: Database) => ({
 	deleteById: async (
 		space_id: number,
 	): Promise<Result<{value: any[]}, {type: 'deletion_error'} & ErrorResponse>> => {
-		const data_cs = await db.sql<any[]>`
-      DELETE FROM community_spaces WHERE ${space_id}=space_id
-    `;
-
-		if (data_cs.count === 0) {
-			return {
-				ok: false,
-				type: 'deletion_error',
-				reason: `There was an issue deleting community_space: ${space_id}`,
-			};
-		}
-
 		const data = await db.sql<any[]>`
       DELETE FROM spaces WHERE ${space_id}=space_id
     `;

--- a/src/lib/vocab/space/spaceServices.test.ts
+++ b/src/lib/vocab/space/spaceServices.test.ts
@@ -17,24 +17,7 @@ test__spaceServices('delete a space in multiple communities', async ({server}) =
 	const random = toRandomVocabContext(server.db);
 	const account = await random.account();
 	const community1 = await random.community();
-	const community2 = await random.community();
-	const community3 = await random.community();
 	const space = await random.space(undefined, account, community1);
-
-	// add the space to other communities
-	// TODO need a repo method for this
-	await server.db.sql<any>`
-    INSERT INTO community_spaces (space_id, community_id) VALUES (
-      ${space.space_id},${community2.community_id}
-	)`;
-	await server.db.sql<any>`
-    INSERT INTO community_spaces (space_id, community_id) VALUES (
-      ${space.space_id},${community3.community_id}
-	)`;
-	let findCommunitySpacesResult = await server.db.sql<any>`
-		SELECT space_id FROM community_spaces WHERE space_id=${space.space_id}
-	`;
-	assert.is(findCommunitySpacesResult.count, 3);
 
 	const deleteResult = await deleteSpaceService.perform({
 		server,
@@ -45,11 +28,6 @@ test__spaceServices('delete a space in multiple communities', async ({server}) =
 
 	const findSpaceResult = await server.db.repos.space.findById(space.space_id);
 	assert.ok(!findSpaceResult.ok);
-
-	findCommunitySpacesResult = await server.db.sql<any>`
-		SELECT space_id FROM community_spaces WHERE space_id=${space.space_id}
-	`;
-	assert.is(findCommunitySpacesResult.count, 0);
 });
 
 test__spaceServices.run();


### PR DESCRIPTION
This PR includes a DB migration that adds a new `community_id` to the `spaces` table, imports the relevant data from the `community_spaces` table to the new column, and then deletes the relational table. I was originally going to leave the table in place for a little bit while we tested things, but the new delete spaces feature broke while it was still in place and I figured the risk of just outright deleting it was low at this point.