### PR TITLE
fix text overflow in messages

### DIFF
--- a/src/lib/app/contextmenu/LinkContextmenu.svelte
+++ b/src/lib/app/contextmenu/LinkContextmenu.svelte
@@ -24,7 +24,7 @@
 <!-- TODO if it's an external link, add target="_blank" -->
 <a href={value}>
 	<span class="icon">🔗</span>
-	{formatUrl(value)}
+	<span class="text">{formatUrl(value)}</span>
 </a>
 
 <style>
@@ -32,11 +32,15 @@
 		display: flex;
 		align-items: center;
 		width: 100%;
-		word-break: break-all;
 	}
 	.icon {
 		display: flex;
 		font-size: var(--icon_size_sm);
 		padding: var(--spacing_sm);
+	}
+	.text {
+		padding: var(--spacing_sm) var(--spacing_sm) var(--spacing_sm) 0;
+		overflow: hidden;
+		overflow-wrap: break-word;
 	}
 </style>

--- a/src/lib/app/contextmenu/LinkContextmenu.svelte
+++ b/src/lib/app/contextmenu/LinkContextmenu.svelte
@@ -32,14 +32,14 @@
 		display: flex;
 		align-items: center;
 		width: 100%;
+		padding: var(--spacing_sm);
 	}
 	.icon {
 		display: flex;
 		font-size: var(--icon_size_sm);
-		padding: var(--spacing_sm);
 	}
 	.text {
-		padding: var(--spacing_sm) var(--spacing_sm) var(--spacing_sm) 0;
+		padding-left: var(--spacing_sm);
 		overflow: hidden;
 		overflow-wrap: break-word;
 	}

--- a/src/lib/app/contextmenu/LinkContextmenu.svelte
+++ b/src/lib/app/contextmenu/LinkContextmenu.svelte
@@ -32,7 +32,7 @@
 		display: flex;
 		align-items: center;
 		width: 100%;
-		word-break: break-word;
+		word-break: break-all;
 	}
 	.icon {
 		display: flex;

--- a/src/lib/ui/Avatar.svelte
+++ b/src/lib/ui/Avatar.svelte
@@ -18,7 +18,7 @@
 		<EntityIcon {name} {icon} {type} />
 	{/if}
 	{#if showName}
-		<span class="actor" class:spaced={showIcon}>{name}</span>
+		<span class="actor" class:has-icon={showIcon}>{name}</span>
 	{/if}
 </div>
 
@@ -30,7 +30,7 @@
 	.actor {
 		font-weight: var(--font_weight_4);
 	}
-	.spaced {
+	.has-icon {
 		padding-left: var(--spacing_sm);
 	}
 </style>

--- a/src/lib/ui/Avatar.svelte
+++ b/src/lib/ui/Avatar.svelte
@@ -17,11 +17,8 @@
 	{#if showIcon}
 		<EntityIcon {name} {icon} {type} />
 	{/if}
-	{#if showIcon && showName}
-		<span class="spacer" />
-	{/if}
 	{#if showName}
-		<span class="actor">{name}</span>
+		<span class="actor" class:spaced={showIcon}>{name}</span>
 	{/if}
 </div>
 
@@ -30,10 +27,10 @@
 		display: flex;
 		align-items: center;
 	}
-	.spacer {
-		padding-left: var(--spacing_md);
-	}
 	.actor {
 		font-weight: var(--font_weight_4);
+	}
+	.spaced {
+		padding-left: var(--spacing_sm);
 	}
 </style>

--- a/src/lib/ui/Avatar.svelte
+++ b/src/lib/ui/Avatar.svelte
@@ -17,6 +17,9 @@
 	{#if showIcon}
 		<EntityIcon {name} {icon} {type} />
 	{/if}
+	{#if showIcon && showName}
+		<span class="spacer" />
+	{/if}
 	{#if showName}
 		<span class="actor">{name}</span>
 	{/if}
@@ -27,8 +30,10 @@
 		display: flex;
 		align-items: center;
 	}
-	.actor {
+	.spacer {
 		padding-left: var(--spacing_md);
+	}
+	.actor {
 		font-weight: var(--font_weight_4);
 	}
 </style>

--- a/src/lib/ui/BoardItem.svelte
+++ b/src/lib/ui/BoardItem.svelte
@@ -43,9 +43,9 @@
 	}
 	.markup {
 		padding: var(--spacing_sm);
-		/* force wrap long strings of text */
+		/* wrap long strings of text */
 		overflow: hidden;
-		/* remove this line when `break-spaces` is supported by Firefox Android:
+		/* TODO remove this line when `break-spaces` is supported by Firefox Android:
 		https://caniuse.com/mdn-css_properties_white-space_break-spaces */
 		white-space: pre-wrap;
 		white-space: break-spaces;

--- a/src/lib/ui/BoardItem.svelte
+++ b/src/lib/ui/BoardItem.svelte
@@ -26,7 +26,7 @@
 		EntityContextmenu: $entity.entity_id,
 	}}
 >
-	<div class="markup">
+	<div class="markup formatted">
 		<p>
 			{$entity.content}
 		</p>
@@ -43,11 +43,5 @@
 	}
 	.markup {
 		padding: var(--spacing_sm);
-		/* wrap long strings of text */
-		overflow: hidden;
-		/* TODO remove this line when `break-spaces` is supported by Firefox Android:
-		https://caniuse.com/mdn-css_properties_white-space_break-spaces */
-		white-space: pre-wrap;
-		white-space: break-spaces;
 	}
 </style>

--- a/src/lib/ui/BoardItem.svelte
+++ b/src/lib/ui/BoardItem.svelte
@@ -41,4 +41,9 @@
 		background-color: hsl(var(--hue), var(--bg_saturation), calc(var(--bg_color_lightness)));
 		flex-direction: column;
 	}
+	.markup {
+		padding: var(--spacing_sm);
+		/* force wrap long strings of text like links */
+		word-break: break-all;
+	}
 </style>

--- a/src/lib/ui/BoardItem.svelte
+++ b/src/lib/ui/BoardItem.svelte
@@ -43,7 +43,11 @@
 	}
 	.markup {
 		padding: var(--spacing_sm);
-		/* force wrap long strings of text like links */
-		word-break: break-all;
+		/* force wrap long strings of text */
+		overflow: hidden;
+		/* remove this line when `break-spaces` is supported by Firefox Android:
+		https://caniuse.com/mdn-css_properties_white-space_break-spaces */
+		white-space: pre-wrap;
+		white-space: break-spaces;
 	}
 </style>

--- a/src/lib/ui/ForumItem.svelte
+++ b/src/lib/ui/ForumItem.svelte
@@ -28,7 +28,7 @@
 >
 	<!-- TODO markup needs to be used for `overflow-wrap: break-word;` but fix padding,
 	and also fix the icon being to the side -->
-	<div class="markup">
+	<div class="markup formatted">
 		{$entity.content}
 	</div>
 	<Avatar name={toName($persona)} icon={toIcon($persona)} />
@@ -46,11 +46,5 @@
 	.markup {
 		font-size: var(--font_size_lg);
 		padding: 0 0 0 var(--spacing_md);
-		/* wrap long strings of text */
-		overflow: hidden;
-		/* TODO remove this line when `break-spaces` is supported by FF Android:
-		https://caniuse.com/mdn-css_properties_white-space_break-spaces */
-		white-space: pre-wrap;
-		white-space: break-spaces;
 	}
 </style>

--- a/src/lib/ui/ForumItem.svelte
+++ b/src/lib/ui/ForumItem.svelte
@@ -26,7 +26,9 @@
 		EntityContextmenu: $entity.entity_id,
 	}}
 >
-	<div class="content">
+	<!-- TODO markup needs to be used for `overflow-wrap: break-word;` but fix padding,
+	and also fix the icon being to the side -->
+	<div class="markup">
 		{$entity.content}
 	</div>
 	<Avatar name={toName($persona)} icon={toIcon($persona)} />
@@ -40,7 +42,11 @@
 		background-color: hsl(var(--hue), var(--bg_saturation), calc(var(--bg_color_lightness)));
 		flex-direction: column;
 	}
-	.content {
+
+	.markup {
 		font-size: var(--font_size_lg);
+		padding: 0 0 0 var(--spacing_md);
+		/* force wrap long strings of text like links */
+		word-break: break-all;
 	}
 </style>

--- a/src/lib/ui/ForumItem.svelte
+++ b/src/lib/ui/ForumItem.svelte
@@ -26,8 +26,6 @@
 		EntityContextmenu: $entity.entity_id,
 	}}
 >
-	<!-- TODO markup needs to be used for `overflow-wrap: break-word;` but fix padding,
-	and also fix the icon being to the side -->
 	<div class="markup formatted">
 		{$entity.content}
 	</div>

--- a/src/lib/ui/ForumItem.svelte
+++ b/src/lib/ui/ForumItem.svelte
@@ -46,7 +46,11 @@
 	.markup {
 		font-size: var(--font_size_lg);
 		padding: 0 0 0 var(--spacing_md);
-		/* force wrap long strings of text like links */
-		word-break: break-all;
+		/* force wrap long strings of text */
+		overflow: hidden;
+		/* remove this line when `break-spaces` is supported by FF Android:
+		https://caniuse.com/mdn-css_properties_white-space_break-spaces */
+		white-space: pre-wrap;
+		white-space: break-spaces;
 	}
 </style>

--- a/src/lib/ui/ForumItem.svelte
+++ b/src/lib/ui/ForumItem.svelte
@@ -46,9 +46,9 @@
 	.markup {
 		font-size: var(--font_size_lg);
 		padding: 0 0 0 var(--spacing_md);
-		/* force wrap long strings of text */
+		/* wrap long strings of text */
 		overflow: hidden;
-		/* remove this line when `break-spaces` is supported by FF Android:
+		/* TODO remove this line when `break-spaces` is supported by FF Android:
 		https://caniuse.com/mdn-css_properties_white-space_break-spaces */
 		white-space: pre-wrap;
 		white-space: break-spaces;

--- a/src/lib/ui/NotesItem.svelte
+++ b/src/lib/ui/NotesItem.svelte
@@ -19,7 +19,7 @@
 		EntityContextmenu: $entity.entity_id,
 	}}
 >
-	<div class="markup">
+	<div class="markup formatted">
 		{$entity.content}
 	</div>
 </li>
@@ -31,14 +31,5 @@
 		max-width: var(--column_width_min);
 		margin: 10px;
 		background-color: var(--input_bg_color);
-	}
-
-	.markup {
-		/* wrap long strings of text */
-		overflow: hidden;
-		/* TODO remove this line when `break-spaces` is supported by Firefox Android:
-		https://caniuse.com/mdn-css_properties_white-space_break-spaces */
-		white-space: pre-wrap;
-		white-space: break-spaces;
 	}
 </style>

--- a/src/lib/ui/NotesItem.svelte
+++ b/src/lib/ui/NotesItem.svelte
@@ -34,9 +34,9 @@
 	}
 
 	.markup {
-		/* force wrap long strings of text */
+		/* wrap long strings of text */
 		overflow: hidden;
-		/* remove this line when `break-spaces` is supported by Firefox Android:
+		/* TODO remove this line when `break-spaces` is supported by Firefox Android:
 		https://caniuse.com/mdn-css_properties_white-space_break-spaces */
 		white-space: pre-wrap;
 		white-space: break-spaces;

--- a/src/lib/ui/NotesItem.svelte
+++ b/src/lib/ui/NotesItem.svelte
@@ -19,7 +19,9 @@
 		EntityContextmenu: $entity.entity_id,
 	}}
 >
-	{$entity.content}
+	<div class="markup">
+		{$entity.content}
+	</div>
 </li>
 
 <style>
@@ -28,7 +30,12 @@
 		border: var(--border);
 		max-width: var(--column_width_min);
 		margin: 10px;
-		padding: 10px;
 		background-color: var(--input_bg_color);
+	}
+
+	.markup {
+		/* force wrap long strings of text like links */
+		word-break: normal;
+		overflow-wrap: break-word;
 	}
 </style>

--- a/src/lib/ui/NotesItem.svelte
+++ b/src/lib/ui/NotesItem.svelte
@@ -34,8 +34,11 @@
 	}
 
 	.markup {
-		/* force wrap long strings of text like links */
-		word-break: normal;
-		overflow-wrap: break-word;
+		/* force wrap long strings of text */
+		overflow: hidden;
+		/* remove this line when `break-spaces` is supported by Firefox Android:
+		https://caniuse.com/mdn-css_properties_white-space_break-spaces */
+		white-space: pre-wrap;
+		white-space: break-spaces;
 	}
 </style>

--- a/src/lib/ui/RoomItem.svelte
+++ b/src/lib/ui/RoomItem.svelte
@@ -44,6 +44,7 @@ And then PersonaContextmenu would be only for *session* personas? `SessionPerson
 
 <style>
 	li {
+		align-items: flex-start;
 		padding: var(--spacing_xs);
 		/* TODO experiment with a border color instead of bg */
 		background-color: hsl(var(--hue), var(--bg_saturation), calc(var(--bg_color_lightness)));
@@ -54,7 +55,11 @@ And then PersonaContextmenu would be only for *session* personas? `SessionPerson
 	}
 	.markup {
 		padding: 0 0 0 var(--spacing_md);
-		/* force wrap long strings of text like links */
-		word-break: break-all;
+		/* force wrap long strings of text */
+		overflow: hidden;
+		/* remove this line when `break-spaces` is supported by Firefox Android:
+		https://caniuse.com/mdn-css_properties_white-space_break-spaces */
+		white-space: pre-wrap;
+		white-space: break-spaces;
 	}
 </style>

--- a/src/lib/ui/RoomItem.svelte
+++ b/src/lib/ui/RoomItem.svelte
@@ -28,9 +28,12 @@ And then PersonaContextmenu would be only for *session* personas? `SessionPerson
 		EntityContextmenu: $entity.entity_id,
 	}}
 >
-	<div class="content">
+	<div class="timestamp">
+		<Avatar name={toName($persona)} icon={toIcon($persona)} showName={false} />
+	</div>
+	<div class="markup">
 		<div class="timestamp">
-			<Avatar name={toName($persona)} icon={toIcon($persona)} />
+			<Avatar name={toName($persona)} icon={toIcon($persona)} showIcon={false} />
 			{$entity.created}
 		</div>
 		<div>
@@ -49,7 +52,9 @@ And then PersonaContextmenu would be only for *session* personas? `SessionPerson
 		display: flex;
 		align-items: center;
 	}
-	.content {
-		padding-left: var(--spacing_sm);
+	.markup {
+		padding: 0 0 0 var(--spacing_md);
+		/* force wrap long strings of text like links */
+		word-break: break-all;
 	}
 </style>

--- a/src/lib/ui/RoomItem.svelte
+++ b/src/lib/ui/RoomItem.svelte
@@ -55,9 +55,9 @@ And then PersonaContextmenu would be only for *session* personas? `SessionPerson
 	}
 	.markup {
 		padding: 0 0 0 var(--spacing_md);
-		/* force wrap long strings of text */
+		/* wrap long strings of text */
 		overflow: hidden;
-		/* remove this line when `break-spaces` is supported by Firefox Android:
+		/* TODO remove this line when `break-spaces` is supported by Firefox Android:
 		https://caniuse.com/mdn-css_properties_white-space_break-spaces */
 		white-space: pre-wrap;
 		white-space: break-spaces;

--- a/src/lib/ui/RoomItem.svelte
+++ b/src/lib/ui/RoomItem.svelte
@@ -31,7 +31,7 @@ And then PersonaContextmenu would be only for *session* personas? `SessionPerson
 	<div class="timestamp">
 		<Avatar name={toName($persona)} icon={toIcon($persona)} showName={false} />
 	</div>
-	<div class="markup">
+	<div class="markup formatted">
 		<div class="timestamp">
 			<Avatar name={toName($persona)} icon={toIcon($persona)} showIcon={false} />
 			{$entity.created}
@@ -55,11 +55,5 @@ And then PersonaContextmenu would be only for *session* personas? `SessionPerson
 	}
 	.markup {
 		padding: 0 0 0 var(--spacing_md);
-		/* wrap long strings of text */
-		overflow: hidden;
-		/* TODO remove this line when `break-spaces` is supported by Firefox Android:
-		https://caniuse.com/mdn-css_properties_white-space_break-spaces */
-		white-space: pre-wrap;
-		white-space: break-spaces;
 	}
 </style>

--- a/src/lib/ui/contextmenu/contextmenu.ts
+++ b/src/lib/ui/contextmenu/contextmenu.ts
@@ -70,7 +70,7 @@ const contextmenuAction = (el: HTMLElement | SVGElement, params: any): any => {
 export const onContextmenu =
 	(contextmenu: ContextmenuStore) =>
 	(e: MouseEvent, excludeEl?: HTMLElement): void | false => {
-		if (e.ctrlKey) return; // defer control!
+		if (e.shiftKey) return;
 		const target = e.target as HTMLElement;
 		if (isEditable(target) || excludeEl?.contains(target)) return;
 		const items = queryContextmenuItems(target);

--- a/src/lib/ui/style.css
+++ b/src/lib/ui/style.css
@@ -46,3 +46,13 @@ main {
 		opacity: 1;
 	}
 }
+
+/* TODO likely upstream to Felt */
+/* Formats blocks of text to wrap long strings and preserve displayed whitespace. */
+.formatted {
+	overflow: hidden;
+	/* TODO remove this line when `break-spaces` is supported by Firefox Android:
+		https://caniuse.com/mdn-css_properties_white-space_break-spaces */
+	white-space: pre-wrap;
+	white-space: break-spaces;
+}

--- a/src/lib/ui/style.css
+++ b/src/lib/ui/style.css
@@ -48,7 +48,7 @@ main {
 }
 
 /* TODO likely upstream to Felt */
-/* Formats blocks of text to wrap long strings and preserve displayed whitespace. */
+/* Formats content to wrap long strings and preserve displayed whitespace. */
 .formatted {
 	overflow: hidden;
 	/* TODO remove this line when `break-spaces` is supported by Firefox Android:


### PR DESCRIPTION
Fixes text overflowing post content areas like with long links and other long unbroken strings of text.

Adds one extra property because of Firefox Android support for `white-space: break-spaces` -- https://caniuse.com/mdn-css_properties_white-space_break-spaces

Also changes the layout of the chat room messages to put the user icon to the left of the user name and text, a better use of vertical space and aligns things more nicely.

Also fixes the contextmenu shift key as we discussed.

The `Avatar` component is starting to look a bit stretched and awkward. We may want to split out `AvatarName` and `AvatarIcon` or something.