### PR TITLE
replace `api` with `dispatch`

### DIFF
--- a/src/lib/app/dispatch.ts
+++ b/src/lib/app/dispatch.ts
@@ -13,9 +13,9 @@ import type {Dispatch} from '$lib/app/eventTypes';
 
 const KEY = Symbol();
 
-export const getApi = (): Api => getContext(KEY);
+export const getDispatch = (): Dispatch => getContext(KEY);
 
-export const setApi = (store: Api): Api => {
+export const setDispatch = (store: Dispatch): Dispatch => {
 	setContext(KEY, store);
 	return store;
 };
@@ -31,31 +31,28 @@ export interface DispatchContext<
 	invoke: TResult extends void ? null : (params?: TParams) => Promise<TResult>;
 }
 
-export interface Api {
-	dispatch: Dispatch;
-}
-
-export const toApi = (ui: Ui, client: ApiClient<EventParamsByName, EventResponseByName>): Api => {
+export const toDispatch = (
+	ui: Ui,
+	client: ApiClient<EventParamsByName, EventResponseByName>,
+): Dispatch => {
 	// TODO delete this and `client2` after adding tests for both the websocket and http clients
-	const api: Api = {
-		// TODO validate the params here to improve UX, but for now we're safe letting the server validate
-		dispatch: (eventName, params) => {
-			console.log(
-				'%c[dispatch.%c' + eventName + '%c]',
-				'color: gray',
-				'color: blue',
-				'color: gray',
-				params === undefined ? '' : params, // print null but not undefined
-			);
-			const ctx: DispatchContext = {
-				eventName,
-				params,
-				dispatch: api.dispatch,
-				client,
-				invoke: client.has(eventName) ? (p = params) => client.invoke(eventName, p) : (null as any), // TODO fix typecast?
-			};
-			return ui.dispatch(ctx);
-		},
+	// TODO validate the params here to improve UX, but for now we're safe letting the server validate
+	const dispatch: Dispatch = (eventName, params) => {
+		console.log(
+			'%c[dispatch.%c' + eventName + '%c]',
+			'color: gray',
+			'color: blue',
+			'color: gray',
+			params === undefined ? '' : params, // print null but not undefined
+		);
+		const ctx: DispatchContext = {
+			eventName,
+			params,
+			dispatch,
+			client,
+			invoke: client.has(eventName) ? (p = params) => client.invoke(eventName, p) : (null as any), // TODO fix typecast?
+		};
+		return ui.dispatch(ctx);
 	};
-	return api;
+	return dispatch;
 };

--- a/src/lib/app/dispatch.ts
+++ b/src/lib/app/dispatch.ts
@@ -35,7 +35,6 @@ export const toDispatch = (
 	ui: Ui,
 	client: ApiClient<EventParamsByName, EventResponseByName>,
 ): Dispatch => {
-	// TODO delete this and `client2` after adding tests for both the websocket and http clients
 	// TODO validate the params here to improve UX, but for now we're safe letting the server validate
 	const dispatch: Dispatch = (eventName, params) => {
 		console.log(

--- a/src/lib/app/eventTypes.gen.ts
+++ b/src/lib/app/eventTypes.gen.ts
@@ -28,7 +28,7 @@ import type {Persona} from '$lib/vocab/persona/persona';
 import type {Membership} from '$lib/vocab/membership/membership';
 import type {Space} from '$lib/vocab/space/space';
 import type {File} from '$lib/vocab/file/file';
-import type {DispatchContext} from '$lib/ui/api';
+import type {DispatchContext} from '$lib/app/dispatch';
 
 export interface EventParamsByName {
 	${eventInfos.reduce(

--- a/src/lib/app/eventTypes.ts
+++ b/src/lib/app/eventTypes.ts
@@ -9,7 +9,7 @@ import type {Persona} from '$lib/vocab/persona/persona';
 import type {Membership} from '$lib/vocab/membership/membership';
 import type {Space} from '$lib/vocab/space/space';
 import type {File} from '$lib/vocab/file/file';
-import type {DispatchContext} from '$lib/ui/api';
+import type {DispatchContext} from '$lib/app/dispatch';
 
 export interface EventParamsByName {
 	log_in: LogInParams;

--- a/src/lib/app/events.test.ts
+++ b/src/lib/app/events.test.ts
@@ -46,7 +46,7 @@ test__eventInfos('dispatch random events in a client app', async ({server, app})
 		}
 
 		// TODO fix typecast with a union for `eventInfo`
-		const result = await app.api.dispatch(eventInfo.name as any, params);
+		const result = await app.dispatch(eventInfo.name as any, params);
 		if (eventInfo.type === 'ClientEvent') {
 			// TODO don't have schemas for `returns` yet, but eventually we'll want them and then validate here
 			if (eventInfo.returns !== 'void') {

--- a/src/lib/ui/Board.svelte
+++ b/src/lib/ui/Board.svelte
@@ -10,7 +10,7 @@
 	import {getApp} from '$lib/ui/app';
 
 	const {
-		api: {dispatch},
+		dispatch,
 		ui: {selectedPersonaId},
 		socket,
 	} = getApp();
@@ -24,9 +24,7 @@
 
 	let text = '';
 
-	// TODO `shouldLoadFiles` should be managed inside the `api` layer
-	// then the code could simply be:
-	// $: files = api.getFilesBySpace(space.space_id);
+	// TODO needs refactoring
 	$: shouldLoadFiles = browser && $socket.connected;
 	$: files = shouldLoadFiles ? dispatch('query_files', {space_id: $space.space_id}) : null;
 

--- a/src/lib/ui/CommunityInput.svelte
+++ b/src/lib/ui/CommunityInput.svelte
@@ -7,7 +7,7 @@
 	import {getApp} from '$lib/ui/app';
 
 	const {
-		api: {dispatch},
+		dispatch,
 		ui: {selectedPersonaId},
 	} = getApp();
 

--- a/src/lib/ui/CommunityNavButton.svelte
+++ b/src/lib/ui/CommunityNavButton.svelte
@@ -9,7 +9,7 @@
 	import {toSpaceUrl} from '$lib/ui/url';
 
 	const {
-		api: {dispatch},
+		dispatch,
 		ui: {selectedSpaceIdByCommunity, findSpaceById, sessionPersonaIndices},
 	} = getApp();
 

--- a/src/lib/ui/Forum.svelte
+++ b/src/lib/ui/Forum.svelte
@@ -10,7 +10,7 @@
 	import {getApp} from '$lib/ui/app';
 
 	const {
-		api: {dispatch},
+		dispatch,
 		ui: {selectedPersonaId},
 		socket,
 	} = getApp();

--- a/src/lib/ui/LoginForm.svelte
+++ b/src/lib/ui/LoginForm.svelte
@@ -7,9 +7,7 @@
 	import {autofocus} from '$lib/ui/actions';
 	import {getApp} from '$lib/ui/app';
 
-	const {
-		api: {dispatch},
-	} = getApp();
+	const {dispatch} = getApp();
 
 	let accountName = '';
 	let password = '';

--- a/src/lib/ui/LogoutForm.svelte
+++ b/src/lib/ui/LogoutForm.svelte
@@ -7,7 +7,7 @@
 	import {getApp} from '$lib/ui/app';
 
 	const {
-		api: {dispatch},
+		dispatch,
 		ui: {selectedPersona},
 	} = getApp();
 

--- a/src/lib/ui/Luggage.svelte
+++ b/src/lib/ui/Luggage.svelte
@@ -1,9 +1,7 @@
 <script lang="ts">
 	import {getApp} from '$lib/ui/app';
 
-	const {
-		api: {dispatch},
-	} = getApp();
+	const {dispatch} = getApp();
 </script>
 
 <div class="luggage">

--- a/src/lib/ui/MainNav.svelte
+++ b/src/lib/ui/MainNav.svelte
@@ -14,7 +14,7 @@
 	import {VITE_GIT_HASH} from '$lib/config';
 
 	const {
-		api: {dispatch},
+		dispatch,
 		ui: {
 			mainNavView,
 			expandMainNav,

--- a/src/lib/ui/MarqueeButton.svelte
+++ b/src/lib/ui/MarqueeButton.svelte
@@ -2,7 +2,7 @@
 	import {getApp} from '$lib/ui/app';
 
 	const {
-		api: {dispatch},
+		dispatch,
 		ui: {expandMarquee},
 	} = getApp();
 

--- a/src/lib/ui/MembershipInputItem.svelte
+++ b/src/lib/ui/MembershipInputItem.svelte
@@ -5,9 +5,7 @@
 	import {getApp} from '$lib/ui/app';
 	import type {Persona} from '$lib/vocab/persona/persona';
 
-	const {
-		api: {dispatch},
-	} = getApp();
+	const {dispatch} = getApp();
 
 	export let persona: Readable<Persona>;
 	export let community: Readable<Community>;

--- a/src/lib/ui/Notes.svelte
+++ b/src/lib/ui/Notes.svelte
@@ -10,7 +10,7 @@
 	import {getApp} from '$lib/ui/app';
 
 	const {
-		api: {dispatch},
+		dispatch,
 		ui: {selectedPersonaId},
 		socket,
 	} = getApp();

--- a/src/lib/ui/PersonaInput.svelte
+++ b/src/lib/ui/PersonaInput.svelte
@@ -5,9 +5,7 @@
 	import {autofocus} from '$lib/ui/actions';
 	import {getApp} from '$lib/ui/app';
 
-	const {
-		api: {dispatch},
-	} = getApp();
+	const {dispatch} = getApp();
 
 	let name = '';
 	let status: AsyncStatus = 'initial'; // TODO refactor

--- a/src/lib/ui/Room.svelte
+++ b/src/lib/ui/Room.svelte
@@ -10,7 +10,7 @@
 	import {getApp} from '$lib/ui/app';
 
 	const {
-		api: {dispatch},
+		dispatch,
 		ui: {selectedPersonaId},
 		socket,
 	} = getApp();

--- a/src/lib/ui/SpaceDelete.svelte
+++ b/src/lib/ui/SpaceDelete.svelte
@@ -5,9 +5,7 @@
 	import {getApp} from '$lib/ui/app';
 	import type {Space} from '$lib/vocab/space/space';
 
-	const {
-		api: {dispatch},
-	} = getApp();
+	const {dispatch} = getApp();
 
 	export let space: Readable<Space>;
 

--- a/src/lib/ui/SpaceInput.svelte
+++ b/src/lib/ui/SpaceInput.svelte
@@ -7,9 +7,7 @@
 	import {getApp} from '$lib/ui/app';
 	import {SpaceType, spaceTypes as allSpaceTypes} from '$lib/vocab/space/space';
 
-	const {
-		api: {dispatch},
-	} = getApp();
+	const {dispatch} = getApp();
 
 	export let community: Readable<Community>;
 

--- a/src/lib/ui/SpaceNavItem.svelte
+++ b/src/lib/ui/SpaceNavItem.svelte
@@ -8,7 +8,7 @@
 	import {getApp} from '$lib/ui/app';
 
 	const {
-		api: {dispatch},
+		dispatch,
 		ui: {mobile, expandMainNav, sessionPersonaIndices},
 	} = getApp();
 

--- a/src/lib/ui/Workspace.svelte
+++ b/src/lib/ui/Workspace.svelte
@@ -7,7 +7,7 @@
 	import {getApp} from '$lib/ui/app';
 
 	const {
-		api: {dispatch},
+		dispatch,
 		ui: {
 			expandMarquee,
 			selectedSpace: selectedSpaceStore,

--- a/src/lib/ui/app.ts
+++ b/src/lib/ui/app.ts
@@ -2,13 +2,13 @@ import {setContext, getContext} from 'svelte';
 import type {Writable} from 'svelte/store';
 
 import type {Ui} from '$lib/ui/ui';
-import type {Api} from '$lib/ui/api';
+import type {Dispatch} from '$lib/app/eventTypes';
 import type {SocketStore} from '$lib/ui/socket';
 
 // TODO refactor/rethink
 
 export interface AppStores {
-	api: Api;
+	dispatch: Dispatch;
 	ui: Ui;
 	socket: SocketStore;
 	devmode: Writable<boolean>;

--- a/src/lib/ui/ui.ts
+++ b/src/lib/ui/ui.ts
@@ -9,7 +9,7 @@ import type {ClientSession} from '$lib/session/clientSession';
 import type {AccountModel} from '$lib/vocab/account/account';
 import type {File} from '$lib/vocab/file/file';
 import type {Membership} from '$lib/vocab/membership/membership';
-import type {DispatchContext} from '$lib/ui/api';
+import type {DispatchContext} from '$lib/app/dispatch';
 import type {UiHandlers} from '$lib/app/eventTypes';
 
 const UNKNOWN_API_ERROR =

--- a/src/lib/util/testAppHelpers.ts
+++ b/src/lib/util/testAppHelpers.ts
@@ -4,7 +4,7 @@ import type {AppStores} from '$lib/ui/app';
 import {toUi} from '$lib/ui/ui';
 import {toHttpApiClient} from '$lib/ui/HttpApiClient';
 import type {EventParamsByName, EventResponseByName} from '$lib/app/eventTypes';
-import {toApi} from '$lib/ui/api';
+import {toDispatch} from '$lib/app/dispatch';
 import {findService} from '$lib/ui/services';
 import type {ClientSession} from '$lib/session/clientSession';
 import {installSourceMaps} from '$lib/util/testHelpers';
@@ -26,7 +26,7 @@ export const setupApp =
 		);
 		context.app = {
 			ui,
-			api: toApi(ui, httpApiClient),
+			dispatch: toDispatch(ui, httpApiClient),
 			devmode: writable(false),
 			// TODO refactor this so the socket isn't an app dependency,
 			// instead the socket should only exist for the websocket client

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -16,7 +16,7 @@
 	import MainNav from '$lib/ui/MainNav.svelte';
 	import Onboard from '$lib/ui/Onboard.svelte';
 	import {setUi, toUi} from '$lib/ui/ui';
-	import {setApi, toApi} from '$lib/ui/api';
+	import {toDispatch} from '$lib/app/dispatch';
 	import {setApp} from '$lib/ui/app';
 	import {randomHue} from '$lib/ui/color';
 	import AccountForm from '$lib/ui/AccountForm.svelte';
@@ -63,15 +63,14 @@
 	);
 	const ui = setUi(toUi(session, initialMobileValue));
 
-	const apiClient = toWebsocketApiClient(findService, socket.send);
+	const apiClient = toWebsocketApiClient(findService, socket.send); // TODO expose on `app`?
 	// alternative http client:
 	// const apiClient = toHttpApiClient(findService);
-	const api = setApi(toApi(ui, apiClient));
-	const app = setApp({ui, api, devmode, socket});
+	const dispatch = toDispatch(ui, apiClient);
+	const app = setApp({dispatch, ui, devmode, socket});
 	browser && console.log('app', app);
 	$: browser && console.log('$session', $session);
 
-	const {dispatch} = api;
 	const {
 		mobile,
 		account,


### PR DESCRIPTION
We had this `api` object wrapper around `dispatch`, but now it's flattened out into the `app`, no more useless `api` wrapper. Mostly simplifies the code.