### PR TITLE
add dialog system

### DIFF
--- a/src/lib/app/ContextmenuSlot.svelte
+++ b/src/lib/app/ContextmenuSlot.svelte
@@ -108,12 +108,6 @@
 		width: 100%;
 	}
 
-	.contextmenu-slot .markup {
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-	}
-
 	.contextmenu-slot > section,
 	.contextmenu-slot > a {
 		border-bottom: var(--border);

--- a/src/lib/app/components.ts
+++ b/src/lib/app/components.ts
@@ -1,0 +1,11 @@
+import ManageMembershipForm from '$lib/ui/ManageMembershipForm.svelte';
+import type {SvelteComponent} from 'svelte';
+
+// The collection of components that can be dynamically mounted by the app.
+
+// TODO refactor this to load these components on demand,
+// instead of preloading the entire component library
+
+export const components: {[key: string]: typeof SvelteComponent} = {
+	ManageMembershipForm,
+};

--- a/src/lib/app/eventTypes.ts
+++ b/src/lib/app/eventTypes.ts
@@ -33,6 +33,7 @@ export interface EventParamsByName {
 	ToggleSecondaryNav: ToggleSecondaryNavParams;
 	SetMobile: SetMobileParams;
 	OpenDialog: OpenDialogParams;
+	CloseDialog: CloseDialogParams;
 	SelectPersona: SelectPersonaParams;
 	SelectCommunity: SelectCommunityParams;
 	SelectSpace: SelectSpaceParams;
@@ -197,7 +198,12 @@ export type SetMobileParams = boolean;
 
 export interface OpenDialogParams {
 	name: string;
+	props?: {
+		[k: string]: unknown;
+	};
 }
+
+export type CloseDialogParams = void;
 
 export interface SelectPersonaParams {
 	persona_id: number;
@@ -249,6 +255,7 @@ export interface Dispatch {
 	(eventName: 'ToggleSecondaryNav', params: ToggleSecondaryNavParams): void;
 	(eventName: 'SetMobile', params: SetMobileParams): void;
 	(eventName: 'OpenDialog', params: OpenDialogParams): void;
+	(eventName: 'CloseDialog', params: CloseDialogParams): void;
 	(eventName: 'SelectPersona', params: SelectPersonaParams): void;
 	(eventName: 'SelectCommunity', params: SelectCommunityParams): void;
 	(eventName: 'SelectSpace', params: SelectSpaceParams): void;
@@ -306,6 +313,7 @@ export interface UiHandlers {
 	ToggleSecondaryNav: (ctx: DispatchContext<ToggleSecondaryNavParams, void>) => void;
 	SetMobile: (ctx: DispatchContext<SetMobileParams, void>) => void;
 	OpenDialog: (ctx: DispatchContext<OpenDialogParams, void>) => void;
+	CloseDialog: (ctx: DispatchContext<CloseDialogParams, void>) => void;
 	SelectPersona: (ctx: DispatchContext<SelectPersonaParams, void>) => void;
 	SelectCommunity: (ctx: DispatchContext<SelectCommunityParams, void>) => void;
 	SelectSpace: (ctx: DispatchContext<SelectSpaceParams, void>) => void;

--- a/src/lib/app/eventTypes.ts
+++ b/src/lib/app/eventTypes.ts
@@ -32,6 +32,7 @@ export interface EventParamsByName {
 	ToggleMainNav: ToggleMainNavParams;
 	ToggleSecondaryNav: ToggleSecondaryNavParams;
 	SetMobile: SetMobileParams;
+	OpenDialog: OpenDialogParams;
 	SelectPersona: SelectPersonaParams;
 	SelectCommunity: SelectCommunityParams;
 	SelectSpace: SelectSpaceParams;
@@ -194,6 +195,10 @@ export type ToggleSecondaryNavParams = void;
 
 export type SetMobileParams = boolean;
 
+export interface OpenDialogParams {
+	name: string;
+}
+
 export interface SelectPersonaParams {
 	persona_id: number;
 }
@@ -243,6 +248,7 @@ export interface Dispatch {
 	(eventName: 'ToggleMainNav', params: ToggleMainNavParams): void;
 	(eventName: 'ToggleSecondaryNav', params: ToggleSecondaryNavParams): void;
 	(eventName: 'SetMobile', params: SetMobileParams): void;
+	(eventName: 'OpenDialog', params: OpenDialogParams): void;
 	(eventName: 'SelectPersona', params: SelectPersonaParams): void;
 	(eventName: 'SelectCommunity', params: SelectCommunityParams): void;
 	(eventName: 'SelectSpace', params: SelectSpaceParams): void;
@@ -299,6 +305,7 @@ export interface UiHandlers {
 	ToggleMainNav: (ctx: DispatchContext<ToggleMainNavParams, void>) => void;
 	ToggleSecondaryNav: (ctx: DispatchContext<ToggleSecondaryNavParams, void>) => void;
 	SetMobile: (ctx: DispatchContext<SetMobileParams, void>) => void;
+	OpenDialog: (ctx: DispatchContext<OpenDialogParams, void>) => void;
 	SelectPersona: (ctx: DispatchContext<SelectPersonaParams, void>) => void;
 	SelectCommunity: (ctx: DispatchContext<SelectCommunityParams, void>) => void;
 	SelectSpace: (ctx: DispatchContext<SelectSpaceParams, void>) => void;

--- a/src/lib/server/random.ts
+++ b/src/lib/server/random.ts
@@ -114,6 +114,9 @@ export const randomEventParams = async (
 		case 'SetMobile': {
 			return randomBool();
 		}
+		case 'OpenDialog': {
+			return {name: 'ManageMembershipForm'};
+		}
 		case 'SelectPersona': {
 			return {
 				persona_id: (randomItem(random.personas) || (await random.persona(account))).persona_id,

--- a/src/lib/server/random.ts
+++ b/src/lib/server/random.ts
@@ -117,6 +117,9 @@ export const randomEventParams = async (
 		case 'OpenDialog': {
 			return {name: 'ManageMembershipForm'};
 		}
+		case 'CloseDialog': {
+			return undefined;
+		}
 		case 'SelectPersona': {
 			return {
 				persona_id: (randomItem(random.personas) || (await random.persona(account))).persona_id,

--- a/src/lib/ui/AccountForm.svelte
+++ b/src/lib/ui/AccountForm.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
 	import LoginForm from '$lib/ui/LoginForm.svelte';
 	import LogoutForm from '$lib/ui/LogoutForm.svelte';
-	import ManageMembershipForm from '$lib/ui/ManageMembershipForm.svelte';
+	import {getApp} from '$lib/ui/app';
+
+	const {dispatch} = getApp();
 
 	export let guest: boolean;
 </script>
@@ -9,6 +11,8 @@
 {#if guest}
 	<LoginForm />
 {:else}
-	<ManageMembershipForm />
+	<button type="button" on:click={() => dispatch('OpenDialog', {name: 'ManageMembershipForm'})}>
+		Manage Memberships
+	</button>
 	<LogoutForm />
 {/if}

--- a/src/lib/ui/ManageMembershipForm.svelte
+++ b/src/lib/ui/ManageMembershipForm.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import {get} from 'svelte/store';
-	import Dialog from '@feltcoop/felt/ui/Dialog.svelte';
 	import type {Community} from '$lib/vocab/community/community';
 
 	import {getApp} from '$lib/ui/app';
@@ -13,7 +12,6 @@
 
 	$: persona = $personaSelection!;
 
-	let opened = false;
 	let errorMessage: string | undefined;
 
 	const getCommunity = (community_id: number): Community =>
@@ -33,45 +31,26 @@
 	};
 </script>
 
-<button
-	aria-label="Delete Space"
-	type="button"
-	class="button-emoji"
-	on:click={() => (opened = true)}
->
-	Manage Memberships
-</button>
-{#if opened}
-	<Dialog on:close={() => (opened = false)}>
-		<div class="markup">
-			<h1>Manage memberships</h1>
-			<div class="avatar"><Avatar name={$persona.name} /></div>
-			<form>
-				<div class:error={!!errorMessage}>{errorMessage || ''}</div>
-				<ul>
-					{#each $persona.community_ids as community_id (community_id)}
-						<li class="community-badge">
-							<button type="button" on:click={() => leaveCommunity(community_id)}>👋 </button>
-							{getCommunity(community_id).name}
-						</li>
-					{/each}
-				</ul>
-			</form>
-		</div>
-	</Dialog>
-{/if}
+<div class="markup">
+	<h1>Manage memberships</h1>
+	<div class="avatar"><Avatar name={$persona.name} /></div>
+	<form>
+		<div class:error={!!errorMessage}>{errorMessage || ''}</div>
+		<ul>
+			{#each $persona.community_ids as community_id (community_id)}
+				<li class="community-badge">
+					<button type="button" on:click={() => leaveCommunity(community_id)}>👋 </button>
+					{getCommunity(community_id).name}
+				</li>
+			{/each}
+		</ul>
+	</form>
+</div>
 
 <style>
 	.error {
 		font-weight: bold;
 		color: rgb(73, 84, 153);
-	}
-	.button-emoji {
-		background: none;
-		border: none;
-		cursor: pointer;
-		margin: 0;
-		word-wrap: break-word;
 	}
 	.community-badge {
 		display: flex;

--- a/src/lib/ui/dialog/Dialogs.svelte
+++ b/src/lib/ui/dialog/Dialogs.svelte
@@ -4,17 +4,20 @@
 
 	import {components} from '$lib/app/components';
 	import type {DialogState} from '$lib/ui/dialog/dialog';
+	import {getApp} from '$lib/ui/app';
 
 	export let dialogs: Readable<DialogState[]>;
+
+	const {dispatch} = getApp();
 
 	let activeDialog: DialogState | undefined;
 	$: activeDialog = $dialogs[$dialogs.length - 1];
 	$: Component = activeDialog && components[activeDialog.name];
-	$: props = {}; // TODO
 </script>
 
 {#if activeDialog}
-	<Dialog>
-		<svelte:component this={Component} {...props} />
+	<!-- TODO should 'CloseDialog' take the dialog object or an id? -->
+	<Dialog on:close={() => dispatch('CloseDialog')}>
+		<svelte:component this={Component} {...activeDialog.props} />
 	</Dialog>
 {/if}

--- a/src/lib/ui/dialog/Dialogs.svelte
+++ b/src/lib/ui/dialog/Dialogs.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import Dialog from '@feltcoop/felt/ui/Dialog.svelte';
+	import type {Readable} from 'svelte/store';
+
+	import {components} from '$lib/app/components';
+	import type {DialogState} from '$lib/ui/dialog/dialog';
+
+	export let dialogs: Readable<DialogState[]>;
+
+	let activeDialog: DialogState | undefined;
+	$: activeDialog = $dialogs[$dialogs.length - 1];
+	$: Component = activeDialog && components[activeDialog.name];
+	$: props = {}; // TODO
+</script>
+
+{#if activeDialog}
+	<Dialog>
+		<svelte:component this={Component} {...props} />
+	</Dialog>
+{/if}

--- a/src/lib/ui/dialog/Dialogs.svelte
+++ b/src/lib/ui/dialog/Dialogs.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import Dialog from '@feltcoop/felt/ui/Dialog.svelte';
+	import Message from '@feltcoop/felt/ui/Message.svelte';
 	import type {Readable} from 'svelte/store';
 
 	import {components} from '$lib/app/components';
@@ -18,6 +19,12 @@
 {#if activeDialog}
 	<!-- TODO should 'CloseDialog' take the dialog object or an id? -->
 	<Dialog on:close={() => dispatch('CloseDialog')}>
-		<svelte:component this={Component} {...activeDialog.props} />
+		{#if Component}
+			<svelte:component this={Component} {...activeDialog.props} />
+		{:else}
+			<div class="markup">
+				<Message status="error">unknown component "{activeDialog.name}"</Message>
+			</div>
+		{/if}
 	</Dialog>
 {/if}

--- a/src/lib/ui/dialog/dialog.ts
+++ b/src/lib/ui/dialog/dialog.ts
@@ -1,4 +1,4 @@
 export interface DialogState {
 	name: string;
-	// TODO attributes/props
+	props?: {[key: string]: any};
 }

--- a/src/lib/ui/dialog/dialog.ts
+++ b/src/lib/ui/dialog/dialog.ts
@@ -1,4 +1,5 @@
 // TODO should this be a Svelte AST? JSON-LD blocks?
+// TODO duplicated from event schema
 export interface DialogState {
 	name: string;
 	props?: {[key: string]: any};

--- a/src/lib/ui/dialog/dialog.ts
+++ b/src/lib/ui/dialog/dialog.ts
@@ -1,3 +1,4 @@
+// TODO should this be a Svelte AST? JSON-LD blocks?
 export interface DialogState {
 	name: string;
 	props?: {[key: string]: any};

--- a/src/lib/ui/dialog/dialog.ts
+++ b/src/lib/ui/dialog/dialog.ts
@@ -1,0 +1,4 @@
+export interface DialogState {
+	name: string;
+	// TODO attributes/props
+}

--- a/src/lib/ui/ui.events.ts
+++ b/src/lib/ui/ui.events.ts
@@ -51,11 +51,17 @@ export const events: EventInfo[] = [
 			type: 'object',
 			properties: {
 				name: {type: 'string'},
-				// TODO props/attributes
+				props: {type: 'object'},
 			},
 			required: ['name'],
 			additionalProperties: false,
 		},
+		returns: 'void',
+	},
+	{
+		type: 'ClientEvent',
+		name: 'CloseDialog',
+		params: null,
 		returns: 'void',
 	},
 	{

--- a/src/lib/ui/ui.events.ts
+++ b/src/lib/ui/ui.events.ts
@@ -45,6 +45,21 @@ export const events: EventInfo[] = [
 	},
 	{
 		type: 'ClientEvent',
+		name: 'OpenDialog',
+		params: {
+			$id: 'https://felt.social/vocab/OpenDialogParams.json',
+			type: 'object',
+			properties: {
+				name: {type: 'string'},
+				// TODO props/attributes
+			},
+			required: ['name'],
+			additionalProperties: false,
+		},
+		returns: 'void',
+	},
+	{
+		type: 'ClientEvent',
 		name: 'SelectPersona',
 		params: {
 			$id: 'https://felt.social/vocab/SelectPersonaParams.json',

--- a/src/lib/ui/ui.ts
+++ b/src/lib/ui/ui.ts
@@ -13,6 +13,7 @@ import type {DispatchContext} from '$lib/app/dispatch';
 import type {UiHandlers} from '$lib/app/eventTypes';
 import type {ContextmenuStore} from '$lib/ui/contextmenu/contextmenu';
 import {createContextmenuStore} from '$lib/ui/contextmenu/contextmenu';
+import type {DialogState} from '$lib/ui/dialog/dialog';
 
 const KEY = Symbol();
 
@@ -56,6 +57,7 @@ export interface Ui extends Partial<UiHandlers> {
 	communitiesByPersonaId: Readable<{[persona_id: number]: Readable<Community>[]}>; // TODO or name `personaCommunities`?
 	mobile: Readable<boolean>;
 	contextmenu: ContextmenuStore;
+	dialogs: Writable<DialogState[]>;
 }
 
 export const toUi = (session: Writable<ClientSession>, initialMobile: boolean): Ui => {
@@ -112,6 +114,7 @@ export const toUi = (session: Writable<ClientSession>, initialMobile: boolean): 
 
 	const mobile = writable(initialMobile);
 	const contextmenu = createContextmenuStore();
+	const dialogs = writable<DialogState[]>([]);
 
 	// derived state
 	// TODO speed up these lookups with id maps
@@ -242,7 +245,7 @@ export const toUi = (session: Writable<ClientSession>, initialMobile: boolean): 
 			if (handler) {
 				return handler(ctx);
 			} else {
-				console.warn('[ui] ignoring a dispatched event', ctx);
+				console.warn('[ui] ignoring unhandled event', ctx);
 			}
 		},
 		Ping: async ({invoke}) => invoke(),
@@ -531,6 +534,7 @@ export const toUi = (session: Writable<ClientSession>, initialMobile: boolean): 
 		expandMainNav,
 		expandMarquee,
 		contextmenu,
+		dialogs,
 		// derived state
 		personaIdSelection,
 		personaSelection,
@@ -544,6 +548,9 @@ export const toUi = (session: Writable<ClientSession>, initialMobile: boolean): 
 		// methods
 		SetMobile: ({params}) => {
 			mobile.set(params);
+		},
+		OpenDialog: ({params}) => {
+			dialogs.update(($dialogs) => $dialogs.concat(params));
 		},
 		SelectPersona: ({params}) => {
 			console.log('[ui.SelectPersona] persona_id', params.persona_id);

--- a/src/lib/ui/ui.ts
+++ b/src/lib/ui/ui.ts
@@ -552,6 +552,9 @@ export const toUi = (session: Writable<ClientSession>, initialMobile: boolean): 
 		OpenDialog: ({params}) => {
 			dialogs.update(($dialogs) => $dialogs.concat(params));
 		},
+		CloseDialog: () => {
+			dialogs.update(($dialogs) => $dialogs.slice(0, $dialogs.length - 1));
+		},
 		SelectPersona: ({params}) => {
 			console.log('[ui.SelectPersona] persona_id', params.persona_id);
 			personaIdSelection.set(params.persona_id);

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -30,6 +30,7 @@
 	import {PERSONA_QUERY_KEY, setUrlPersona} from '$lib/ui/url';
 	import Contextmenu from '$lib/ui/contextmenu/Contextmenu.svelte';
 	import ContextmenuSlot from '$lib/app/ContextmenuSlot.svelte';
+	import Dialogs from '$lib/ui/dialog/Dialogs.svelte';
 
 	let initialMobileValue = false; // TODO this hardcoded value causes mobile view to change on load -- detect for SSR via User-Agent?
 	const MOBILE_WIDTH = '50rem'; // treats anything less than 800px width as mobile
@@ -80,6 +81,7 @@
 	const {
 		mobile,
 		contextmenu,
+		dialogs,
 		account,
 		sessionPersonas,
 		communities,
@@ -223,6 +225,7 @@
 		{/if}
 	</main>
 	<Devmode {devmode} />
+	<Dialogs {dialogs} />
 	<Contextmenu {contextmenu}>
 		<ContextmenuSlot {contextmenu} {devmode} />
 	</Contextmenu>


### PR DESCRIPTION
Adds the simplest dialog system I could think of. The motivation is to be able to open dialogs without requiring the triggering component to remain mounted. Currently we have a contextmenu button that tries to open a dialog, but it fails because when the contextmenu closes, so does its child dialog component. 

As a side effect, we'll now be able to drive dialogs throughout the whole system programmatically like any other event. (e.g. so we could use it to build a tutorial system and user macros/automations)

Uses two new events, `'OpenDialog'` and `'CloseDialog'`. I implemented it for only one existing dialog, the `ManageMembershipsForm`, because it's currently broken. 

Might want to rename the `DialogState` interface. I kept it intentionally simple so there's no wrapper store or class, but I think we'll need features that increase complexity.

Next steps:

- change the other dialogs to use this system (will inform more of the following questions)
- API for `'CloseDialog'` -- should it send the entire object? An ID?
- types for component names
- how to handle return values (Picker usecase)
- what JSON data structure should we be using? Svelte AST or JSON-LD? dynamically load components? move from an import to context?
- should it interact with the URL nav at all? currently it is completely separate

