### PR TITLE
fix selection after deleting space

### DIFF
--- a/src/lib/ui/ui.ts
+++ b/src/lib/ui/ui.ts
@@ -315,10 +315,11 @@ export const toUi = (
 					: Object.fromEntries(
 							$session.communities
 								.map(($community) => {
-									const $firstSpace = $session.spaces.find(
-										(s) => s.community_id === $community.community_id,
+									//TODO lookup space by community_id+url (see this comment in multiple places)
+									const $homeSpace = $session.spaces.find(
+										(s) => s.community_id === $community.community_id && s.url === '/',
 									)!;
-									return [$community.community_id, $firstSpace.space_id];
+									return [$community.community_id, $homeSpace.space_id];
 								})
 								.filter(Boolean),
 					  ),

--- a/src/lib/vocab/space/spaceMutations.ts
+++ b/src/lib/vocab/space/spaceMutations.ts
@@ -34,19 +34,19 @@ export const DeleteSpace: Mutations['DeleteSpace'] = async ({
 	const {community_id} = $space;
 	const $spaceIdSelectionByCommunityId = get(spaceIdSelectionByCommunityId);
 
-	// If the deleted space is selected, select a fallback.
+	// If the deleted space is selected, select the home space as a fallback.
 	if (space_id === $spaceIdSelectionByCommunityId[community_id]) {
 		const community = communityById.get(community_id)!;
 		if (community === get(communitySelection)) {
 			await goto('/' + get(community).name + location.search, {replaceState: true});
 		} else {
 			//TODO lookup space by community_id+url (see this comment in multiple places)
-			const selectedSpaceFallback = get(spacesByCommunityId)
+			const homeSpace = get(spacesByCommunityId)
 				.get(community_id)!
 				.find((s) => get(s).url === '/')!;
 			spaceIdSelectionByCommunityId.update(($v) => ({
 				...$v,
-				[community_id]: get(selectedSpaceFallback).space_id,
+				[community_id]: get(homeSpace).space_id,
 			}));
 		}
 	}

--- a/src/lib/vocab/space/spaceMutations.ts
+++ b/src/lib/vocab/space/spaceMutations.ts
@@ -16,29 +16,41 @@ export const CreateSpace: Mutations['CreateSpace'] = async ({invoke, ui: {spaceB
 export const DeleteSpace: Mutations['DeleteSpace'] = async ({
 	params,
 	invoke,
-	ui: {communities, spaceIdSelectionByCommunityId, spacesByCommunityId, spaceById, spaces},
+	ui: {
+		communityById,
+		spaceIdSelectionByCommunityId,
+		spacesByCommunityId,
+		spaceById,
+		spaces,
+		communitySelection,
+	},
 }) => {
 	const result = await invoke();
 	if (!result.ok) return result;
-	//update state here
-	const {space_id} = params;
-	get(communities).value.forEach((community) => {
-		// TODO maybe make a nav helper or event?
-		const $community = get(community);
-		// TODO this should only nav for the active community, otherwise update just update the spaceIdSelectionByCommunityId
-		if (space_id === get(spaceIdSelectionByCommunityId)[$community.community_id]) {
-			// eslint-disable-next-line @typescript-eslint/no-floating-promises
-			goto(
-				'/' +
-					$community.name +
-					get(get(spacesByCommunityId).get($community.community_id)![0]).url +
-					location.search,
-				{replaceState: true},
-			);
-		}
-	});
 
+	const {space_id} = params;
 	const space = spaceById.get(space_id)!;
+	const $space = get(space);
+	const {community_id} = $space;
+	const $spaceIdSelectionByCommunityId = get(spaceIdSelectionByCommunityId);
+
+	// If the deleted space is selected, select a fallback.
+	if (space_id === $spaceIdSelectionByCommunityId[community_id]) {
+		const community = communityById.get(community_id)!;
+		if (community === get(communitySelection)) {
+			await goto('/' + get(community).name + location.search, {replaceState: true});
+		} else {
+			//TODO lookup space by community_id+url (see this comment in multiple places)
+			const selectedSpaceFallback = get(spacesByCommunityId)
+				.get(community_id)!
+				.find((s) => get(s).url === '/')!;
+			spaceIdSelectionByCommunityId.update(($v) => ({
+				...$v,
+				[community_id]: get(selectedSpaceFallback).space_id,
+			}));
+		}
+	}
+
 	spaceById.delete(space_id);
 	spaces.mutate(($spaces) => $spaces.splice($spaces.indexOf(space), 1));
 

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -137,7 +137,7 @@
 		}
 		if (community_id) {
 			const spaceUrl = '/' + (params.space || '');
-			//TODO lookup space by url
+			//TODO lookup space by community_id+url (see this comment in multiple places)
 			const space = $spacesByCommunityId.get(community_id)!.find((s) => get(s).url === spaceUrl);
 			if (!space) throw Error(`TODO Unable to find space: ${spaceUrl}`);
 			const {space_id} = get(space);


### PR DESCRIPTION
Fixes the `DeleteSpace` mutation to properly update the selected space cache, falling back to the home space. If the space's community is not selected, it still needs to update the cache because it may be broadcast from another user. Previously it didn't handle this case.