### PR TITLE
improve community and space inputs

### DIFF
--- a/src/lib/ui/CommunityInput.svelte
+++ b/src/lib/ui/CommunityInput.svelte
@@ -20,13 +20,8 @@
 	let nameEl: HTMLInputElement;
 	let errorMessage: string | null = null;
 
-	// TODO this has a small bug because of component immutability,
-	// where whitespace characters appear in the input until a non-space character is entered,
-	// because the local `name` doesn't change, and so Svelte doens't update the input's value
-	const updateName = (updated: string) => {
-		// TODO formalize this (probably through the schema)
-		name = updated.replace(/\W/g, '');
-	};
+	// TODO formalize this (probably through the schema)
+	$: name = name.replace(/[^a-zA-Z0-9-]+/g, '');
 
 	const create = async (): Promise<void> => {
 		if (!name) {
@@ -65,8 +60,7 @@
 	<form>
 		<input
 			placeholder="> name"
-			value={name}
-			on:input={(e) => updateName(e.currentTarget.value)}
+			bind:value={name}
 			bind:this={nameEl}
 			use:autofocus
 			on:keydown={onKeydown}

--- a/src/lib/ui/SpaceInput.svelte
+++ b/src/lib/ui/SpaceInput.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import type {Readable} from 'svelte/store';
+	import PendingButton from '@feltcoop/felt/ui/PendingButton.svelte';
+	import Message from '@feltcoop/felt/ui/Message.svelte';
 
 	import type {Community} from '$lib/vocab/community/community.js';
 	import {autofocus} from '$lib/ui/actions';
@@ -15,31 +17,44 @@
 	export let community: Readable<Community>;
 	export let done: (() => void) | undefined = undefined;
 
-	let newName = '';
-	let newType = availableViewTypes[0];
+	let name = '';
+	let type = availableViewTypes[0];
+
+	let pending = false;
 	let nameEl: HTMLInputElement;
-	let errorMessage: string | undefined;
+	let errorMessage: string | null = null;
+
+	// TODO this has a small bug because of component immutability,
+	// where whitespace characters appear in the input until a non-space character is entered,
+	// because the local `name` doesn't change, and so Svelte doens't update the input's value
+	const updateName = (updated: string) => {
+		// TODO formalize this (probably through the schema)
+		name = updated.replace(/\W/g, '');
+	};
 
 	const create = async () => {
-		if (!newName) {
+		if (!name) {
 			errorMessage = 'please enter a name for your new space';
 			nameEl.focus();
 			return;
 		}
+		if (pending) return;
+		pending = true;
+		errorMessage = null;
 		//Needs to collect url(i.e. name for now), type (currently default application/json), & content (hardcoded JSON struct)
-		errorMessage = '';
-		const url = `/${newName}`;
+		const url = `/${name}`;
 		const result = await dispatch('CreateSpace', {
 			community_id: $community.community_id,
-			name: newName,
+			name,
 			url,
 			//TODO : add space type picker
 			media_type: 'application/fuz+json',
-			content: `{"type": "${newType}", "props": {"data": "/entities"}}`,
+			content: `{"type": "${type}", "props": {"data": "/entities"}}`,
 		});
+		pending = false;
 		if (result.ok) {
-			newName = '';
-			newType = availableViewTypes[0];
+			errorMessage = null;
+			name = '';
 			done?.();
 		} else {
 			errorMessage = result.message;
@@ -62,31 +77,30 @@
 		<Avatar name={$community.name} type="Community" />
 	</section>
 	<form>
-		<div class:error={!!errorMessage}>{errorMessage || ''}</div>
 		<input
 			placeholder="> name"
-			bind:value={newName}
-			use:autofocus
+			value={name}
+			on:input={(e) => updateName(e.currentTarget.value)}
 			bind:this={nameEl}
+			use:autofocus
 			on:keydown={onKeydown}
 		/>
 		<label>
 			Select Type:
-			<select class="type-selector" bind:value={newType}>
+			<select class="type-selector" bind:value={type}>
 				{#each availableViewTypes as type (type)}
 					<option value={type}>{type}</option>
 				{/each}
 			</select>
 		</label>
-		<button type="button" on:click={create}> Create space </button>
+		<PendingButton type="button" on:click={create} {pending}>Create space</PendingButton>
+		{#if errorMessage}
+			<Message status="error">{errorMessage}</Message>
+		{/if}
 	</form>
 </div>
 
 <style>
-	.error {
-		font-weight: bold;
-		color: rgb(73, 84, 153);
-	}
 	.type-selector {
 		margin-left: var(--spacing_xs);
 	}

--- a/src/lib/ui/SpaceInput.svelte
+++ b/src/lib/ui/SpaceInput.svelte
@@ -24,13 +24,8 @@
 	let nameEl: HTMLInputElement;
 	let errorMessage: string | null = null;
 
-	// TODO this has a small bug because of component immutability,
-	// where whitespace characters appear in the input until a non-space character is entered,
-	// because the local `name` doesn't change, and so Svelte doens't update the input's value
-	const updateName = (updated: string) => {
-		// TODO formalize this (probably through the schema)
-		name = updated.replace(/\W/g, '');
-	};
+	// TODO formalize this (probably through the schema)
+	$: name = name.replace(/[^a-zA-Z0-9-]+/g, '');
 
 	const create = async () => {
 		if (!name) {
@@ -79,8 +74,7 @@
 	<form>
 		<input
 			placeholder="> name"
-			value={name}
-			on:input={(e) => updateName(e.currentTarget.value)}
+			bind:value={name}
 			bind:this={nameEl}
 			use:autofocus
 			on:keydown={onKeydown}


### PR DESCRIPTION
This refactors the community and space inputs to be similar -- most of their code is now identical, and so it'll help us move towards generic handling.

- disallow creating communities with an empty string name
- disallow whitespace in the names of communities and spaces, and characters other than letters/numbers/dashes (this is temporarily overly-constrained until we decide on better rules)
- display error messages consistently
- don't close the community input if creation fails

future:

- decide on naming restrictions and implement