### PR TITLE
add community editor

### DIFF
--- a/src/lib/app/contextmenu/CommunityContextmenu.svelte
+++ b/src/lib/app/contextmenu/CommunityContextmenu.svelte
@@ -9,6 +9,7 @@
 	import ContextmenuSubmenu from '$lib/ui/contextmenu/ContextmenuSubmenu.svelte';
 	import SpaceInput from '$lib/ui/SpaceInput.svelte';
 	import MembershipInput from '$lib/ui/MembershipInput.svelte';
+	import CommunityEditor from '$lib/ui/CommunityEditor.svelte';
 
 	const {dispatch} = getApp();
 
@@ -21,6 +22,15 @@
 		<CommunityAvatar {community} />
 	</svelte:fragment>
 	<svelte:fragment slot="menu">
+		<ContextmenuEntry
+			action={() =>
+				dispatch('OpenDialog', {
+					Component: CommunityEditor,
+					props: {community},
+				})}
+		>
+			<span class="title"> Edit Community </span>
+		</ContextmenuEntry>
 		<ContextmenuEntry
 			action={() =>
 				dispatch('OpenDialog', {

--- a/src/lib/ui/CommunityAvatar.svelte
+++ b/src/lib/ui/CommunityAvatar.svelte
@@ -13,6 +13,7 @@
 <Avatar
 	name={$community.name}
 	type="Community"
+	hue={$community.settings.hue}
 	{showName}
 	{showIcon}
 	contextmenuAction={[[CommunityContextmenu, {community}]]}

--- a/src/lib/ui/CommunityEditor.svelte
+++ b/src/lib/ui/CommunityEditor.svelte
@@ -11,7 +11,7 @@
 
 <div class="community-editor column">
 	<div class="markup">
-		<h2>Edit Community</h2>
+		<h1>Edit Community</h1>
 		<section class="row" style:font-size="var(--font_size_xl)">
 			<CommunityAvatar {community} />
 		</section>
@@ -33,7 +33,7 @@
 		flex-direction: column;
 		padding: var(--spacing_xl);
 	}
-	h2 {
+	h1 {
 		text-align: center;
 	}
 </style>

--- a/src/lib/ui/CommunityEditor.svelte
+++ b/src/lib/ui/CommunityEditor.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+	import {type Readable} from 'svelte/store';
+	import {format} from 'date-fns';
+
+	import {type Community} from '$lib/vocab/community/community';
+	import CommunityAvatar from '$lib/ui/CommunityAvatar.svelte';
+	import CommunitySettingsHue from '$lib/ui/CommunitySettingsHue.svelte';
+
+	export let community: Readable<Community>;
+</script>
+
+<div class="community-editor column">
+	<div class="markup">
+		<h2>Edit Community</h2>
+		<section class="row" style:font-size="var(--font_size_xl)">
+			<CommunityAvatar {community} />
+		</section>
+		<section>
+			<p>created {format(new Date($community.created), 'PPPPp')}</p>
+			{#if $community.updated !== null}
+				<p>updated {format(new Date($community.updated), 'PPPPp')}</p>
+			{/if}
+		</section>
+	</div>
+	<section>
+		<CommunitySettingsHue {community} />
+	</section>
+</div>
+
+<style>
+	.community-editor {
+		display: flex;
+		flex-direction: column;
+		padding: var(--spacing_xl);
+	}
+	h2 {
+		text-align: center;
+	}
+</style>

--- a/src/lib/ui/CommunitySettingsHue.svelte
+++ b/src/lib/ui/CommunitySettingsHue.svelte
@@ -3,7 +3,6 @@
 	import {throttle} from 'throttle-debounce';
 	import HueInput from '@feltcoop/felt/ui/HueInput.svelte';
 
-	import EntityIcon from '$lib/ui/EntityIcon.svelte';
 	import {getApp} from '$lib/ui/app';
 	import type {Community} from '$lib/vocab/community/community';
 
@@ -22,14 +21,3 @@
 
 <!-- TODO maybe add a title or tooltip explaining `community.settings.hue` -->
 <HueInput hue={$community.settings.hue} on:input={(e) => updateHue(e.detail)} />
-<div class="community-icon">
-	<EntityIcon name={$community.name} type="Community" --hue={$community.settings.hue} />
-</div>
-
-<style>
-	.community-icon {
-		/* TODO instead of this, maybe have a "centered-box" or "box" or "flex-centered" or copy Tailwind */
-		display: flex;
-		justify-content: center;
-	}
-</style>

--- a/src/lib/ui/EntityEditor.svelte
+++ b/src/lib/ui/EntityEditor.svelte
@@ -34,7 +34,7 @@
 
 <div class="entity-editor column">
 	<div class="markup">
-		<h2>Edit Entity</h2>
+		<h1>Edit Entity</h1>
 		<section class="row">
 			<span class="spaced">created by</span>
 			<PersonaAvatar {persona} />
@@ -81,7 +81,7 @@
 	.entity-editor {
 		padding: var(--spacing_xl);
 	}
-	h2 {
+	h1 {
 		text-align: center;
 	}
 	form li {

--- a/src/lib/ui/SpaceEditor.svelte
+++ b/src/lib/ui/SpaceEditor.svelte
@@ -27,7 +27,7 @@
 
 <div class="space-editor column">
 	<div class="markup">
-		<h2>Edit Space</h2>
+		<h1>Edit Space</h1>
 		<section class="row" style:font-size="var(--font_size_xl)">
 			<SpaceName {space} />
 		</section>
@@ -84,7 +84,7 @@
 		flex-direction: column;
 		padding: var(--spacing_xl);
 	}
-	h2 {
+	h1 {
 		text-align: center;
 	}
 	form li {

--- a/src/lib/ui/view/Home.svelte
+++ b/src/lib/ui/view/Home.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import {format} from 'date-fns';
 
-	import CommunitySettingsHue from '$lib/ui/CommunitySettingsHue.svelte';
 	import MemberItem from '$lib/ui/MemberItem.svelte';
 	import SpaceInfo from '$lib/ui/SpaceInfo.svelte';
 	import {getApp} from '$lib/ui/app';
@@ -46,10 +45,6 @@
 		<h2>activity</h2>
 		<div>This community was created on {format(new Date($community.created), 'PPPPp')}</div>
 		<code>TODO</code>
-	</section>
-	<section>
-		<h2>settings</h2>
-		<CommunitySettingsHue {community} />
 	</section>
 </div>
 


### PR DESCRIPTION
- add "Edit Community" contextmenu entry which opens a new `CommunityEditor.svelte`
- move the hue settings widget from `Home.svelte` to `CommunityEditor.svelte`
- consistently use `h1` in dialog menus for the titles (we're manually centering these each time they're used, might be a good time to standardize a pattern with a class)