### PR TITLE
keep contextmenu onscreen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "@types/ws": "^8.2.2",
         "ley": "^0.7.1",
         "prettier": "^2.5.1",
-        "prettier-plugin-svelte": "^2.5.1",
+        "prettier-plugin-svelte": "^2.6.0",
         "regexparam": "^2.0.0",
         "strict-event-emitter-types": "^2.0.0",
         "svelte": "^3.46.3",
@@ -1831,9 +1831,9 @@
       }
     },
     "node_modules/prettier-plugin-svelte": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-2.5.1.tgz",
-      "integrity": "sha512-IhZUcqr7Bg4LY15d87t9lDr7EyC0IPehkzH5ya5igG8zYwf3UYaYDFnVW2mckREaZyLREcH9YOouesmt4f5Ozg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-2.6.0.tgz",
+      "integrity": "sha512-NPSRf6Y5rufRlBleok/pqg4+1FyGsL0zYhkYP6hnueeL1J/uCm3OfOZPsLX4zqD9VAdcXfyEL2PYqGv8ZoOSfA==",
       "dev": true,
       "peerDependencies": {
         "prettier": "^1.16.4 || ^2.0.0",
@@ -3793,9 +3793,9 @@
       "dev": true
     },
     "prettier-plugin-svelte": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-2.5.1.tgz",
-      "integrity": "sha512-IhZUcqr7Bg4LY15d87t9lDr7EyC0IPehkzH5ya5igG8zYwf3UYaYDFnVW2mckREaZyLREcH9YOouesmt4f5Ozg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-2.6.0.tgz",
+      "integrity": "sha512-NPSRf6Y5rufRlBleok/pqg4+1FyGsL0zYhkYP6hnueeL1J/uCm3OfOZPsLX4zqD9VAdcXfyEL2PYqGv8ZoOSfA==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@types/ws": "^8.2.2",
     "ley": "^0.7.1",
     "prettier": "^2.5.1",
-    "prettier-plugin-svelte": "^2.5.1",
+    "prettier-plugin-svelte": "^2.6.0",
     "regexparam": "^2.0.0",
     "strict-event-emitter-types": "^2.0.0",
     "svelte": "^3.46.3",

--- a/src/lib/ui/contextmenu/Contextmenu.svelte
+++ b/src/lib/ui/contextmenu/Contextmenu.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import {isEditable} from '@feltcoop/felt/util/dom.js';
 	import {type SvelteComponent} from 'svelte';
+	import {type Readable} from 'svelte/store';
 
 	import {setContextmenu, type ContextmenuStore} from '$lib/ui/contextmenu/contextmenu';
 	import {onContextmenu} from '$lib/ui/contextmenu/contextmenu';
@@ -13,6 +14,7 @@
 	// https://svelte.dev/docs#template-syntax-key
 	export let contextmenu: ContextmenuStore;
 	export let LinkContextmenu: typeof SvelteComponent;
+	export let layout: Readable<{width: number; height: number}>;
 
 	setContextmenu(contextmenu);
 
@@ -66,6 +68,13 @@
 	};
 
 	$: console.log('$contextmenu', $contextmenu);
+
+	// TODO how to get dimensions ahead of time? render hidden/invisible first?
+	// TODO how to position the submenus?
+	const contextmenuWidth = 400;
+	const contextmenuHeight = 400;
+	$: x = $contextmenu.x + Math.min(0, $layout.width - ($contextmenu.x + contextmenuWidth));
+	$: y = $contextmenu.y + Math.min(0, $layout.height - ($contextmenu.y + contextmenuHeight));
 </script>
 
 <!-- TODO need long-press detection for contextmenu on iOS -->
@@ -85,7 +94,7 @@
 		aria-modal
 		tabindex="-1"
 		bind:this={contextmenuEl}
-		style="transform: translate3d({$contextmenu.x}px, {$contextmenu.y}px, 0);"
+		style="transform: translate3d({x}px, {y}px, 0);"
 		on:click={onClickContent}
 	>
 		{#each $contextmenu.items as [component, props] (component)}

--- a/src/lib/ui/contextmenu/Contextmenu.svelte
+++ b/src/lib/ui/contextmenu/Contextmenu.svelte
@@ -67,14 +67,19 @@
 		}
 	};
 
-	$: console.log('$contextmenu', $contextmenu);
+	$: ({open} = $contextmenu);
 
-	// TODO how to get dimensions ahead of time? render hidden/invisible first?
-	// TODO how to position the submenus?
-	const contextmenuWidth = 400;
-	const contextmenuHeight = 400;
-	$: x = $contextmenu.x + Math.min(0, $layout.width - ($contextmenu.x + contextmenuWidth));
-	$: y = $contextmenu.y + Math.min(0, $layout.height - ($contextmenu.y + contextmenuHeight));
+	$: if (open && contextmenuEl) updateDimensions();
+	const updateDimensions = () => {
+		const rect = contextmenuEl.getBoundingClientRect();
+		width = rect.width;
+		height = rect.height;
+	};
+
+	let width = 0;
+	let height = 0;
+	$: x = $contextmenu.x + Math.min(0, $layout.width - ($contextmenu.x + width));
+	$: y = $contextmenu.y + Math.min(0, $layout.height - ($contextmenu.y + height));
 </script>
 
 <!-- TODO need long-press detection for contextmenu on iOS -->
@@ -82,13 +87,13 @@
 <!-- Capture keydown so it can handle the event before any dialogs. -->
 <svelte:window
 	on:contextmenu|capture={(e) => onContextmenu(e, contextmenu, contextmenuEl, LinkContextmenu)}
-	on:mousedown|capture={$contextmenu.open ? onWindowMousedown : undefined}
-	on:keydown|capture={$contextmenu.open ? onWindowKeydown : undefined}
+	on:mousedown|capture={open ? onWindowMousedown : undefined}
+	on:keydown|capture={open ? onWindowKeydown : undefined}
 />
 
 <!-- TODO Maybe animate a subtle highlight around the contextmenu as it appears? -->
-{#if $contextmenu.open}
-	<ul
+{#if open}
+	<div
 		class="contextmenu pane"
 		role="menu"
 		aria-modal
@@ -102,7 +107,7 @@
 				<svelte:component this={component} {...props} />
 			</section>
 		{/each}
-	</ul>
+	</div>
 {/if}
 
 <style>

--- a/src/lib/ui/contextmenu/Contextmenu.svelte
+++ b/src/lib/ui/contextmenu/Contextmenu.svelte
@@ -100,7 +100,7 @@
 		aria-modal
 		tabindex="-1"
 		bind:this={el}
-		style="transform: translate3d({x}px, {y}px, 0);"
+		style:transform="translate3d({x}px, {y}px, 0)"
 		on:click={onClickContent}
 	>
 		{#each $contextmenu.items as [component, props] (component)}

--- a/src/lib/ui/contextmenu/Contextmenu.svelte
+++ b/src/lib/ui/contextmenu/Contextmenu.svelte
@@ -74,7 +74,7 @@
 	$: contextmenuX = $contextmenu.x; // pull off `contextmenu` to avoid unnecessary recalculations
 	$: contextmenuY = $contextmenu.y;
 	const dimensions = setContextmenuDimensions();
-	$: if (open && el) updateDimensions();
+	$: if (el) updateDimensions();
 	const updateDimensions = () => {
 		const rect = el.getBoundingClientRect();
 		$dimensions = {width: rect.width, height: rect.height};

--- a/src/lib/ui/contextmenu/Contextmenu.svelte
+++ b/src/lib/ui/contextmenu/Contextmenu.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import {isEditable} from '@feltcoop/felt/util/dom.js';
 	import {type SvelteComponent} from 'svelte';
-	import {type Readable} from 'svelte/store';
 
 	import {setContextmenu, type ContextmenuStore} from '$lib/ui/contextmenu/contextmenu';
 	import {onContextmenu} from '$lib/ui/contextmenu/contextmenu';
@@ -14,16 +13,15 @@
 	// https://svelte.dev/docs#template-syntax-key
 	export let contextmenu: ContextmenuStore;
 	export let LinkContextmenu: typeof SvelteComponent;
-	export let layout: Readable<{width: number; height: number}>;
 
 	setContextmenu(contextmenu);
 
-	let contextmenuEl: HTMLElement;
+	let el: HTMLElement;
 
 	// This handler runs during the event's `capture` phase
 	// so that things like the Dialog don't eat the events and prevent the contextmenu from closing.
 	const onWindowMousedown = (e: MouseEvent) => {
-		if (!contextmenuEl.contains(e.target as any)) {
+		if (!el.contains(e.target as any)) {
 			contextmenu.close();
 		}
 	};
@@ -67,26 +65,27 @@
 		}
 	};
 
+	$: ({layout} = contextmenu);
 	$: ({open} = $contextmenu);
-
-	$: if (open && contextmenuEl) updateDimensions();
+	$: contextmenuX = $contextmenu.x; // pull off `contextmenu` to avoid unnecessary recalculations
+	$: contextmenuY = $contextmenu.y;
+	let width = 0;
+	let height = 0;
+	$: if (open && el) updateDimensions();
 	const updateDimensions = () => {
-		const rect = contextmenuEl.getBoundingClientRect();
+		const rect = el.getBoundingClientRect();
 		width = rect.width;
 		height = rect.height;
 	};
-
-	let width = 0;
-	let height = 0;
-	$: x = $contextmenu.x + Math.min(0, $layout.width - ($contextmenu.x + width));
-	$: y = $contextmenu.y + Math.min(0, $layout.height - ($contextmenu.y + height));
+	$: x = contextmenuX + Math.min(0, $layout.width - (contextmenuX + width));
+	$: y = contextmenuY + Math.min(0, $layout.height - (contextmenuY + height));
 </script>
 
 <!-- TODO need long-press detection for contextmenu on iOS -->
 <!-- TODO ensure `mousedown` works everywhere; might want to add `touchstart` or substitute `pointerdown` -->
 <!-- Capture keydown so it can handle the event before any dialogs. -->
 <svelte:window
-	on:contextmenu|capture={(e) => onContextmenu(e, contextmenu, contextmenuEl, LinkContextmenu)}
+	on:contextmenu|capture={(e) => onContextmenu(e, contextmenu, el, LinkContextmenu)}
 	on:mousedown|capture={open ? onWindowMousedown : undefined}
 	on:keydown|capture={open ? onWindowKeydown : undefined}
 />
@@ -98,14 +97,14 @@
 		role="menu"
 		aria-modal
 		tabindex="-1"
-		bind:this={contextmenuEl}
+		bind:this={el}
 		style="transform: translate3d({x}px, {y}px, 0);"
 		on:click={onClickContent}
 	>
 		{#each $contextmenu.items as [component, props] (component)}
-			<section>
+			<ul>
 				<svelte:component this={component} {...props} />
-			</section>
+			</ul>
 		{/each}
 	</div>
 {/if}
@@ -119,10 +118,10 @@
 		width: var(--contextmenu_width);
 		border: var(--border);
 	}
-	section {
+	ul {
 		border-bottom: var(--border);
 	}
-	section:last-child {
+	ul:last-child {
 		border-bottom: none;
 	}
 </style>

--- a/src/lib/ui/contextmenu/Contextmenu.svelte
+++ b/src/lib/ui/contextmenu/Contextmenu.svelte
@@ -2,7 +2,11 @@
 	import {isEditable} from '@feltcoop/felt/util/dom.js';
 	import {type SvelteComponent} from 'svelte';
 
-	import {setContextmenu, type ContextmenuStore} from '$lib/ui/contextmenu/contextmenu';
+	import {
+		setContextmenu,
+		setContextmenuDimensions,
+		type ContextmenuStore,
+	} from '$lib/ui/contextmenu/contextmenu';
 	import {onContextmenu} from '$lib/ui/contextmenu/contextmenu';
 
 	// TODO upstream to Felt
@@ -69,16 +73,14 @@
 	$: ({open} = $contextmenu);
 	$: contextmenuX = $contextmenu.x; // pull off `contextmenu` to avoid unnecessary recalculations
 	$: contextmenuY = $contextmenu.y;
-	let width = 0;
-	let height = 0;
+	const dimensions = setContextmenuDimensions();
 	$: if (open && el) updateDimensions();
 	const updateDimensions = () => {
 		const rect = el.getBoundingClientRect();
-		width = rect.width;
-		height = rect.height;
+		$dimensions = {width: rect.width, height: rect.height};
 	};
-	$: x = contextmenuX + Math.min(0, $layout.width - (contextmenuX + width));
-	$: y = contextmenuY + Math.min(0, $layout.height - (contextmenuY + height));
+	$: x = contextmenuX + Math.min(0, $layout.width - (contextmenuX + $dimensions.width));
+	$: y = contextmenuY + Math.min(0, $layout.height - (contextmenuY + $dimensions.height));
 </script>
 
 <!-- TODO need long-press detection for contextmenu on iOS -->

--- a/src/lib/ui/contextmenu/ContextmenuSubmenu.svelte
+++ b/src/lib/ui/contextmenu/ContextmenuSubmenu.svelte
@@ -27,7 +27,7 @@
 
 	let translateX = 0;
 	let translateY = 0;
-	$: el && updatePosition(el, $layout, $parentDimensions);
+	$: if (el) updatePosition(el, $layout, $parentDimensions);
 	const updatePosition = (
 		el: HTMLElement,
 		$layout: {width: number; height: number},

--- a/src/lib/ui/contextmenu/ContextmenuSubmenu.svelte
+++ b/src/lib/ui/contextmenu/ContextmenuSubmenu.svelte
@@ -11,6 +11,8 @@
 		if (!selected) contextmenu.selectItem(submenu);
 	};
 
+	// TODO BLOCK how to make this stay onscreen? should there be store properties on `contextmenu`?
+
 	// the `$contextmenu` is needed because `submenu` is not reactive
 	$: ({selected} = ($contextmenu, submenu));
 </script>

--- a/src/lib/ui/contextmenu/ContextmenuSubmenu.svelte
+++ b/src/lib/ui/contextmenu/ContextmenuSubmenu.svelte
@@ -25,8 +25,8 @@
 	const parentDimensions = getContextmenuDimensions();
 	const dimensions = setContextmenuDimensions();
 
-	// TODO BLOCK clamp height
 	let translateX = 0;
+	let translateY = 0;
 	$: updatePosition(el, $layout, $parentDimensions);
 	const updatePosition = (
 		el: HTMLElement | undefined,
@@ -35,11 +35,11 @@
 	) => {
 		if (!el) {
 			translateX = 0;
+			translateY = 0;
 			return;
 		}
-		const rect = el.getBoundingClientRect();
-		$dimensions = {width: rect.width, height: rect.height};
-		const {x, width} = rect;
+		const {x, y, width, height} = el.getBoundingClientRect();
+		$dimensions = {width, height};
 		const overflowRight = x + width + $parentDimensions.width - $layout.width;
 		if (overflowRight <= 0) {
 			translateX = $parentDimensions.width;
@@ -53,6 +53,7 @@
 				translateX = overflowLeft - width;
 			}
 		}
+		translateY = Math.min(0, $layout.height - (y + height));
 	};
 </script>
 
@@ -74,7 +75,7 @@
 			bind:this={el}
 			class="contextmenu-submenu pane"
 			role="menu"
-			style="transform: translate3d({translateX}px, 0, 0)"
+			style="transform: translate3d({translateX}px, {translateY}px, 0)"
 		>
 			<slot name="menu" />
 		</ul>

--- a/src/lib/ui/contextmenu/ContextmenuSubmenu.svelte
+++ b/src/lib/ui/contextmenu/ContextmenuSubmenu.svelte
@@ -11,10 +11,39 @@
 		if (!selected) contextmenu.selectItem(submenu);
 	};
 
-	// TODO BLOCK how to make this stay onscreen? should there be store properties on `contextmenu`?
+	$: ({layout} = contextmenu);
 
 	// the `$contextmenu` is needed because `submenu` is not reactive
 	$: ({selected} = ($contextmenu, submenu));
+
+	let el: HTMLElement;
+
+	// TODO BLOCK if it still doesn't fit onscreen, we need to choose the best side and clamp to the screen
+	// TODO BLOCK test with 3 levels deep
+	let translateX = '0px';
+	$: updatePosition(el, $layout);
+	const updatePosition = (
+		el: HTMLElement | undefined,
+		$layout: {width: number; height: number},
+	) => {
+		if (!el) {
+			translateX = '0px';
+			return;
+		}
+		const rect = el.getBoundingClientRect();
+		console.log('rect', rect);
+		// TODO change to reactive statements?
+		const parentWidth = 360; // TODO do we need the precise dimensions of the parent element or can we get away without them?
+		const {x, width} = rect;
+		// Does it fit onscreen to the right? If so just set x to 100%.
+		const overflowRight = x + width + parentWidth - $layout.width;
+		console.log('overflowRight', overflowRight);
+		if (overflowRight <= 0) {
+			translateX = '100%';
+		} else {
+			translateX = '-100%';
+		}
+	};
 </script>
 
 <!-- TODO what's the right structure for a11y? -->
@@ -31,7 +60,12 @@
 		<div class="chevron" />
 	</div>
 	{#if selected}
-		<ul class="contextmenu-submenu pane" role="menu" style="transform: translate3d(100%, 0, 0)">
+		<ul
+			bind:this={el}
+			class="contextmenu-submenu pane"
+			role="menu"
+			style="transform: translate3d({translateX}, 0, 0)"
+		>
 			<slot name="menu" />
 		</ul>
 	{/if}

--- a/src/lib/ui/contextmenu/ContextmenuSubmenu.svelte
+++ b/src/lib/ui/contextmenu/ContextmenuSubmenu.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	import {getContextmenu} from '$lib/ui/contextmenu/contextmenu';
+	import {
+		getContextmenu,
+		getContextmenuDimensions,
+		setContextmenuDimensions,
+	} from '$lib/ui/contextmenu/contextmenu';
 
 	const contextmenu = getContextmenu();
 
@@ -18,36 +22,35 @@
 
 	let el: HTMLElement;
 
+	const parentDimensions = getContextmenuDimensions();
+	const dimensions = setContextmenuDimensions();
+
 	// TODO BLOCK clamp height
-	let translateX = '0px';
-	$: updatePosition(el, $layout);
+	let translateX = 0;
+	$: updatePosition(el, $layout, $parentDimensions);
 	const updatePosition = (
 		el: HTMLElement | undefined,
 		$layout: {width: number; height: number},
+		$parentDimensions: {width: number; height: number},
 	) => {
 		if (!el) {
-			translateX = '0px';
+			translateX = 0;
 			return;
 		}
 		const rect = el.getBoundingClientRect();
-		console.log('rect', rect);
-		// TODO BLOCK get the precise dimensions of the parent element --
-		// in context or search the DOM and measure directly?
-		const parentWidth = 360;
+		$dimensions = {width: rect.width, height: rect.height};
 		const {x, width} = rect;
-		const overflowRight = x + width + parentWidth - $layout.width;
-		console.log('overflowRight', overflowRight);
+		const overflowRight = x + width + $parentDimensions.width - $layout.width;
 		if (overflowRight <= 0) {
-			translateX = '100%';
+			translateX = $parentDimensions.width;
 		} else {
 			const overflowLeft = width - x;
-			console.log('overflowLeft', overflowLeft);
 			if (overflowLeft <= 0) {
-				translateX = '-100%';
+				translateX = -width;
 			} else if (overflowLeft > overflowRight) {
-				translateX = `calc(100% - ${overflowRight}px)`;
+				translateX = $parentDimensions.width - overflowRight;
 			} else {
-				translateX = `calc(-100% + ${overflowLeft}px)`;
+				translateX = overflowLeft - width;
 			}
 		}
 	};
@@ -71,7 +74,7 @@
 			bind:this={el}
 			class="contextmenu-submenu pane"
 			role="menu"
-			style="transform: translate3d({translateX}, 0, 0)"
+			style="transform: translate3d({translateX}px, 0, 0)"
 		>
 			<slot name="menu" />
 		</ul>

--- a/src/lib/ui/contextmenu/ContextmenuSubmenu.svelte
+++ b/src/lib/ui/contextmenu/ContextmenuSubmenu.svelte
@@ -27,24 +27,21 @@
 
 	let translateX = 0;
 	let translateY = 0;
-	$: updatePosition(el, $layout, $parentDimensions);
+	$: el && updatePosition(el, $layout, $parentDimensions);
 	const updatePosition = (
-		el: HTMLElement | undefined,
+		el: HTMLElement,
 		$layout: {width: number; height: number},
 		$parentDimensions: {width: number; height: number},
 	) => {
-		if (!el) {
-			translateX = 0;
-			translateY = 0;
-			return;
-		}
 		const {x, y, width, height} = el.getBoundingClientRect();
 		$dimensions = {width, height};
-		const overflowRight = x + width + $parentDimensions.width - $layout.width;
+		const baseX = x - translateX;
+		const baseY = y - translateY;
+		const overflowRight = baseX + width + $parentDimensions.width - $layout.width;
 		if (overflowRight <= 0) {
 			translateX = $parentDimensions.width;
 		} else {
-			const overflowLeft = width - x;
+			const overflowLeft = width - baseX;
 			if (overflowLeft <= 0) {
 				translateX = -width;
 			} else if (overflowLeft > overflowRight) {
@@ -53,7 +50,7 @@
 				translateX = overflowLeft - width;
 			}
 		}
-		translateY = Math.min(0, $layout.height - (y + height));
+		translateY = Math.min(0, $layout.height - (baseY + height));
 	};
 </script>
 

--- a/src/lib/ui/contextmenu/ContextmenuSubmenu.svelte
+++ b/src/lib/ui/contextmenu/ContextmenuSubmenu.svelte
@@ -18,7 +18,7 @@
 
 	let el: HTMLElement;
 
-	// TODO BLOCK test with 3 levels deep
+	// TODO BLOCK clamp height
 	let translateX = '0px';
 	$: updatePosition(el, $layout);
 	const updatePosition = (
@@ -31,7 +31,9 @@
 		}
 		const rect = el.getBoundingClientRect();
 		console.log('rect', rect);
-		const parentWidth = 360; // TODO do we need the precise dimensions of the parent element or can we get away without them?
+		// TODO BLOCK get the precise dimensions of the parent element --
+		// in context or search the DOM and measure directly?
+		const parentWidth = 360;
 		const {x, width} = rect;
 		const overflowRight = x + width + parentWidth - $layout.width;
 		console.log('overflowRight', overflowRight);

--- a/src/lib/ui/contextmenu/ContextmenuSubmenu.svelte
+++ b/src/lib/ui/contextmenu/ContextmenuSubmenu.svelte
@@ -55,7 +55,7 @@
 </script>
 
 <!-- TODO what's the right structure for a11y? -->
-<li class="contextmenu-submenu-item">
+<li>
 	<div
 		class="menu-item"
 		role="menuitem"
@@ -70,9 +70,10 @@
 	{#if selected}
 		<ul
 			bind:this={el}
-			class="contextmenu-submenu pane"
+			class="pane"
 			role="menu"
-			style="transform: translate3d({translateX}px, {translateY}px, 0)"
+			style:transform="translate3d({translateX}px, {translateY}px, 0)"
+			style:max-height="{$layout.height}px"
 		>
 			<slot name="menu" />
 		</ul>
@@ -80,13 +81,13 @@
 </li>
 
 <style>
-	.contextmenu-submenu-item {
+	li {
 		position: relative;
 	}
 	.chevron {
 		padding-left: 5px;
 	}
-	.contextmenu-submenu {
+	ul {
 		z-index: 1;
 		position: absolute;
 		/* TODO this is a hack to avoid the pixel gap, probably change to 0 after adding transparent bg hitbox */

--- a/src/lib/ui/contextmenu/ContextmenuSubmenu.svelte
+++ b/src/lib/ui/contextmenu/ContextmenuSubmenu.svelte
@@ -18,7 +18,6 @@
 
 	let el: HTMLElement;
 
-	// TODO BLOCK if it still doesn't fit onscreen, we need to choose the best side and clamp to the screen
 	// TODO BLOCK test with 3 levels deep
 	let translateX = '0px';
 	$: updatePosition(el, $layout);
@@ -32,16 +31,22 @@
 		}
 		const rect = el.getBoundingClientRect();
 		console.log('rect', rect);
-		// TODO change to reactive statements?
 		const parentWidth = 360; // TODO do we need the precise dimensions of the parent element or can we get away without them?
 		const {x, width} = rect;
-		// Does it fit onscreen to the right? If so just set x to 100%.
 		const overflowRight = x + width + parentWidth - $layout.width;
 		console.log('overflowRight', overflowRight);
 		if (overflowRight <= 0) {
 			translateX = '100%';
 		} else {
-			translateX = '-100%';
+			const overflowLeft = width - x;
+			console.log('overflowLeft', overflowLeft);
+			if (overflowLeft <= 0) {
+				translateX = '-100%';
+			} else if (overflowLeft > overflowRight) {
+				translateX = `calc(100% - ${overflowRight}px)`;
+			} else {
+				translateX = `calc(-100% + ${overflowLeft}px)`;
+			}
 		}
 	};
 </script>
@@ -79,6 +84,7 @@
 		padding-left: 5px;
 	}
 	.contextmenu-submenu {
+		z-index: 1;
 		position: absolute;
 		/* TODO this is a hack to avoid the pixel gap, probably change to 0 after adding transparent bg hitbox */
 		left: -1px;

--- a/src/lib/ui/contextmenu/contextmenu.ts
+++ b/src/lib/ui/contextmenu/contextmenu.ts
@@ -36,6 +36,7 @@ export interface Contextmenu {
 }
 
 export interface ContextmenuStore extends Readable<Contextmenu> {
+	layout: Readable<{width: number; height: number}>;
 	action: typeof contextmenuAction;
 	open(items: ContextmenuItems, x: number, y: number): void;
 	close(): void;
@@ -65,7 +66,9 @@ const CONTEXTMENU_STATE_KEY = Symbol();
  * and for internal usage see `Contextmenu.svelte`.
  * @returns
  */
-export const createContextmenuStore = (): ContextmenuStore => {
+export const createContextmenuStore = (
+	layout: Readable<{width: number; height: number}>,
+): ContextmenuStore => {
 	const rootMenu: ContextmenuStore['rootMenu'] = {isMenu: true, menu: null, items: []};
 	const selections: ContextmenuStore['selections'] = [];
 
@@ -75,6 +78,7 @@ export const createContextmenuStore = (): ContextmenuStore => {
 		subscribe,
 		rootMenu,
 		selections,
+		layout,
 		action: contextmenuAction,
 		open: (items, x, y) => {
 			selections.length = 0;

--- a/src/lib/ui/contextmenu/contextmenu.ts
+++ b/src/lib/ui/contextmenu/contextmenu.ts
@@ -1,4 +1,4 @@
-import {writable, type Readable} from 'svelte/store';
+import {writable, type Readable, type Writable} from 'svelte/store';
 import {isEditable} from '@feltcoop/felt/util/dom.js';
 import {last} from '@feltcoop/felt/util/array.js';
 import {getContext, onDestroy, setContext, type SvelteComponent} from 'svelte';
@@ -238,3 +238,12 @@ const CONTEXTMENU_STORE_KEY = Symbol();
 export const setContextmenu = (contextmenu: ContextmenuStore): void =>
 	setContext(CONTEXTMENU_STORE_KEY, contextmenu);
 export const getContextmenu = (): ContextmenuStore => getContext(CONTEXTMENU_STORE_KEY);
+
+const CONTEXTMENU_DIMENSIONS_STORE_KEY = Symbol();
+export const setContextmenuDimensions = (): Writable<{width: number; height: number}> => {
+	const dimensions = writable({width: 0, height: 0});
+	setContext(CONTEXTMENU_DIMENSIONS_STORE_KEY, dimensions);
+	return dimensions;
+};
+export const getContextmenuDimensions = (): Writable<{width: number; height: number}> =>
+	getContext(CONTEXTMENU_DIMENSIONS_STORE_KEY);

--- a/src/lib/ui/contextmenu/contextmenu.ts
+++ b/src/lib/ui/contextmenu/contextmenu.ts
@@ -191,12 +191,11 @@ export const onContextmenu = (
 	LinkContextmenu?: typeof SvelteComponent,
 ): void | false => {
 	if (e.shiftKey) return;
-	const target = e.target as HTMLElement;
-	if (isEditable(target) || excludeEl?.contains(target)) return;
-	const items = queryContextmenuItems(target, LinkContextmenu);
-	if (!items) return;
 	e.stopPropagation();
 	e.preventDefault();
+	const target = e.target as HTMLElement;
+	const items = queryContextmenuItems(target, LinkContextmenu);
+	if (!items || isEditable(target) || excludeEl?.contains(target)) return;
 	// TODO dispatch a UI event, like OpenContextmenu
 	contextmenu.open(items, e.clientX, e.clientY);
 	return false; // TODO remove this if it doesn't fix FF mobile (and update the `false` return value)

--- a/src/lib/ui/ui.ts
+++ b/src/lib/ui/ui.ts
@@ -129,7 +129,7 @@ export const toUi = (
 
 	const mobile = writable(initialMobile);
 	const layout = writable({width: 0, height: 0}); // TODO will this initial value cause problems?
-	const contextmenu = createContextmenuStore();
+	const contextmenu = createContextmenuStore(layout);
 	const dialogs = writable<DialogData[]>([]);
 	const viewBySpace = mutable(new WeakMap());
 

--- a/src/lib/ui/ui.ts
+++ b/src/lib/ui/ui.ts
@@ -128,7 +128,7 @@ export const toUi = (
 	);
 
 	const mobile = writable(initialMobile);
-	const layout = writable({width: 0, height: 0}); // TODO will this initial value cause problems?
+	const layout = writable({width: 0, height: 0});
 	const contextmenu = createContextmenuStore(layout);
 	const dialogs = writable<DialogData[]>([]);
 	const viewBySpace = mutable(new WeakMap());

--- a/src/lib/ui/ui.ts
+++ b/src/lib/ui/ui.ts
@@ -65,6 +65,7 @@ export interface Ui extends Partial<UiHandlers> {
 	spaceIdSelectionByCommunityId: Readable<{[key: number]: number | null}>;
 	spaceSelection: Readable<Readable<Space> | null>;
 	mobile: Readable<boolean>;
+	layout: Writable<{width: number; height: number}>; // TODO maybe make `Readable` and update with an event? `resizeLayout`?
 	contextmenu: ContextmenuStore;
 	dialogs: Writable<DialogData[]>;
 	viewBySpace: Mutable<WeakMap<Readable<Space>, ViewData>>; // client overrides for the views set by the community
@@ -127,6 +128,7 @@ export const toUi = (
 	);
 
 	const mobile = writable(initialMobile);
+	const layout = writable({width: 0, height: 0}); // TODO will this initial value cause problems?
 	const contextmenu = createContextmenuStore();
 	const dialogs = writable<DialogData[]>([]);
 	const viewBySpace = mutable(new WeakMap());
@@ -259,6 +261,7 @@ export const toUi = (
 		communitiesBySessionPersona,
 		// view state
 		mobile,
+		layout,
 		expandMainNav,
 		expandMarquee,
 		contextmenu,

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -208,7 +208,7 @@
 	</main>
 	<DevmodeControls {devmode} />
 	<Dialogs {dialogs} on:close={() => dispatch('CloseDialog')} />
-	<Contextmenu {contextmenu} {LinkContextmenu} {layout} />
+	<Contextmenu {contextmenu} {LinkContextmenu} />
 	<FeltWindowHost query={() => ({hue: randomHue($account?.name || GUEST_PERSONA_NAME)})} />
 </div>
 

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -208,7 +208,7 @@
 	</main>
 	<DevmodeControls {devmode} />
 	<Dialogs {dialogs} on:close={() => dispatch('CloseDialog')} />
-	<Contextmenu {contextmenu} {LinkContextmenu} />
+	<Contextmenu {contextmenu} {LinkContextmenu} {layout} />
 	<FeltWindowHost query={() => ({hue: randomHue($account?.name || GUEST_PERSONA_NAME)})} />
 </div>
 

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -85,6 +85,7 @@
 
 	const {
 		mobile,
+		layout,
 		contextmenu,
 		dialogs,
 		account,
@@ -171,6 +172,10 @@
 			socket.connect(WEBSOCKET_URL);
 		}
 	}
+
+	let clientWidth: number;
+	let clientHeight: number;
+	$: $layout = {width: clientWidth, height: clientHeight};
 </script>
 
 <svelte:body
@@ -183,7 +188,7 @@
 	<link rel="shortcut icon" href="/favicon.png" />
 </svelte:head>
 
-<div class="layout" class:mobile={$mobile}>
+<div class="layout" class:mobile={$mobile} bind:clientHeight bind:clientWidth>
 	{#if !guest && !onboarding}
 		<Luggage />
 		<MainNav />


### PR DESCRIPTION
Improves the contextmenu to stay onscreen. It should choose the best placement of the pane, be reactive to window size changes, and it should work on small screens as long as there's enough width for each contextmenu pane.  (though it gets close to unusable on small screens, we'll want entirely different behavior for mobile)

We can't directly use `window.innerWidth` and `innerHeight` because they don't account for scrollbars, so to prevent scrollbars from overlapping the contextmenu, we pass it a `layout` store containing the `width` and `height` of whatever the app wants. In our case, this is the measured dimensions of `div.layout` in the root `__layout.svelte`. It seems useful to put this new `layout` store on our main `ui` object rather than hardcoding it to just the contextmenu; I imagine it'll be reused in the future.

I think we're close to upstreaming the contextmenu to Felt so it can join the dialogs, though we need to figure how we want to handle event dispatching in felt-server first.

future improvements, not pressing:

- if a contextmenu cannot fit vertically onscreen, clamp height and add scrollbars -- this is really difficult because of how we're doing layout where submenus are positioned naturally within their DOM element containers, so setting `overflow: auto` on menus hides any submenus
- in addition to the width/height controls, let users set an offsetX/Y to arbitrarily scope the positioning (currently it's forced to be relative to `0,0`, but users can choose the width/height to deal with scrollbars