### PR TITLE
Only render the community invite entry if it's not a personal community

### DIFF
--- a/src/lib/app/contextmenu/CommunityContextmenu.svelte
+++ b/src/lib/app/contextmenu/CommunityContextmenu.svelte
@@ -30,14 +30,16 @@
 		>
 			<span class="title">Create Space</span>
 		</ContextmenuEntry>
-		<ContextmenuEntry
-			action={() =>
-				dispatch('OpenDialog', {
-					Component: MembershipInput,
-					props: {community},
-				})}
-		>
-			<span class="title">Invite Members</span>
-		</ContextmenuEntry>
+		{#if $community.type !== 'personal'}
+			<ContextmenuEntry
+				action={() =>
+					dispatch('OpenDialog', {
+						Component: MembershipInput,
+						props: {community},
+					})}
+			>
+				<span class="title">Invite Members</span>
+			</ContextmenuEntry>
+		{/if}
 	</svelte:fragment>
 </ContextmenuSubmenu>


### PR DESCRIPTION
Block users from inviting users to personal communities in the UX