### PR TITLE
refactor dialog components

### DIFF
--- a/src/lib/app/components.ts
+++ b/src/lib/app/components.ts
@@ -1,4 +1,8 @@
 import ManageMembershipForm from '$lib/ui/ManageMembershipForm.svelte';
+import CommunityInput from '$lib/ui/CommunityInput.svelte';
+import MembershipInput from '$lib/ui/MembershipInput.svelte';
+import SpaceDelete from '$lib/ui/SpaceDelete.svelte';
+import SpaceInput from '$lib/ui/SpaceInput.svelte';
 import type {SvelteComponent} from 'svelte';
 
 // The collection of components that can be dynamically mounted by the app.
@@ -8,4 +12,8 @@ import type {SvelteComponent} from 'svelte';
 
 export const components: {[key: string]: typeof SvelteComponent} = {
 	ManageMembershipForm,
+	CommunityInput,
+	MembershipInput,
+	SpaceDelete,
+	SpaceInput,
 };

--- a/src/lib/ui/CommunityInput.svelte
+++ b/src/lib/ui/CommunityInput.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import Dialog from '@feltcoop/felt/ui/Dialog.svelte';
 	import PendingButton from '@feltcoop/felt/ui/PendingButton.svelte';
 	import Message from '@feltcoop/felt/ui/Message.svelte';
 	import type {Readable} from 'svelte/store';
@@ -14,7 +13,6 @@
 
 	export let persona: Readable<Persona>;
 
-	let opened = false;
 	let name = '';
 	let pending = false;
 	let errorMessage: string | null = null;
@@ -38,44 +36,24 @@
 	};
 </script>
 
-<!--TODO: Make an IconButton component in felt and use it here-->
-<button
-	aria-label="Create Community"
-	type="button"
-	class="button-emoji"
-	on:click={() => (opened = true)}
->
-	➕
-</button>
-{#if opened}
-	<Dialog on:close={() => (opened = false)}>
-		<div class="markup">
-			<h1>Create a new community</h1>
-			<section>
-				<!-- TODO likely make this a `select` or picker -->
-				<Avatar name={toName($persona)} icon={toIcon($persona)} />
-			</section>
-			<form>
-				<input placeholder="> name" on:keydown={onKeydown} bind:value={name} use:autofocus />
-				<PendingButton type="button" on:click={() => create()} {pending}>
-					Create community
-				</PendingButton>
-			</form>
-			{#if errorMessage}
-				<Message status="error">{errorMessage}</Message>
-			{/if}
-		</div>
-	</Dialog>
-{/if}
+<div class="markup">
+	<h1>Create a new community</h1>
+	<section>
+		<!-- TODO likely make this a `select` or picker -->
+		<Avatar name={toName($persona)} icon={toIcon($persona)} />
+	</section>
+	<form>
+		<input placeholder="> name" on:keydown={onKeydown} bind:value={name} use:autofocus />
+		<PendingButton type="button" on:click={() => create()} {pending}>
+			Create community
+		</PendingButton>
+	</form>
+	{#if errorMessage}
+		<Message status="error">{errorMessage}</Message>
+	{/if}
+</div>
 
 <style>
-	.button-emoji {
-		background: none;
-		border: none;
-		cursor: pointer;
-		margin: 0;
-		word-wrap: break-word;
-	}
 	section {
 		display: flex;
 		flex-direction: column;

--- a/src/lib/ui/CommunityNav.svelte
+++ b/src/lib/ui/CommunityNav.svelte
@@ -3,12 +3,12 @@
 	import type {Readable} from 'svelte/store';
 
 	import type {Community} from '$lib/vocab/community/community.js';
-	import CommunityInput from '$lib/ui/CommunityInput.svelte';
 	import CommunityNavButton from '$lib/ui/CommunityNavButton.svelte';
 	import type {Persona} from '$lib/vocab/persona/persona';
 	import {getApp} from '$lib/ui/app';
 
 	const {
+		dispatch,
 		ui: {sessionPersonas, personaSelection, communitySelection, communitiesByPersonaId},
 	} = getApp();
 
@@ -22,7 +22,14 @@
 
 <div class="community-nav">
 	<div class="header">
-		<CommunityInput persona={selectedPersona} />
+		<button
+			aria-label="Create Community"
+			type="button"
+			on:click={() =>
+				dispatch('OpenDialog', {name: 'CommunityInput', props: {persona: selectedPersona}})}
+		>
+			➕
+		</button>
 	</div>
 	<!-- TODO maybe refactor this to be nested elements instead of a flat list -->
 	<div>

--- a/src/lib/ui/MembershipInput.svelte
+++ b/src/lib/ui/MembershipInput.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import Dialog from '@feltcoop/felt/ui/Dialog.svelte';
 	import {get} from 'svelte/store';
 	import type {Readable} from 'svelte/store';
 
@@ -13,8 +12,6 @@
 
 	export let community: Readable<Community>;
 
-	let opened = false;
-
 	// TODO speed this up with a better cached data structures; the use of `get` is particularly bad
 	$: invitableMembers = $community
 		? $personas.filter(
@@ -23,34 +20,11 @@
 		: [];
 </script>
 
-<!--TODO: Make an IconButton component in felt and use it here-->
-<button
-	aria-label="Invite users to {$community.name}"
-	type="button"
-	class="button-emoji"
-	on:click={() => (opened = true)}
->
-	✉️
-</button>
-{#if opened}
-	<Dialog on:close={() => (opened = false)}>
-		<div class="markup">
-			<h1>Invite users to {$community.name}</h1>
-			{#each invitableMembers as persona (persona)}
-				<MembershipInputItem {persona} {community} />
-			{:else}
-				<p>There's no one new to invite</p>
-			{/each}
-		</div>
-	</Dialog>
-{/if}
-
-<style>
-	.button-emoji {
-		background: none;
-		border: none;
-		cursor: pointer;
-		margin: 0;
-		word-wrap: break-word;
-	}
-</style>
+<div class="markup">
+	<h1>Invite users to {$community.name}</h1>
+	{#each invitableMembers as persona (persona)}
+		<MembershipInputItem {persona} {community} />
+	{:else}
+		<p>There's no one new to invite</p>
+	{/each}
+</div>

--- a/src/lib/ui/SpaceDelete.svelte
+++ b/src/lib/ui/SpaceDelete.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import Dialog from '@feltcoop/felt/ui/Dialog.svelte';
 	import type {Readable} from 'svelte/store';
 
 	import {getApp} from '$lib/ui/app';
@@ -9,7 +8,6 @@
 
 	export let space: Readable<Space>;
 
-	let opened = false;
 	let errorMessage: string | undefined;
 
 	const deleteSpace = async () => {
@@ -32,36 +30,17 @@
 	};
 </script>
 
-<button
-	aria-label="Delete Space"
-	type="button"
-	class="button-emoji"
-	on:click={() => (opened = true)}
->
-	🗑️
-</button>
-{#if opened}
-	<Dialog on:close={() => (opened = false)}>
-		<div class="markup">
-			<h1>Delete {$space.name} space?</h1>
-			<form>
-				<div class:error={!!errorMessage}>{errorMessage || ''}</div>
-				<button type="button" on:click={deleteSpace} on:keydown={onKeydown}> Delete space </button>
-			</form>
-		</div>
-	</Dialog>
-{/if}
+<div class="markup">
+	<h1>Delete {$space.name} space?</h1>
+	<form>
+		<div class:error={!!errorMessage}>{errorMessage || ''}</div>
+		<button type="button" on:click={deleteSpace} on:keydown={onKeydown}> Delete space </button>
+	</form>
+</div>
 
 <style>
 	.error {
 		font-weight: bold;
 		color: rgb(73, 84, 153);
-	}
-	.button-emoji {
-		background: none;
-		border: none;
-		cursor: pointer;
-		margin: 0;
-		word-wrap: break-word;
 	}
 </style>

--- a/src/lib/ui/SpaceInput.svelte
+++ b/src/lib/ui/SpaceInput.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import Dialog from '@feltcoop/felt/ui/Dialog.svelte';
 	import type {Readable} from 'svelte/store';
 
 	import type {Community} from '$lib/vocab/community/community.js';
@@ -18,7 +17,6 @@
 	// TODO instead of filtering here, this perhaps should be determined by metadata on space types
 	const ViewTypes = allViewTypes.filter((s) => s !== ViewType.Home);
 
-	let opened = false;
 	let newName = '';
 	let newType = ViewTypes[0];
 	let nameEl: HTMLInputElement;
@@ -58,57 +56,38 @@
 	};
 </script>
 
-<button
-	aria-label="Create Space"
-	type="button"
-	class="button-emoji"
-	on:click={() => (opened = true)}
->
-	➕
-</button>
-{#if opened}
-	<Dialog on:close={() => (opened = false)}>
-		<div class="markup">
-			<h1>Create a new space</h1>
-			<section>
-				<!-- TODO likely make these a `select` or picker -->
-				<Avatar name={toName($persona)} icon={toIcon($persona)} />
-				<Avatar name={$community.name} type="Community" />
-			</section>
-			<form>
-				<div class:error={!!errorMessage}>{errorMessage || ''}</div>
-				<input
-					placeholder="> name"
-					bind:value={newName}
-					use:autofocus
-					bind:this={nameEl}
-					on:keydown={onKeydown}
-				/>
-				<label>
-					Select Type:
-					<select class="type-selector" bind:value={newType}>
-						{#each ViewTypes as type (type)}
-							<option value={type}>{type}</option>
-						{/each}
-					</select>
-				</label>
-				<button type="button" on:click={create}> Create space </button>
-			</form>
-		</div>
-	</Dialog>
-{/if}
+<div class="markup">
+	<h1>Create a new space</h1>
+	<section>
+		<!-- TODO likely make these a `select` or picker -->
+		<Avatar name={toName($persona)} icon={toIcon($persona)} />
+		<Avatar name={$community.name} type="Community" />
+	</section>
+	<form>
+		<div class:error={!!errorMessage}>{errorMessage || ''}</div>
+		<input
+			placeholder="> name"
+			bind:value={newName}
+			use:autofocus
+			bind:this={nameEl}
+			on:keydown={onKeydown}
+		/>
+		<label>
+			Select Type:
+			<select class="type-selector" bind:value={newType}>
+				{#each ViewTypes as type (type)}
+					<option value={type}>{type}</option>
+				{/each}
+			</select>
+		</label>
+		<button type="button" on:click={create}> Create space </button>
+	</form>
+</div>
 
 <style>
 	.error {
 		font-weight: bold;
 		color: rgb(73, 84, 153);
-	}
-	.button-emoji {
-		background: none;
-		border: none;
-		cursor: pointer;
-		margin: 0;
-		word-wrap: break-word;
 	}
 	.type-selector {
 		margin-left: var(--spacing_xs);

--- a/src/lib/ui/SpaceNav.svelte
+++ b/src/lib/ui/SpaceNav.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
 	import type {Space} from '$lib/vocab/space/space.js';
-	import SpaceInput from '$lib/ui/SpaceInput.svelte';
-	import SpaceDelete from '$lib/ui/SpaceDelete.svelte';
 	import type {Community} from '$lib/vocab/community/community.js';
-	import MembershipInput from '$lib/ui/MembershipInput.svelte';
 	import type {Readable} from 'svelte/store';
 	import SpaceNavItem from '$lib/ui/SpaceNavItem.svelte';
 	import type {Persona} from '$lib/vocab/persona/persona.js';
+	import {getApp} from '$lib/ui/app';
+
+	const {dispatch} = getApp();
 
 	export let persona: Readable<Persona>;
 	export let community: Readable<Community>;
@@ -16,9 +16,27 @@
 
 <div class="space-nav" data-entity="community:{$community.name}">
 	<div class="header">
-		<SpaceInput {persona} {community} />
-		<MembershipInput {community} />
-		<SpaceDelete space={selectedSpace} />
+		<button
+			aria-label="Create Space"
+			type="button"
+			on:click={() => dispatch('OpenDialog', {name: 'SpaceInput', props: {persona, community}})}
+		>
+			➕
+		</button>
+		<button
+			aria-label="Invite users to {$community.name}"
+			type="button"
+			on:click={() => dispatch('OpenDialog', {name: 'MembershipInput', props: {community}})}
+		>
+			✉️
+		</button>
+		<button
+			aria-label="Delete Space"
+			type="button"
+			on:click={() => dispatch('OpenDialog', {name: 'SpaceDelete', props: {space: selectedSpace}})}
+		>
+			🗑️
+		</button>
 	</div>
 	<!-- TODO the community url -->
 	{#each spaces as space (space.space_id)}


### PR DESCRIPTION
Continues the work in #209, using the new `'OpenDialog'` event in the 4 other places we used dialogs.

There's one issue to fix, closing the dialogs when the component is "done". A quick hack would be to dispatch `'CloseDialog'` but the components shouldn't have any knowledge that they're in a dialog. Might be worth considering if future `Picker` component behavior will need something similar.