### PR TITLE
Add delete entity

### DIFF
--- a/src/lib/app/contextmenu/EntityContextmenu.svelte
+++ b/src/lib/app/contextmenu/EntityContextmenu.svelte
@@ -23,5 +23,8 @@
 		>
 			<span class="title">Edit Entity</span>
 		</ContextmenuEntry>
+		<ContextmenuEntry action={() => dispatch('DeleteEntity', {entity_id: $entity.entity_id})}>
+			<span class="title">Delete Entity</span>
+		</ContextmenuEntry>
 	</svelte:fragment>
 </ContextmenuSubmenu>

--- a/src/lib/app/eventTypes.ts
+++ b/src/lib/app/eventTypes.ts
@@ -36,6 +36,7 @@ export interface EventParamsByName {
 	ReadEntities: ReadEntitiesParams;
 	UpdateEntity: UpdateEntityParams;
 	QueryEntities: QueryEntitiesParams;
+	DeleteEntity: DeleteEntityParams;
 	Ping: PingParams;
 	ToggleMainNav: ToggleMainNavParams;
 	ToggleSecondaryNav: ToggleSecondaryNavParams;
@@ -67,6 +68,7 @@ export interface EventResponseByName {
 	CreateEntity: CreateEntityResponse;
 	ReadEntities: ReadEntitiesResponse;
 	UpdateEntity: UpdateEntityResponse;
+	DeleteEntity: DeleteEntityResponse;
 	Ping: PingResponse;
 	CreateTie: CreateTieResponse;
 	ReadTies: ReadTiesResponse;
@@ -222,6 +224,12 @@ export interface QueryEntitiesParams {
 	space_id: number;
 }
 
+export interface DeleteEntityParams {
+	entity_id: number;
+}
+export type DeleteEntityResponse = null;
+export type DeleteEntityResponseResult = ApiResult<DeleteEntityResponse>;
+
 export type PingParams = void;
 export type PingResponse = null;
 export type PingResponseResult = ApiResult<PingResponse>;
@@ -314,6 +322,7 @@ export interface Dispatch {
 	(eventName: 'ReadEntities', params: ReadEntitiesParams): Promise<ReadEntitiesResponseResult>;
 	(eventName: 'UpdateEntity', params: UpdateEntityParams): Promise<UpdateEntityResponseResult>;
 	(eventName: 'QueryEntities', params: QueryEntitiesParams): Readable<Readable<Entity>[]>;
+	(eventName: 'DeleteEntity', params: DeleteEntityParams): Promise<DeleteEntityResponseResult>;
 	(eventName: 'Ping', params: PingParams): Promise<ApiResult<null>>;
 	(eventName: 'ToggleMainNav', params: ToggleMainNavParams): void;
 	(eventName: 'ToggleSecondaryNav', params: ToggleSecondaryNavParams): void;
@@ -381,6 +390,9 @@ export interface UiHandlers {
 		ctx: DispatchContext<UpdateEntityParams, UpdateEntityResponseResult>,
 	) => Promise<UpdateEntityResponseResult>;
 	QueryEntities: (ctx: DispatchContext<QueryEntitiesParams, void>) => Readable<Readable<Entity>[]>;
+	DeleteEntity: (
+		ctx: DispatchContext<DeleteEntityParams, DeleteEntityResponseResult>,
+	) => Promise<DeleteEntityResponseResult>;
 	Ping: (ctx: DispatchContext<PingParams, PingResponseResult>) => Promise<ApiResult<null>>;
 	ToggleMainNav: (ctx: DispatchContext<ToggleMainNavParams, void>) => void;
 	ToggleSecondaryNav: (ctx: DispatchContext<ToggleSecondaryNavParams, void>) => void;

--- a/src/lib/server/random.ts
+++ b/src/lib/server/random.ts
@@ -122,6 +122,13 @@ export const randomEventParams = async (
 				data: randomEntityData(),
 			};
 		}
+		case 'DeleteEntity': {
+			return {
+				entity_id: (
+					randomItem(random.entities) || (await random.entity(persona, account, community, space))
+				).entity_id,
+			};
+		}
 		case 'CreateTie': {
 			return {
 				source_id: (

--- a/src/lib/server/services.ts
+++ b/src/lib/server/services.ts
@@ -16,6 +16,7 @@ import {
 	readEntitiesService,
 	createEntityService,
 	updateEntityService,
+	deleteEntityService,
 } from '$lib/vocab/entity/entityServices';
 import {
 	readSpaceService,
@@ -38,6 +39,7 @@ export const services: Map<string, Service<any, any>> = new Map(
 		createSpaceService,
 		createEntityService,
 		updateEntityService,
+		deleteEntityService,
 		readCommunityService,
 		readCommunitiesService,
 		updateCommunitySettingsService,

--- a/src/lib/ui/ui.ts
+++ b/src/lib/ui/ui.ts
@@ -505,11 +505,11 @@ export const toUi = (
 			entity!.set(updatedEntity);
 			return result;
 		},
-		DeleteEntity: async ({params, invoke}) => {
+		DeleteEntity: async ({invoke}) => {
 			const result = await invoke();
 			if (!result.ok) return result;
 			//update state here
-			const {entity_id} = params;
+
 			//TODO add store updates once new entity/tie stores are in place
 			return result;
 		},

--- a/src/lib/ui/ui.ts
+++ b/src/lib/ui/ui.ts
@@ -495,7 +495,7 @@ export const toUi = (
 		},
 		UpdateEntity: async ({invoke}) => {
 			const result = await invoke();
-			console.log('updateEnity result', result);
+			console.log('updateEntity result', result);
 			if (!result.ok) return result;
 			//TODO maybe return to $entity naming convention OR propagate this pattern?
 			const {entity: updatedEntity} = result.value;
@@ -503,6 +503,14 @@ export const toUi = (
 			const entities = entitiesBySpace.get(updatedEntity.space_id);
 			const entity = get(entities!).find((e) => get(e).entity_id === updatedEntity.entity_id);
 			entity!.set(updatedEntity);
+			return result;
+		},
+		DeleteEntity: async ({params, invoke}) => {
+			const result = await invoke();
+			if (!result.ok) return result;
+			//update state here
+			const {entity_id} = params;
+			//TODO add store updates once new entity/tie stores are in place
 			return result;
 		},
 		ReadEntities: async ({params, invoke}) => {

--- a/src/lib/vocab/entity/entity.events.ts
+++ b/src/lib/vocab/entity/entity.events.ts
@@ -109,4 +109,34 @@ export const QueryEntities: ClientEventInfo = {
 	returns: 'Readable<Readable<Entity>[]>',
 };
 
-export const events: EventInfo[] = [CreateEntity, ReadEntities, UpdateEntity, QueryEntities];
+export const DeleteEntity: ServiceEventInfo = {
+	type: 'ServiceEvent',
+	name: 'DeleteEntity',
+	broadcast: true,
+	params: {
+		$id: '/schemas/DeleteEntityParams.json',
+		type: 'object',
+		properties: {
+			entity_id: {type: 'number'},
+		},
+		required: ['entity_id'],
+		additionalProperties: false,
+	},
+	response: {
+		$id: '/schemas/DeleteEntityResponse.json',
+		type: 'null',
+	},
+	returns: 'Promise<DeleteEntityResponseResult>',
+	route: {
+		path: '/api/v1/entities/:entity_id',
+		method: 'DELETE',
+	},
+};
+
+export const events: EventInfo[] = [
+	CreateEntity,
+	ReadEntities,
+	UpdateEntity,
+	QueryEntities,
+	DeleteEntity,
+];

--- a/src/lib/vocab/entity/entityRepo.ts
+++ b/src/lib/vocab/entity/entityRepo.ts
@@ -46,7 +46,27 @@ export const entityRepo = (db: Database) =>
 			}
 			return {ok: true, value: result[0]};
 		},
+		//This function is a idempotent soft delete, that leaves behind a Tombstone entity per Activity-Streams spec
 		deleteById: async (
+			entity_id: number,
+		): Promise<Result<{value: any[]}, {type: 'deletion_error'} & ErrorResponse>> => {
+			console.log('[entityRepo] deleting space :', entity_id);
+			const data = await db.sql<any[]>`
+				UPDATE entities
+				SET data = jsonb_build_object('type','Tombstone','formerType',data->'type','deleted',NOW())
+				WHERE entity_id=${entity_id} AND data->>'type' != 'Tombstone';
+			`;
+			if (data.count !== 1) {
+				return {
+					ok: false,
+					type: 'deletion_error',
+					message: 'failed to delete entity',
+				};
+			}
+			return {ok: true, value: data};
+		},
+		//This function actually deletes the record in the DB
+		hardDeleteById: async (
 			entity_id: number,
 		): Promise<Result<{value: any[]}, {type: 'deletion_error'} & ErrorResponse>> => {
 			console.log('[entityRepo] deleting space :', entity_id);
@@ -57,7 +77,7 @@ export const entityRepo = (db: Database) =>
 				return {
 					ok: false,
 					type: 'deletion_error',
-					message: 'failed to delete entity',
+					message: 'failed to hard delete entity',
 				};
 			}
 			return {ok: true, value: data};

--- a/src/lib/vocab/entity/entityRepo.ts
+++ b/src/lib/vocab/entity/entityRepo.ts
@@ -17,25 +17,25 @@ export const entityRepo = (db: Database) =>
 					${actor_id},${space_id},${db.sql.json(data)}
 				) RETURNING *
 			`;
-			// console.log('[db] create entity', data);
+			// console.log('[entityRepo] create entity', data);
 			return {ok: true, value: entity[0]};
 		},
 		// TODO maybe `EntityQuery`?
 		filterBySpace: async (space_id: number): Promise<Result<{value: Entity[]}>> => {
-			console.log(`[db] preparing to query for space entities: ${space_id}`);
+			console.log(`[entityRepo] preparing to query for space entities: ${space_id}`);
 			const entities = await db.sql<Entity[]>`
 				SELECT entity_id, data, actor_id, space_id, created, updated 
 				FROM entities WHERE space_id= ${space_id}
 				ORDER BY created ASC
 			`;
-			console.log('[db] space entities', entities);
+			console.log('[entityRepo] space entities', entities);
 			return {ok: true, value: entities};
 		},
 		updateEntityData: async (
 			entity_id: number,
 			data: EntityData,
 		): Promise<Result<{value: Entity}, ErrorResponse>> => {
-			console.log(`[db] updating data for entity: ${entity_id}`);
+			console.log(`[entityRepo] updating data for entity: ${entity_id}`);
 			const result = await db.sql<Entity[]>`
 				UPDATE entities SET data=${db.sql.json(data)}, updated=NOW()
 				WHERE entity_id= ${entity_id}
@@ -45,5 +45,21 @@ export const entityRepo = (db: Database) =>
 				return {ok: false, message: 'failed to update entity data'};
 			}
 			return {ok: true, value: result[0]};
+		},
+		deleteById: async (
+			entity_id: number,
+		): Promise<Result<{value: any[]}, {type: 'deletion_error'} & ErrorResponse>> => {
+			console.log('[entityRepo] deleting space :', entity_id);
+			const data = await db.sql<any[]>`
+				DELETE FROM entities WHERE ${entity_id}=entity_id
+			`;
+			if (data.count !== 1) {
+				return {
+					ok: false,
+					type: 'deletion_error',
+					message: 'failed to delete entity',
+				};
+			}
+			return {ok: true, value: data};
 		},
 	} as const);

--- a/src/lib/vocab/entity/entityServices.ts
+++ b/src/lib/vocab/entity/entityServices.ts
@@ -6,8 +6,15 @@ import type {
 	ReadEntitiesResponseResult,
 	UpdateEntityParams,
 	UpdateEntityResponseResult,
+	DeleteEntityParams,
+	DeleteEntityResponseResult,
 } from '$lib/app/eventTypes';
-import {ReadEntities, UpdateEntity, CreateEntity} from '$lib/vocab/entity/entity.events';
+import {
+	ReadEntities,
+	UpdateEntity,
+	CreateEntity,
+	DeleteEntity,
+} from '$lib/vocab/entity/entity.events';
 
 // TODO rename to `getEntities`? `loadEntities`?
 export const readEntitiesService: Service<ReadEntitiesParams, ReadEntitiesResponseResult> = {
@@ -51,5 +58,20 @@ export const updateEntityService: Service<UpdateEntityParams, UpdateEntityRespon
 		}
 		console.log('[UpdateEntity] error updating entity');
 		return {ok: false, status: 500, message: 'failed to update entity'};
+	},
+};
+
+//deletes a single entity
+export const deleteEntityService: Service<DeleteEntityParams, DeleteEntityResponseResult> = {
+	event: DeleteEntity,
+	perform: async ({repos, params}) => {
+		console.log('[DeleteEntity] deleting entity with id:', params.entity_id);
+		const result = await repos.entity.deleteById(params.entity_id);
+		console.log(result);
+		if (!result.ok) {
+			console.log('[DeleteEntity] error removing entity: ', params.entity_id);
+			return {ok: false, status: 500, message: result.message};
+		}
+		return {ok: true, status: 200, value: null};
 	},
 };

--- a/src/lib/vocab/space/spaceServices.ts
+++ b/src/lib/vocab/space/spaceServices.ts
@@ -103,7 +103,7 @@ export const updateSpaceService: Service<UpdateSpaceParams, UpdateSpaceResponseR
 	},
 };
 
-//deletes a single space and returns the id of the deleted spaces
+//deletes a single space
 export const deleteSpaceService: Service<DeleteSpaceParams, DeleteSpaceResponseResult> = {
 	event: DeleteSpace,
 	perform: async ({repos, params}) => {


### PR DESCRIPTION
This PR adds both server & client functionality for deleting an Entity

A few notes:
1.) I implemented both a hard and soft delete query. Currently the logic calls the soft version. No views have been updated to reflect these "Tombstone" objects though.

2.) The client UI call to delete doesn't do anything with Entity stores, since we're planning on refactoring those soon (and I'd then have to add the space_id to the params and it would just become a Thing)

3.) There's currently no friction the delete entity action. Might want that for context deletes by default and then have views manage any "frictionless" deletes directly.