### PR TITLE
navigate to space on view event

### DIFF
--- a/src/lib/ui/ManageMembershipForm.svelte
+++ b/src/lib/ui/ManageMembershipForm.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 	import {get} from 'svelte/store';
-	import type {Community} from '$lib/vocab/community/community';
 
 	import {getApp} from '$lib/ui/app';
-	import Avatar from './Avatar.svelte';
+	import {getCommunity} from '$lib/ui/ui';
+	import Avatar from '$lib/ui/Avatar.svelte';
 
 	const {
 		dispatch,
@@ -13,10 +13,6 @@
 	$: persona = $personaSelection!;
 
 	let errorMessage: string | undefined;
-
-	// TODO lookup from `communitiesById` map instead
-	const getCommunity = (community_id: number): Community =>
-		get($communities.find((c) => get(c).community_id === community_id)!);
 
 	const leaveCommunity = async (community_id: number) => {
 		errorMessage = '';
@@ -39,7 +35,8 @@
 			{#each $persona.community_ids as community_id (community_id)}
 				<li class="community-badge">
 					<button type="button" on:click={() => leaveCommunity(community_id)}> 👋 </button>
-					{getCommunity(community_id).name}
+					<!-- TODO refactor, probably extract a component -->
+					{get(getCommunity($communities, community_id)).name}
 				</li>
 			{/each}
 		</ul>

--- a/src/lib/ui/ui.ts
+++ b/src/lib/ui/ui.ts
@@ -165,7 +165,7 @@ export const toUi = (
 	);
 	const communitySelection = derived(
 		[communities, communityIdSelection],
-		// TODO lookup from `communitiesById` map instead
+		// TODO lookup from `communityById` map instead
 		([$communities, $communityIdSelection]) =>
 			$communities.find((c) => get(c).community_id === $communityIdSelection) || null,
 	);
@@ -602,6 +602,13 @@ export const toUi = (
 					$viewBySpace.delete(space);
 				}
 			});
+			// TODO speed this up with a map of `communityById`
+			const community = getCommunity(get(communities), get(space).community_id);
+			const $community = get(community);
+			goto('/' + $community.name + $community.spaces[0].url + location.search, {
+				replaceState: true,
+			});
+			// TODO nav
 		},
 		ToggleMainNav: () => {
 			expandMainNav.update(($expandMainNav) => !$expandMainNav);
@@ -626,3 +633,9 @@ const toInitialPersonas = (session: ClientSession): Persona[] =>
 					(p1) => !session.personas.find((p2) => p2.persona_id === p1.persona_id),
 				),
 		  );
+
+// TODO delete this and lookup from `communityById` map instead
+export const getCommunity = (
+	communities: Readable<Community>[],
+	community_id: number,
+): Readable<Community> => communities.find((c) => get(c).community_id === community_id)!;

--- a/src/lib/ui/ui.ts
+++ b/src/lib/ui/ui.ts
@@ -167,7 +167,7 @@ export const toUi = (
 		[communities, communityIdSelection],
 		// TODO lookup from `communityById` map instead
 		([$communities, $communityIdSelection]) =>
-			$communities.find((c) => get(c).community_id === $communityIdSelection) || null,
+			$communityIdSelection === null ? null : getCommunity($communities, $communityIdSelection),
 	);
 	// TODO this should store the selected space by community+persona,
 	// possibly alongside additional UI state, maybe in a store or namespace of stores

--- a/src/lib/ui/ui.ts
+++ b/src/lib/ui/ui.ts
@@ -95,7 +95,7 @@ export const toUi = (
 	const communities = writable<Writable<Community>[]>(
 		initialSession.guest ? [] : initialSession.communities.map((p) => writable(p)),
 	);
-	// TODO communitiesById
+	// TODO add `communityById` and delete `getCommunity`
 	const spaces = writable<Writable<Space>[]>(
 		initialSession.guest ? [] : initialSession.spaces.map((s) => writable(s)),
 	);
@@ -393,8 +393,7 @@ export const toUi = (
 		},
 		UpdateCommunitySettings: async ({params, invoke}) => {
 			// optimistic update
-			// TODO lookup with `communitiesById`
-			const community = get(communities).find((c) => get(c).community_id === params.community_id)!;
+			const community = getCommunity(get(communities), params.community_id);
 			const originalSettings = get(community).settings;
 			community.update(($community) => ({
 				...$community,
@@ -477,9 +476,7 @@ export const toUi = (
 							$community.name +
 							get(get(spacesByCommunityId).get($community.community_id)![0]).url +
 							location.search,
-						{
-							replaceState: true,
-						},
+						{replaceState: true},
 					);
 				}
 			});
@@ -594,13 +591,9 @@ export const toUi = (
 					$viewBySpace.delete(space);
 				}
 			});
-			// TODO speed this up with a map of `communityById`
-			const community = getCommunity(get(communities), get(space).community_id);
-			const $community = get(community);
-			goto('/' + $community.name + $community.spaces[0].url + location.search, {
-				replaceState: true,
-			});
-			// TODO nav
+			const $space = get(space);
+			const $community = get(getCommunity(get(communities), $space.community_id));
+			goto('/' + $community.name + $space.url + location.search, {replaceState: true});
 		},
 		ToggleMainNav: () => {
 			expandMainNav.update(($expandMainNav) => !$expandMainNav);
@@ -630,4 +623,7 @@ const toInitialPersonas = (session: ClientSession): Persona[] =>
 export const getCommunity = (
 	communities: Readable<Community>[],
 	community_id: number,
-): Readable<Community> => communities.find((c) => get(c).community_id === community_id)!;
+): Writable<Community> =>
+	// TODO typecast allows `Readable` input and `Writable` return value for usage in components,
+	// but this function will be deleted soon anyway (see the comment above)
+	communities.find((c) => get(c).community_id === community_id) as Writable<Community>;

--- a/src/lib/ui/ui.ts
+++ b/src/lib/ui/ui.ts
@@ -165,7 +165,6 @@ export const toUi = (
 	);
 	const communitySelection = derived(
 		[communities, communityIdSelection],
-		// TODO lookup from `communityById` map instead
 		([$communities, $communityIdSelection]) =>
 			$communityIdSelection === null ? null : getCommunity($communities, $communityIdSelection),
 	);

--- a/src/lib/ui/ui.ts
+++ b/src/lib/ui/ui.ts
@@ -171,6 +171,7 @@ export const toUi = (
 	);
 	// TODO this should store the selected space by community+persona,
 	// possibly alongside additional UI state, maybe in a store or namespace of stores
+	// TODO consider making this the space store so we don't have to chase id references
 	const spaceIdByCommunitySelection = writable<{[key: number]: number | null}>(
 		initialSession.guest
 			? {}
@@ -591,9 +592,19 @@ export const toUi = (
 					$viewBySpace.delete(space);
 				}
 			});
+			// Navigate the browser to the target space.
+			// The target community may not match the selected community,
+			// so it's not as simple as checking if this is already the selected space for its community,
+			// we need to check if the selected community's selected space matches this space.
+			const selectedCommunity = get(communitySelection);
 			const $space = get(space);
-			const $community = get(getCommunity(get(communities), $space.community_id));
-			goto('/' + $community.name + $space.url + location.search, {replaceState: true});
+			if (
+				selectedCommunity &&
+				$space.space_id !== get(spaceIdByCommunitySelection)[get(selectedCommunity).community_id]
+			) {
+				const $community = get(getCommunity(get(communities), $space.community_id));
+				goto('/' + $community.name + $space.url + location.search, {replaceState: true});
+			}
 		},
 		ToggleMainNav: () => {
 			expandMainNav.update(($expandMainNav) => !$expandMainNav);

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -128,7 +128,7 @@
 			dispatch('SelectPersona', {persona_id: get(persona).persona_id});
 		} // else already selected
 
-		// TODO speed this up with a map of communities by name
+		// TODO speed this up with a map of communityByName
 		const communityStore = $communities.find((c) => get(c).name === params.community);
 		if (!communityStore) return; // occurs when a session routes to a community they can't access
 		const community = get(communityStore);


### PR DESCRIPTION
Before this change, sending a `ViewSpace` event didn't do any browser navigation, so it was easy to right click on an inactive space, choose the different view, and seemingly nothing would happen. Now it'll update the browser URL.

I extracted a `getCommunity` helper that's used in a few places, and will soon be replaced with a `communityById` map.