### PR TITLE
Add types to entities

### DIFF
--- a/src/lib/app/eventTypes.ts
+++ b/src/lib/app/eventTypes.ts
@@ -168,6 +168,7 @@ export interface CreateEntityParams {
 	actor_id: number;
 	space_id: number;
 	content: string;
+	type: string;
 }
 export interface CreateEntityResponse {
 	entity: Entity;

--- a/src/lib/db/migrations/00009-add-type-to-entities.js
+++ b/src/lib/db/migrations/00009-add-type-to-entities.js
@@ -1,0 +1,8 @@
+/** @param {import('postgres').Sql<any>} sql */
+export const up = async (sql) => {
+	await sql`
+		ALTER TABLE entities
+			ADD COLUMN type VARCHAR(50)
+			NOT NULL DEFAULT 'Message';
+	`;
+};

--- a/src/lib/db/repos.test.ts
+++ b/src/lib/db/repos.test.ts
@@ -99,11 +99,12 @@ test__repos('create, change, and delete some data from repos', async ({server}) 
 
 	const entityContent1 = 'this is entity 1';
 	const entityContent2 = 'entity: 2';
+	const entityType = 'Message';
 	const entity1 = await unwrapEntity(
-		server.db.repos.entity.create(persona.persona_id, space.space_id, entityContent1),
+		server.db.repos.entity.create(persona.persona_id, space.space_id, entityContent1, entityType),
 	);
 	const entity2 = await unwrapEntity(
-		server.db.repos.entity.create(persona.persona_id, space.space_id, entityContent2),
+		server.db.repos.entity.create(persona.persona_id, space.space_id, entityContent2, entityType),
 	);
 
 	// do queries

--- a/src/lib/ui/Board.svelte
+++ b/src/lib/ui/Board.svelte
@@ -30,6 +30,7 @@
 			space_id: $space.space_id,
 			content,
 			actor_id: $persona.persona_id,
+			type: 'Message',
 		});
 		text = '';
 	};

--- a/src/lib/ui/ForumItem.svelte
+++ b/src/lib/ui/ForumItem.svelte
@@ -12,14 +12,20 @@
 	} = getApp();
 
 	export let entity: Readable<Entity>;
+	export let selectThread: (thread: Readable<Entity>) => void;
 
 	$: persona = findPersonaById($entity.actor_id); // TODO should this be `Actor` and `actor`?
 
 	// TODO refactor to some client view-model for the actor
 	$: hue = randomHue($persona.name);
+
+	const selectThreadLocal = async () => {
+		selectThread(entity);
+	};
 </script>
 
 <li
+	on:click={selectThreadLocal}
 	style="--hue: {hue}"
 	use:contextmenu.action={{
 		PersonaContextmenu: persona,

--- a/src/lib/ui/ForumItems.svelte
+++ b/src/lib/ui/ForumItems.svelte
@@ -6,12 +6,13 @@
 
 	// TODO this should possibly be a generic component instead of this named one
 
-	export let entities: Readable<Readable<Entity>[]>;
+	export let entities: Readable<Entity>[];
+	export let selectThread: (thread: Readable<Entity>) => void;
 </script>
 
 <!-- TODO possibly remove the `ul` wrapper and change the `li`s to `div`s -->
 <ul>
-	{#each $entities as entity (entity)}
-		<ForumItem {entity} />
+	{#each entities as entity (entity)}
+		<ForumItem {entity} {selectThread} />
 	{/each}
 </ul>

--- a/src/lib/ui/Notes.svelte
+++ b/src/lib/ui/Notes.svelte
@@ -30,6 +30,7 @@
 			space_id: $space.space_id,
 			content,
 			actor_id: $persona.persona_id,
+			type: 'Message',
 		});
 		text = '';
 	};

--- a/src/lib/ui/Room.svelte
+++ b/src/lib/ui/Room.svelte
@@ -30,6 +30,7 @@
 			space_id: $space.space_id,
 			content,
 			actor_id: $persona.persona_id,
+			type: 'Message',
 		});
 		text = '';
 	};

--- a/src/lib/vocab/entity/entity.events.ts
+++ b/src/lib/vocab/entity/entity.events.ts
@@ -10,8 +10,9 @@ export const CreateEntity: ServiceEventInfo = {
 			actor_id: {type: 'number'},
 			space_id: {type: 'number'},
 			content: {type: 'string'},
+			type: {type: 'string'},
 		},
-		required: ['actor_id', 'space_id', 'content'],
+		required: ['actor_id', 'space_id', 'content', 'type'],
 		additionalProperties: false,
 	},
 	response: {

--- a/src/lib/vocab/entity/entity.ts
+++ b/src/lib/vocab/entity/entity.ts
@@ -5,6 +5,7 @@ export interface Entity {
 	actor_id: number;
 	space_id: number;
 	content: string;
+	type: string;
 	created: Date;
 	updated: Date | null;
 }
@@ -16,10 +17,11 @@ export const EntitySchema = {
 		actor_id: {type: 'number'},
 		space_id: {type: 'number'},
 		content: {type: 'string'},
+		type: {type: 'string'},
 		created: {type: 'object', format: 'date-time', tsType: 'Date'},
 		updated: {type: ['object', 'null'], format: 'date-time', tsType: 'Date | null'},
 	},
-	required: ['entity_id', 'actor_id', 'space_id', 'content', 'created', 'updated'],
+	required: ['entity_id', 'actor_id', 'space_id', 'content', 'type', 'created', 'updated'],
 	additionalProperties: false,
 };
 

--- a/src/lib/vocab/entity/entityRepo.ts
+++ b/src/lib/vocab/entity/entityRepo.ts
@@ -8,10 +8,11 @@ export const entityRepo = (db: Database) => ({
 		actor_id: number,
 		space_id: number,
 		content: string,
+		type: string,
 	): Promise<Result<{value: Entity}>> => {
 		const data = await db.sql<Entity[]>`
-			INSERT INTO entities (actor_id, space_id, content) VALUES (
-				${actor_id},${space_id},${content}
+			INSERT INTO entities (actor_id, space_id, content, type) VALUES (
+				${actor_id},${space_id},${content},${type}
 			) RETURNING *
 		`;
 		// console.log('[db] create entity', data);

--- a/src/lib/vocab/entity/entityRepo.ts
+++ b/src/lib/vocab/entity/entityRepo.ts
@@ -21,7 +21,7 @@ export const entityRepo = (db: Database) => ({
 	filterBySpace: async (space_id: number): Promise<Result<{value: Entity[]}>> => {
 		console.log(`[db] preparing to query for space entities: ${space_id}`);
 		const data = await db.sql<Entity[]>`
-			SELECT entity_id, content, actor_id, space_id, created, updated 
+			SELECT entity_id, content, type, actor_id, space_id, created, updated 
 			FROM entities WHERE space_id= ${space_id}
 		`;
 		console.log('[db] space entities', data);

--- a/src/lib/vocab/entity/entityServices.ts
+++ b/src/lib/vocab/entity/entityServices.ts
@@ -31,6 +31,7 @@ export const createEntityService: Service<CreateEntityParams, CreateEntityRespon
 			params.actor_id,
 			params.space_id,
 			params.content,
+			params.type,
 		);
 		if (insertEntitiesResult.ok) {
 			return {ok: true, status: 200, value: {entity: insertEntitiesResult.value}}; // TODO API types

--- a/src/lib/vocab/random.ts
+++ b/src/lib/vocab/random.ts
@@ -56,6 +56,7 @@ export const randomEntityParams = (actor_id: number, space_id: number): CreateEn
 	actor_id,
 	space_id,
 	content: randomContent(),
+	type: 'Message',
 });
 
 // TODO maybe compute in relation to `RandomVocabContext`


### PR DESCRIPTION
This is a draft PR for a proof-of-concept implementing a forum feature utilizing our current architecture.

From the last PR
Things to discuss/iterate/brainstorm:
1.) Data model of Entity (i.e. added a Type attribute, should content just be JSON?)
`We chatted about this and seemed to agree on both, I think?`
2.) Schemas for Entity content
3.) Dynamic querying by space, id set, and/or type
4.) Better caching system for QueryEntities event
`Punting on 3/4 & for now fetch the world is an acceptable solution`
5.) How to do URL nav & grabbing for stuff
6.) How to handle entity (thread) selection/deselection. Generic system or on a View by View basis?