### PR TITLE
simplify MarqueeNav

### DIFF
--- a/src/lib/ui/Marquee.svelte
+++ b/src/lib/ui/Marquee.svelte
@@ -22,7 +22,7 @@
 	$: communityPersonas = $personasByCommunityId.get($community.community_id)!;
 </script>
 
-<MarqueeNav {community} {space} />
+<MarqueeNav />
 
 <!-- TODO display other meta info about the community -->
 {#if $expandMarquee}

--- a/src/lib/ui/Marquee.svelte
+++ b/src/lib/ui/Marquee.svelte
@@ -22,7 +22,7 @@
 	$: communityPersonas = $personasByCommunityId.get($community.community_id)!;
 </script>
 
-<MarqueeNav />
+<MarqueeNav {communityPersonas} />
 
 <!-- TODO display other meta info about the community -->
 {#if $expandMarquee}

--- a/src/lib/ui/MarqueeNav.svelte
+++ b/src/lib/ui/MarqueeNav.svelte
@@ -1,4 +1,12 @@
-<div class="marquee-nav">Members</div>
+<script lang="ts">
+	import type {Readable} from 'svelte/store';
+
+	import type {Persona} from '$lib/vocab/persona/persona';
+
+	export let communityPersonas: Array<Readable<Persona>>;
+</script>
+
+<div class="marquee-nav">Members — {communityPersonas.length}</div>
 
 <style>
 	.marquee-nav {

--- a/src/lib/ui/MarqueeNav.svelte
+++ b/src/lib/ui/MarqueeNav.svelte
@@ -1,49 +1,14 @@
-<script lang="ts">
-	import type {Readable} from 'svelte/store';
-
-	import type {Space} from '$lib/vocab/space/space';
-	import type {Community} from '$lib/vocab/community/community';
-	import Avatar from '$lib/ui/Avatar.svelte';
-	import {toUrl} from '$lib/vocab/persona/constants';
-	import {randomHue} from '$lib/ui/color';
-
-	/* 
-  
-  TODO design
-  
-  - maybe show only icons for the persona+community?
-
-  */
-
-	export let community: Readable<Community>;
-	export let space: Readable<Space | null>;
-
-	$: href = `/${$community.name}${toUrl($space?.url)}`;
-</script>
-
-<div class="marquee-nav">
-	<!-- TODO url extract helper -->
-	<a class="avatars" {href} style="--hue: {randomHue($community.name)}">
-		<Avatar name={$community.name} showName={false} type="Community" />
-		<span class="url">{href}</span>
-	</a>
-</div>
+<div class="marquee-nav">Members</div>
 
 <style>
 	.marquee-nav {
 		position: relative;
 		display: flex;
 		justify-content: space-between;
+		align-items: center;
+		padding-left: var(--spacing_lg);
 		height: var(--navbar_size);
 		background-color: var(--tint_dark_1);
 		padding-right: var(--navbar_size); /* placeholder for button, which is rendered elsewhere */
-	}
-	.avatars {
-		display: flex;
-		align-items: center;
-		height: 100%;
-	}
-	.url {
-		padding: 0 var(--spacing_xs);
 	}
 </style>

--- a/src/lib/ui/MarqueeNav.svelte
+++ b/src/lib/ui/MarqueeNav.svelte
@@ -6,9 +6,9 @@
 		display: flex;
 		justify-content: space-between;
 		align-items: center;
-		padding-left: var(--spacing_lg);
 		height: var(--navbar_size);
 		background-color: var(--tint_dark_1);
 		padding-right: var(--navbar_size); /* placeholder for button, which is rendered elsewhere */
+		padding-left: var(--spacing_lg);
 	}
 </style>

--- a/src/lib/ui/MemberItem.svelte
+++ b/src/lib/ui/MemberItem.svelte
@@ -13,10 +13,8 @@
 	export let persona: Readable<Persona>;
 </script>
 
-{#if $persona.type === 'account'}
-	<li
-		use:contextmenu.action={[[PersonaContextmenu, {persona: personaById.get($persona.persona_id)}]]}
-	>
-		<PersonaAvatar {persona} />
-	</li>
-{/if}
+<li
+	use:contextmenu.action={[[PersonaContextmenu, {persona: personaById.get($persona.persona_id)}]]}
+>
+	<PersonaAvatar {persona} />
+</li>

--- a/src/lib/ui/ui.ts
+++ b/src/lib/ui/ui.ts
@@ -123,7 +123,9 @@ export const toUi = (
 				const {community_id} = get(community);
 				for (const membership of $memberships.value) {
 					if (get(membership).community_id === community_id) {
-						communityPersonas.push(personaById.get(get(membership).persona_id)!);
+						const persona = personaById.get(get(membership).persona_id)!;
+						if (get(persona).type !== 'account') continue;
+						communityPersonas.push(persona);
 					}
 				}
 				map.set(community_id, communityPersonas);


### PR DESCRIPTION
The `MarqueeNav` previously displayed useful information, but after adding the community icon+name to the main space header, it's now redundant. This changes its content to a single word, `Members`, along with the member count. I'm also open to just deleting it for now, but I assume we'll want a component with its name in the future once the marquee gets filled out.

I also changed `personasByCommunityId` to include only `account` personas, because the count was off otherwise. This also let us remove the hack from `MemberItem` where we excluded `community` personas. We shouldn't have to deal with those until we're ready for them.
