### PR TITLE
fix redirect aftering creating a community and persona

### DIFF
--- a/src/lib/ui/ui.ts
+++ b/src/lib/ui/ui.ts
@@ -390,13 +390,9 @@ export const toUi = (
 			log.trace('[CreatePersona]', $persona, $community, $spaces);
 			const persona = addPersona($persona);
 			addCommunity($community, $spaces, [$membership]);
-			// TODO BLOCK probably extract a helper
-			await goto(
-				'/' +
-					$community.name +
-					// TODO after upgrading SvelteKit, use `$page`'s `URLSearchParams` instead of constructing the search like this
-					`?persona=${get(sessionPersonaIndices).get(persona)}`,
-			);
+			// TODO extract a helper after upgrading SvelteKit and using
+			// `$page`'s `URLSearchParams` instead of constructing the search like this
+			await goto('/' + $community.name + `?persona=${get(sessionPersonaIndices).get(persona)}`);
 			return result;
 		},
 		CreateCommunity: async ({params, invoke}) => {
@@ -412,13 +408,9 @@ export const toUi = (
 			log.trace('[ui.CreateCommunity]', $community, persona_id);
 			const persona = addPersona($persona);
 			addCommunity($community, $spaces, $memberships);
-			// TODO BLOCK probably extract a helper
-			await goto(
-				'/' +
-					$community.name +
-					// TODO after upgrading SvelteKit, use `$page`'s `URLSearchParams` instead of constructing the search like this
-					`?persona=${get(sessionPersonaIndices).get(persona)}`,
-			);
+			// TODO extract a helper after upgrading SvelteKit and using
+			// `$page`'s `URLSearchParams` instead of constructing the search like this
+			await goto('/' + $community.name + `?persona=${get(sessionPersonaIndices).get(persona)}`);
 			return result;
 		},
 		UpdateCommunitySettings: async ({params, invoke}) => {

--- a/src/lib/ui/ui.ts
+++ b/src/lib/ui/ui.ts
@@ -406,11 +406,15 @@ export const toUi = (
 				communityPersona: $persona,
 			} = result.value;
 			log.trace('[ui.CreateCommunity]', $community, persona_id);
-			const persona = addPersona($persona);
+			addPersona($persona);
 			addCommunity($community, $spaces, $memberships);
 			// TODO extract a helper after upgrading SvelteKit and using
 			// `$page`'s `URLSearchParams` instead of constructing the search like this
-			await goto('/' + $community.name + `?persona=${get(sessionPersonaIndices).get(persona)}`);
+			await goto(
+				'/' +
+					$community.name +
+					`?persona=${get(sessionPersonaIndices).get(personaById.get(params.persona_id)!)}`,
+			);
 			return result;
 		},
 		UpdateCommunitySettings: async ({params, invoke}) => {

--- a/src/lib/ui/ui.ts
+++ b/src/lib/ui/ui.ts
@@ -18,6 +18,7 @@ import {type UiHandlers} from '$lib/app/eventTypes';
 import {createContextmenuStore, type ContextmenuStore} from '$lib/ui/contextmenu/contextmenu';
 import {type ViewData} from '$lib/vocab/view/view';
 import {initBrowser} from '$lib/ui/init';
+import {page} from '$app/stores';
 
 if (browser) initBrowser();
 
@@ -387,11 +388,12 @@ export const toUi = (
 			log.trace('[CreatePersona]', $persona, $community, $spaces);
 			addPersona($persona);
 			addCommunity($community, $spaces, [$membership]);
+			// TODO BLOCK
 			dispatch('SelectPersona', {persona_id: $persona.persona_id});
 			dispatch('SelectCommunity', {community_id: $community.community_id});
 			return result;
 		},
-		CreateCommunity: async ({params, invoke, dispatch}) => {
+		CreateCommunity: async ({params, invoke}) => {
 			const result = await invoke();
 			if (!result.ok) return result;
 			const {persona_id} = params;
@@ -404,7 +406,12 @@ export const toUi = (
 			log.trace('[ui.CreateCommunity]', $community, persona_id);
 			addPersona($persona);
 			addCommunity($community, $spaces, $memberships);
-			dispatch('SelectCommunity', {community_id: $community.community_id});
+			await goto(
+				'/' +
+					$community.name +
+					// TODO after upgrading SvelteKit, use `$page`'s `URLSearchParams` instead of constructing the search like this
+					`?persona=${get(sessionPersonaIndices).get(personaById.get(persona_id)!)}`,
+			);
 			return result;
 		},
 		UpdateCommunitySettings: async ({params, invoke}) => {

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -101,6 +101,7 @@
 		params: {community?: string; space?: string},
 		query: URLSearchParams,
 	) => {
+		console.log(`updateStateFromPageParams params, query`, params, query);
 		if (!params.community) return;
 
 		const rawPersonaIndex = query.get(PERSONA_QUERY_KEY);

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -101,7 +101,6 @@
 		params: {community?: string; space?: string},
 		query: URLSearchParams,
 	) => {
-		console.log(`updateStateFromPageParams params, query`, params, query);
 		if (!params.community) return;
 
 		const rawPersonaIndex = query.get(PERSONA_QUERY_KEY);


### PR DESCRIPTION
Instead of dispatching select events after creating a community or persona, this updates the URL as the source of truth, and then fixes the state to be properly reactive.

Also appears to fix the bug where newly created communities don't appear correctly selected in the nav.