### PR TITLE
refactor memberships fixes

### DIFF
--- a/src/lib/server/random.ts
+++ b/src/lib/server/random.ts
@@ -1,5 +1,6 @@
 import {randomBool, randomItem} from '@feltcoop/felt/util/random.js';
 import {writable} from 'svelte/store';
+import {SvelteComponent} from 'svelte';
 
 import type {EventInfo} from '$lib/vocab/event/event';
 import {
@@ -11,7 +12,6 @@ import {
 } from '$lib/vocab/random';
 import {randomPersonaParams, randomCommunityParams, randomSpaceParams} from '$lib/vocab/random';
 import {randomHue} from '$lib/ui/color';
-import ManageMembershipForm from '$lib/ui/ManageMembershipForm.svelte';
 
 // TODO consider the pattern below where every `create` event creates all dependencies from scratch.
 // We may want to instead test things for both new and existing objects.
@@ -117,7 +117,7 @@ export const randomEventParams = async (
 			return randomBool();
 		}
 		case 'OpenDialog': {
-			return {Component: ManageMembershipForm};
+			return {Component: class SomeSvelteComponent extends SvelteComponent {}};
 		}
 		case 'CloseDialog': {
 			return undefined;

--- a/src/lib/server/random.ts
+++ b/src/lib/server/random.ts
@@ -116,7 +116,8 @@ export const randomEventParams = async (
 			return randomBool();
 		}
 		case 'OpenDialog': {
-			// TODO what should this value be? schema type `object` fails with this valid value:
+			// TODO should use the `instanceof` `ajv-keywords` extension for this:
+			// https://github.com/ajv-validator/ajv-keywords#instanceof
 			// `class SomeComponent extends SvelteComponent {}`
 			return {Component: {}};
 		}

--- a/src/lib/server/random.ts
+++ b/src/lib/server/random.ts
@@ -1,6 +1,5 @@
 import {randomBool, randomItem} from '@feltcoop/felt/util/random.js';
 import {writable} from 'svelte/store';
-import {SvelteComponent} from 'svelte';
 
 import type {EventInfo} from '$lib/vocab/event/event';
 import {
@@ -117,7 +116,9 @@ export const randomEventParams = async (
 			return randomBool();
 		}
 		case 'OpenDialog': {
-			return {Component: class SomeSvelteComponent extends SvelteComponent {}};
+			// TODO what should this value be? schema type `object` fails with this valid value:
+			// `class SomeComponent extends SvelteComponent {}`
+			return {Component: {}};
 		}
 		case 'CloseDialog': {
 			return undefined;

--- a/src/lib/server/random.ts
+++ b/src/lib/server/random.ts
@@ -118,6 +118,9 @@ export const randomEventParams = async (
 		case 'OpenDialog': {
 			// TODO should use the `instanceof` `ajv-keywords` extension for this:
 			// https://github.com/ajv-validator/ajv-keywords#instanceof
+			// using the single keyword directly:
+			// `require("ajv-keywords/dist/keywords/instanceof")(ajv, opts)`
+			// and this value should be:
 			// `class SomeComponent extends SvelteComponent {}`
 			return {Component: {}};
 		}

--- a/src/lib/ui/ManageMembershipItem.svelte
+++ b/src/lib/ui/ManageMembershipItem.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
 	import Message from '@feltcoop/felt/ui/Message.svelte';
+	import type {Readable} from 'svelte/store';
+
 	import {getApp} from '$lib/ui/app';
 	import type {Community} from '$lib/vocab/community/community';
 	import type {Persona} from '$lib/vocab/persona/persona';
-	import type {Readable} from 'svelte/store';
 
 	const {dispatch} = getApp();
 

--- a/src/lib/ui/Marquee.svelte
+++ b/src/lib/ui/Marquee.svelte
@@ -27,7 +27,7 @@
 	<section>
 		<ul>
 			<!-- TODO probably want these to be sorted so the selected persona is always first -->
-			{#each $communityPersonas as persona (persona)}
+			{#each communityPersonas as persona (persona)}
 				<MemberItem {community} {persona} />
 			{/each}
 		</ul>

--- a/src/lib/ui/MembershipInput.svelte
+++ b/src/lib/ui/MembershipInput.svelte
@@ -17,7 +17,7 @@
 	// TODO speed this up with a better cached data structures; the use of `get` is particularly bad
 	$: invitableMembers = $community
 		? $personas.filter(
-				(x) => !$communityPersonas.some((y) => get(x).persona_id == get(y).persona_id),
+				(x) => !communityPersonas.some((y) => get(x).persona_id == get(y).persona_id),
 		  )
 		: [];
 </script>

--- a/src/lib/ui/ui.ts
+++ b/src/lib/ui/ui.ts
@@ -432,7 +432,6 @@ export const toUi = (
 			const {persona_id} = params;
 			const {community, spaces} = result.value;
 			console.log('[ui.CreateCommunity]', community, persona_id);
-			// TODO how should `persona.community_ids` be modeled and kept up to date?
 			addCommunity(community, persona_id, spaces);
 			dispatch('SelectCommunity', {community_id: community.community_id});
 			return result;

--- a/src/lib/ui/ui.ts
+++ b/src/lib/ui/ui.ts
@@ -113,7 +113,7 @@ export const toUi = (
 	const spacesByCommunityId: Readable<Map<number, Readable<Space>[]>> = derived(
 		[communities, spaces],
 		([$communities, $spaces]) => {
-			const map = new Map();
+			const map: Map<number, Readable<Space>[]> = new Map();
 			for (const community of $communities) {
 				const communitySpaces: Writable<Space>[] = [];
 				const {community_id} = get(community);
@@ -131,7 +131,7 @@ export const toUi = (
 	const personasByCommunityId: Readable<Map<number, Readable<Persona>[]>> = derived(
 		[communities, memberships],
 		([$communities, $memberships]) => {
-			const map = new Map();
+			const map: Map<number, Readable<Persona>[]> = new Map();
 			for (const community of $communities) {
 				const communityPersonas: Writable<Persona>[] = [];
 				const {community_id} = get(community);
@@ -179,10 +179,10 @@ export const toUi = (
 		derived(
 			[sessionPersonas, memberships, communities],
 			([$sessionPersonas, $memberships, $communities]) => {
-				const map = new Map();
+				const map: Map<Readable<Persona>, Readable<Community>[]> = new Map();
 				for (const sessionPersona of $sessionPersonas) {
 					const $sessionPersona = get(sessionPersona);
-					const sessionPersonaCommunities = [];
+					const sessionPersonaCommunities: Readable<Community>[] = [];
 					for (const community of $communities) {
 						const $community = get(community);
 						for (const membership of $memberships) {

--- a/src/lib/ui/ui.ts
+++ b/src/lib/ui/ui.ts
@@ -382,7 +382,7 @@ export const toUi = (
 			}
 
 			communities.set(session.guest ? [] : session.communities.map((p) => writable(p)));
-			// TODO init memberships when they're added to the session
+			memberships.set(session.guest ? [] : session.memberships.map((s) => writable(s)));
 			spaces.set(session.guest ? [] : session.spaces.map((s) => writable(s)));
 			communityIdByPersonaSelection.set(
 				// TODO copypasta from above

--- a/src/lib/ui/view/Home.svelte
+++ b/src/lib/ui/view/Home.svelte
@@ -22,7 +22,6 @@
 	$: communitySpaces = $spacesByCommunityId.get($community.community_id)!;
 
 	$: communityPersonas = $personasByCommunityId.get($community.community_id)!;
-	$: console.log('$$$$$$', communityPersonas);
 </script>
 
 <div class="markup">
@@ -30,7 +29,7 @@
 		<h2>members</h2>
 		<!-- TODO display other meta info about the community -->
 		<ul>
-			{#each $communityPersonas as persona (persona)}
+			{#each communityPersonas as persona (persona)}
 				<MemberItem {persona} {community} />
 			{/each}
 		</ul>

--- a/src/lib/vocab/persona/persona.ts
+++ b/src/lib/vocab/persona/persona.ts
@@ -21,7 +21,7 @@ export const PersonaSchema = {
 		created: {type: 'object', format: 'date-time', tsType: 'Date'},
 		updated: {type: ['object', 'null'], format: 'date-time', tsType: 'Date | null'},
 	},
-	required: ['persona_id', 'community_id', 'type', 'name', 'community_ids', 'created', 'updated'],
+	required: ['persona_id', 'community_id', 'type', 'name', 'created', 'updated'],
 	additionalProperties: false,
 };
 

--- a/src/lib/vocab/persona/personaRepo.ts
+++ b/src/lib/vocab/persona/personaRepo.ts
@@ -36,10 +36,7 @@ export const personaRepo = (db: Database) => ({
 			if (!createCommunityResult.ok) {
 				return {ok: false, message: 'failed to create initial persona community'};
 			}
-			// TODO this is a hack -- always adding/expecting `community_ids`
-			// like in `filterByAccount` below is probably not the best idea because of overfetching
 			const {community, spaces} = createCommunityResult.value;
-			// TODO another hack
 			await db.sql`
 				UPDATE personas SET community_id = ${community.community_id}
 					WHERE persona_id = ${persona.persona_id}


### PR DESCRIPTION
- [x] fix tests by not importing `ManageMembershipForm.svelte` as a random value
- [x] fix type of `personasByCommunityId` to be a plain array, not readable of an array, and then fix its usage to not prefix with `$` (more type annotations would have caught this)
- [x] fix error caused by memberships being returned for personas of type `'community'`
- [x] init memberships in `setSession`
- [x] fix tests by removing `community_ids` from `required` on persona schema
