### PR TITLE
fix logged error in tests

### DIFF
--- a/src/lib/app/events.test.ts
+++ b/src/lib/app/events.test.ts
@@ -43,7 +43,7 @@ test__eventInfos('dispatch random events in a client app', async ({db, app}) => 
 		}
 
 		// TODO can't make remote calls yet -- either use `node-fetch` or mock
-		if (eventInfo.type !== 'ClientEvent') {
+		if (eventInfo.type !== 'ClientEvent' || eventInfo.name === 'QueryEntities') {
 			continue;
 		}
 


### PR DESCRIPTION
Running tests logs (but doesn't throw) an error for the `QueryEntities` event because we don't support `fetch` from the client during tests yet. Ideally it should be a thrown error, but the problem is that the event blurs the lines between client events and service events. It synchronously returns a store and then populates it, and doesn't throw an error. We can figure out a more robust fix later down the line when we figure out entity querying and using `fetch` in tests.