### PR TITLE
Add default sort by created for entities

### DIFF
--- a/src/lib/vocab/entity/entityRepo.test.ts
+++ b/src/lib/vocab/entity/entityRepo.test.ts
@@ -21,6 +21,8 @@ test__entityRepo('entites return sorted by created', async ({db}) => {
 	assert.equal(entity0.space_id, entity1.space_id);
 	assert.equal(entity1.space_id, entity2.space_id);
 
+	// Ensure db sort order is shuffled from the insertion order.
+	await db.repos.entity.updateEntityData(entity1.entity_id, entity1.data);
 	const result = await db.repos.entity.filterBySpace(entity0.space_id);
 	assert.ok(result.ok);
 	assert.equal(entity0.entity_id, result.value[0].entity_id);

--- a/src/lib/vocab/entity/entityRepo.test.ts
+++ b/src/lib/vocab/entity/entityRepo.test.ts
@@ -1,0 +1,32 @@
+import {suite} from 'uvu';
+import * as assert from 'uvu/assert';
+
+import {setupDb, teardownDb, type TestDbContext} from '$lib/util/testDbHelpers';
+import {toRandomVocabContext} from '$lib/vocab/random';
+import type {TestAppContext} from '$lib/util/testAppHelpers';
+
+/* test__entityRepo */
+const test__entityRepo = suite<TestDbContext & TestAppContext>('entityRepo');
+
+test__entityRepo.before(setupDb);
+test__entityRepo.after(teardownDb);
+
+test__entityRepo('entites return sorted by created', async ({db}) => {
+	const random = toRandomVocabContext(db);
+	const space = await random.space();
+	const entity0 = await random.entity(undefined, undefined, undefined, space);
+	const entity1 = await random.entity(undefined, undefined, undefined, space);
+	const entity2 = await random.entity(undefined, undefined, undefined, space);
+
+	assert.equal(entity0.space_id, entity1.space_id);
+	assert.equal(entity1.space_id, entity2.space_id);
+
+	const result = await db.repos.entity.filterBySpace(entity0.space_id);
+	assert.ok(result.ok);
+	assert.equal(entity0.entity_id, result.value[0].entity_id);
+	assert.equal(entity1.entity_id, result.value[1].entity_id);
+	assert.equal(entity2.entity_id, result.value[2].entity_id);
+});
+
+test__entityRepo.run();
+/* test__entityRepo */

--- a/src/lib/vocab/entity/entityRepo.ts
+++ b/src/lib/vocab/entity/entityRepo.ts
@@ -26,6 +26,7 @@ export const entityRepo = (db: Database) =>
 			const entities = await db.sql<Entity[]>`
 				SELECT entity_id, data, actor_id, space_id, created, updated 
 				FROM entities WHERE space_id= ${space_id}
+				ORDER BY created ASC
 			`;
 			console.log('[db] space entities', entities);
 			return {ok: true, value: entities};


### PR DESCRIPTION
Quick PR that sorts entities by their `created` timestamp in ascending order (i.e 0th index is chronologically first).