### PR TITLE
refactor initial session and session updating to a single code path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "prettier-plugin-svelte": "^2.5.1",
         "regexparam": "^2.0.0",
         "strict-event-emitter-types": "^2.0.0",
-        "svelte": "^3.44.2",
+        "svelte": "^3.46.3",
         "svelte-check": "^2.3.0",
         "svelte-preprocess-esbuild": "^2.0.0",
         "throttle-debounce": "^3.0.1",
@@ -2127,9 +2127,9 @@
       }
     },
     "node_modules/svelte": {
-      "version": "3.44.2",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.44.2.tgz",
-      "integrity": "sha512-jrZhZtmH3ZMweXg1Q15onb8QlWD+a5T5Oca4C1jYvSURp2oD35h4A5TV6t6MEa93K4LlX6BkafZPdQoFjw/ylA==",
+      "version": "3.46.3",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.46.3.tgz",
+      "integrity": "sha512-mTOXvv74CVQqJHqoIZDprVfRKVVmYNadXP0VKnOEA54223kLGCr1nMrifS4Zx29qMt/xRB38Eq1D7dDH/fM8fQ==",
       "engines": {
         "node": ">= 8"
       }
@@ -3981,9 +3981,9 @@
       }
     },
     "svelte": {
-      "version": "3.44.2",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.44.2.tgz",
-      "integrity": "sha512-jrZhZtmH3ZMweXg1Q15onb8QlWD+a5T5Oca4C1jYvSURp2oD35h4A5TV6t6MEa93K4LlX6BkafZPdQoFjw/ylA=="
+      "version": "3.46.3",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.46.3.tgz",
+      "integrity": "sha512-mTOXvv74CVQqJHqoIZDprVfRKVVmYNadXP0VKnOEA54223kLGCr1nMrifS4Zx29qMt/xRB38Eq1D7dDH/fM8fQ=="
     },
     "svelte-check": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "prettier-plugin-svelte": "^2.5.1",
     "regexparam": "^2.0.0",
     "strict-event-emitter-types": "^2.0.0",
-    "svelte": "^3.44.2",
+    "svelte": "^3.46.3",
     "svelte-check": "^2.3.0",
     "svelte-preprocess-esbuild": "^2.0.0",
     "throttle-debounce": "^3.0.1",

--- a/src/lib/ui/BoardItem.svelte
+++ b/src/lib/ui/BoardItem.svelte
@@ -10,12 +10,12 @@
 	import EntityContextmenu from '$lib/app/contextmenu/EntityContextmenu.svelte';
 
 	const {
-		ui: {contextmenu, findPersonaById},
+		ui: {contextmenu, personaById},
 	} = getApp();
 
 	export let entity: Readable<Entity>;
 
-	$: persona = findPersonaById($entity.actor_id); // TODO should this be `Actor` and `actor`?
+	$: persona = personaById.get($entity.actor_id)!; // TODO should this be `Actor` and `actor`?
 
 	// TODO refactor to some client view-model for the actor
 	$: hue = randomHue($persona.name);

--- a/src/lib/ui/CommunityNavButton.svelte
+++ b/src/lib/ui/CommunityNavButton.svelte
@@ -10,7 +10,7 @@
 
 	const {
 		dispatch,
-		ui: {contextmenu, spaceIdByCommunitySelection, findSpaceById, sessionPersonaIndices},
+		ui: {contextmenu, spaceIdSelectionByCommunityId, findSpaceById, sessionPersonaIndices},
 	} = getApp();
 
 	// TODO should this just use `ui` instead of taking all of these props?
@@ -20,9 +20,8 @@
 	export let community: Readable<Community>;
 	export let selected: boolean = false;
 
-	$: communitySelectionSpaceId = $spaceIdByCommunitySelection[$community.community_id];
-	$: communitySelectionSpace =
-		communitySelectionSpaceId === null ? null : findSpaceById(communitySelectionSpaceId);
+	$: spaceIdSelection = $spaceIdSelectionByCommunityId[$community.community_id];
+	$: selectedSpace = spaceIdSelection === null ? null : findSpaceById(spaceIdSelection);
 
 	$: isPersonaHomeCommunity = $community.name === $persona.name;
 
@@ -32,7 +31,7 @@
 <!-- TODO can this be well abstracted via the Entity with a `link` prop? -->
 <a
 	class="community"
-	href={toSpaceUrl(personaIndex, $community, communitySelectionSpace && $communitySelectionSpace)}
+	href={toSpaceUrl(personaIndex, $community, selectedSpace && $selectedSpace)}
 	class:selected
 	class:persona={isPersonaHomeCommunity}
 	style="--hue: {$community.settings.hue}"

--- a/src/lib/ui/CommunityNavButton.svelte
+++ b/src/lib/ui/CommunityNavButton.svelte
@@ -10,7 +10,7 @@
 
 	const {
 		dispatch,
-		ui: {contextmenu, spaceIdSelectionByCommunityId, findSpaceById, sessionPersonaIndices},
+		ui: {contextmenu, spaceIdSelectionByCommunityId, spaceById, sessionPersonaIndices},
 	} = getApp();
 
 	// TODO should this just use `ui` instead of taking all of these props?
@@ -21,7 +21,7 @@
 	export let selected: boolean = false;
 
 	$: spaceIdSelection = $spaceIdSelectionByCommunityId[$community.community_id];
-	$: selectedSpace = spaceIdSelection === null ? null : findSpaceById(spaceIdSelection);
+	$: selectedSpace = spaceIdSelection === null ? null : $spaceById.get(spaceIdSelection)!;
 
 	$: isPersonaHomeCommunity = $community.name === $persona.name;
 

--- a/src/lib/ui/EntityItem.svelte
+++ b/src/lib/ui/EntityItem.svelte
@@ -7,12 +7,12 @@
 	import PersonaContextmenu from '$lib/app/contextmenu/PersonaContextmenu.svelte';
 
 	const {
-		ui: {contextmenu, findPersonaById},
+		ui: {contextmenu, personaById},
 	} = getApp();
 
 	export let entity: Readable<Entity>;
 
-	$: persona = findPersonaById($entity.actor_id);
+	$: persona = personaById.get($entity.actor_id)!;
 </script>
 
 <li

--- a/src/lib/ui/ForumItem.svelte
+++ b/src/lib/ui/ForumItem.svelte
@@ -10,12 +10,12 @@
 	import PersonaContextmenu from '$lib/app/contextmenu/PersonaContextmenu.svelte';
 
 	const {
-		ui: {contextmenu, findPersonaById},
+		ui: {contextmenu, personaById},
 	} = getApp();
 
 	export let entity: Readable<Entity>;
 
-	$: persona = findPersonaById($entity.actor_id); // TODO should this be `Actor` and `actor`?
+	$: persona = personaById.get($entity.actor_id)!; // TODO should this be `Actor` and `actor`?
 
 	// TODO refactor to some client view-model for the actor
 	$: hue = randomHue($persona.name);

--- a/src/lib/ui/MemberItem.svelte
+++ b/src/lib/ui/MemberItem.svelte
@@ -9,7 +9,7 @@
 	import PersonaContextmenu from '$lib/app/contextmenu/PersonaContextmenu.svelte';
 
 	const {
-		ui: {contextmenu, personasById},
+		ui: {contextmenu, personaById},
 	} = getApp();
 
 	export let persona: Readable<Persona>;
@@ -18,9 +18,7 @@
 
 {#if $persona.type === 'account'}
 	<li
-		use:contextmenu.action={[
-			[PersonaContextmenu, {persona: personasById.get($persona.persona_id)}],
-		]}
+		use:contextmenu.action={[[PersonaContextmenu, {persona: personaById.get($persona.persona_id)}]]}
 	>
 		<Avatar name={toName($persona)} icon={toIcon($persona)} />
 	</li>

--- a/src/lib/ui/NotesItem.svelte
+++ b/src/lib/ui/NotesItem.svelte
@@ -7,12 +7,12 @@
 	import EntityContextmenu from '$lib/app/contextmenu/EntityContextmenu.svelte';
 
 	const {
-		ui: {contextmenu, findPersonaById},
+		ui: {contextmenu, personaById},
 	} = getApp();
 
 	export let entity: Readable<Entity>;
 
-	$: persona = findPersonaById($entity.actor_id);
+	$: persona = personaById.get($entity.actor_id)!;
 </script>
 
 <li

--- a/src/lib/ui/RoomItem.svelte
+++ b/src/lib/ui/RoomItem.svelte
@@ -11,12 +11,12 @@
 	import EntityContextmenu from '$lib/app/contextmenu/EntityContextmenu.svelte';
 
 	const {
-		ui: {contextmenu, findPersonaById},
+		ui: {contextmenu, personaById},
 	} = getApp();
 
 	export let entity: Readable<Entity>;
 
-	$: persona = findPersonaById($entity.actor_id); // TODO should this be `Actor` and `actor`?
+	$: persona = personaById.get($entity.actor_id)!; // TODO should this be `Actor` and `actor`?
 
 	// TODO refactor to some client view-model for the actor
 	$: hue = randomHue($persona.name);

--- a/src/lib/ui/ui.ts
+++ b/src/lib/ui/ui.ts
@@ -231,10 +231,10 @@ export const toUi = (
 		if (spacesToAdd) {
 			spaces.update(($spaces) => $spaces.concat(spacesToAdd!.map((s) => writable(s))));
 		}
-		spaceIdSelectionByCommunityId.update(($spaceIdSelectionByCommunityId) => {
-			$spaceIdSelectionByCommunityId[community.community_id] = communitySpaces[0].space_id;
-			return $spaceIdSelectionByCommunityId;
-		});
+		spaceIdSelectionByCommunityId.update(($v) => ({
+			...$v,
+			[community.community_id]: communitySpaces[0].space_id,
+		}));
 		const communityStore = writable(community);
 		communities.update(($communities) => $communities.concat(communityStore));
 	};
@@ -302,13 +302,15 @@ export const toUi = (
 			} else {
 				personaIdSelection.set(null);
 			}
+			const $communitiesBySessionPersona = get(communitiesBySessionPersona);
+			console.log('$communitiesBySessionPersona', $communitiesBySessionPersona);
 			communityIdSelectionByPersonaId.set(
 				Object.fromEntries(
 					get(sessionPersonas)
 						.map((persona) => {
 							// TODO needs to be rethought, the `get` isn't reactive
 							const $persona = get(persona);
-							const $communities = get(communitiesBySessionPersona).get(persona)!;
+							const $communities = $communitiesBySessionPersona.get(persona)!;
 							const $firstCommunity = $communities[0];
 							return $firstCommunity
 								? [$persona.persona_id, get($firstCommunity).community_id]
@@ -318,7 +320,7 @@ export const toUi = (
 				),
 			);
 			const $spacesByCommunityId = get(spacesByCommunityId);
-			console.log('spacesByCommunityId', $spacesByCommunityId);
+			console.log('$spacesByCommunityId', $spacesByCommunityId);
 			spaceIdSelectionByCommunityId.set(
 				$session.guest
 					? {}
@@ -584,6 +586,13 @@ export const toUi = (
 		// TODO why is this firing twice? Upgrade SvelteKit?
 		if (browser) console.log('$session changed', $session);
 		ui.setSession($session);
+	});
+
+	communityIdSelectionByPersonaId.subscribe(($communityIdSelectionByPersonaId) => {
+		console.log('CHANGED communityIdSelectionByPersonaId', $communityIdSelectionByPersonaId);
+	});
+	spaceIdSelectionByCommunityId.subscribe(($spaceIdSelectionByCommunityId) => {
+		console.log('CHANGED spaceIdSelectionByCommunityId', $spaceIdSelectionByCommunityId);
 	});
 
 	return ui;

--- a/src/lib/ui/ui.ts
+++ b/src/lib/ui/ui.ts
@@ -292,12 +292,14 @@ export const toUi = (
 			communities.set($session.guest ? [] : $session.communities.map((p) => writable(p)));
 			spaces.set($session.guest ? [] : $session.spaces.map((s) => writable(s)));
 			memberships.set($session.guest ? [] : $session.memberships.map((s) => writable(s)));
+
+			// TODO fix this and the 2 below to use the URL to initialize the correct persona+community+space
 			const $firstSessionPersona = $session.guest ? null : $sessionPersonas[0];
 			personaIdSelection.set($firstSessionPersona?.persona_id ?? null);
 
 			// TODO these two selections are hacky because using the derived stores
 			// was causing various confusing issues, so they find stuff directly on the session objects
-			// instead of using derived stores like `sessionPersonas` and `spacesByCommunityId`
+			// instead of using derived stores like `sessionPersonas` and `spacesByCommunityId`.
 			communityIdSelectionByPersonaId.set(
 				$session.guest
 					? {}

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -91,12 +91,10 @@
 		personaIndexSelection,
 		communityIdSelection,
 		spacesByCommunityId,
-		spaceIdByCommunitySelection,
+		spaceIdSelectionByCommunityId,
 		personaSelection,
-		setSession,
 	} = ui;
 
-	$: setSession($session);
 	$: guest = $session.guest;
 	$: onboarding = !guest && !$sessionPersonas.length;
 
@@ -146,7 +144,7 @@
 			const space = $spacesByCommunityId.get(community_id)!.find((s) => get(s).url === spaceUrl);
 			if (!space) throw Error(`TODO Unable to find space: ${spaceUrl}`);
 			const {space_id} = get(space);
-			if (space_id !== $spaceIdByCommunitySelection[community_id]) {
+			if (space_id !== $spaceIdSelectionByCommunityId[community_id]) {
 				dispatch('SelectSpace', {community_id, space_id});
 			}
 		} else {
@@ -190,7 +188,7 @@
 	{/if}
 	<main>
 		{#if guest}
-			<div class="column markup">
+			<div class="account column markup">
 				<AccountForm {guest} />
 			</div>
 		{:else if onboarding}
@@ -222,5 +220,8 @@
 		align-items: center;
 		justify-content: center;
 		flex-direction: column;
+	}
+	.account {
+		align-items: center;
 	}
 </style>


### PR DESCRIPTION
This changes the `ui` initialization to start up with empty values, and then calls `ui.setSession` so there's a single code path.

I also renamed a few things for clarity.

- [x] fix the initialization problem on login (fixed by initializing objects directly from the session instead of using the derived stores; it's fine for now)
- [x] delete the logging

followup

- fix bug where the wrong community is initialized because it's not reading from the URL (not caused by this PR)