### PR TITLE
improve schema registration hack

### DIFF
--- a/src/lib/util/ajv.ts
+++ b/src/lib/util/ajv.ts
@@ -12,12 +12,12 @@ export const ajv = (opts?: Options): Ajv => {
 	ajvInstance = new Ajv(opts);
 	ajvInstance.addKeyword('tsType').addKeyword('tsImport');
 	addFormats(ajvInstance);
-	const addedSchemas = new Set<string>();
+	const registered = new Set<string>();
 	for (const schema of schemas) {
 		//TODO BIG HACK HERE; should use references in anyOf, and then call `addSchema` with only `schema`
 		traverse(schema, (key, value, obj) => {
-			if (key === '$id' && !addedSchemas.has(value)) {
-				addedSchemas.add(value);
+			if (key === '$id' && !registered.has(value)) {
+				registered.add(value);
 				ajvInstance!.addSchema(obj);
 			}
 		});


### PR DESCRIPTION
edit: closing because #281 has a proper fix

Improves the schema registration hack to include any `$id` schema declared anywhere in any schema, rather than hardcoding to just `anyOf`.