### PR TITLE
hoist dispatching mutations from ui

### DIFF
--- a/src/lib/app/dispatch.ts
+++ b/src/lib/app/dispatch.ts
@@ -59,7 +59,7 @@ export const toDispatch = (
 			};
 			const mutation = mutations[eventName];
 			if (!mutation) {
-				log.warn(`ignoring event with no mutation: ${eventName}`, ctx);
+				log.warn('ignoring event with no mutation', ctx);
 				return;
 			}
 			return mutation(ctx);
@@ -96,7 +96,7 @@ export const toDispatchBroadcastMessage =
 		};
 		const mutation = mutations[eventName];
 		if (!mutation) {
-			log.warn(`ignoring broadcast event with no mutation: ${eventName}`, ctx);
+			log.warn('ignoring broadcast event with no mutation', ctx);
 			return;
 		}
 		return mutation(ctx);

--- a/src/lib/app/dispatch.ts
+++ b/src/lib/app/dispatch.ts
@@ -49,20 +49,19 @@ export const toDispatch = (
 				'color: gray',
 				params === undefined ? '' : params, // print null but not undefined
 			);
+			const mutation = mutations[eventName];
+			if (!mutation) {
+				log.warn('ignoring event with no mutation', eventName, params);
+				return;
+			}
 			const client = toClient(eventName);
-			const ctx: DispatchContext = {
+			return mutation({
 				eventName,
 				params,
 				ui,
 				dispatch,
 				invoke: client ? (p = params) => client.invoke(eventName, p) : null,
-			};
-			const mutation = mutations[eventName];
-			if (!mutation) {
-				log.warn('ignoring event with no mutation', ctx);
-				return;
-			}
-			return mutation(ctx);
+			});
 		},
 	});
 	return dispatch;
@@ -87,17 +86,16 @@ export const toDispatchBroadcastMessage =
 			'color: gray',
 			params === undefined ? '' : params, // print null but not undefined
 		);
-		const ctx: DispatchContext = {
+		const mutation = mutations[eventName];
+		if (!mutation) {
+			log.warn('ignoring broadcast event with no mutation', eventName, params);
+			return;
+		}
+		return mutation({
 			eventName,
 			params,
 			ui,
 			dispatch,
 			invoke: () => Promise.resolve(message.result),
-		};
-		const mutation = mutations[eventName];
-		if (!mutation) {
-			log.warn('ignoring broadcast event with no mutation', ctx);
-			return;
-		}
-		return mutation(ctx);
+		});
 	};

--- a/src/lib/ui/ui.ts
+++ b/src/lib/ui/ui.ts
@@ -12,11 +12,9 @@ import type {ClientSession} from '$lib/session/clientSession';
 import type {AccountModel} from '$lib/vocab/account/account';
 import type {Entity} from '$lib/vocab/entity/entity';
 import type {Membership} from '$lib/vocab/membership/membership';
-import type {DispatchContext} from '$lib/app/dispatch';
 import {createContextmenuStore, type ContextmenuStore} from '$lib/ui/contextmenu/contextmenu';
 import type {ViewData} from '$lib/vocab/view/view';
 import {initBrowser} from '$lib/ui/init';
-import {mutations} from '$lib/app/mutations';
 
 if (browser) initBrowser();
 
@@ -35,7 +33,6 @@ export interface Ui {
 	session: Readable<ClientSession>;
 	setSession: ($session: ClientSession) => void;
 	destroy: () => void;
-	dispatch: (ctx: DispatchContext) => any; // TODO return value type?
 
 	// TODO instead of eagerly loading these components,
 	// this should be an interface to lazy-load UI components
@@ -249,13 +246,6 @@ export const toUi = (
 		spaceSelection,
 		destroy: () => {
 			unsubscribeSession();
-		},
-		dispatch: (ctx: DispatchContext) => {
-			const mutation = mutations[ctx.eventName];
-			if (mutation) {
-				return mutation(ctx);
-			}
-			log.warn(`ignoring event with no mutation: ${ctx.eventName}`, ctx);
 		},
 		session,
 		setSession: ($session: ClientSession) => {

--- a/src/lib/util/testAppHelpers.ts
+++ b/src/lib/util/testAppHelpers.ts
@@ -8,6 +8,7 @@ import {toDispatch} from '$lib/app/dispatch';
 import {findHttpService} from '$lib/ui/services';
 import type {ClientSession} from '$lib/session/clientSession';
 import {installSourceMaps} from '$lib/util/testHelpers';
+import {mutations} from '$lib/app/mutations';
 
 installSourceMaps();
 
@@ -26,7 +27,7 @@ export const setupApp =
 		);
 		context.app = {
 			ui,
-			dispatch: toDispatch(ui, () => httpApiClient),
+			dispatch: toDispatch(ui, mutations, () => httpApiClient),
 			devmode: writable(false),
 			// TODO refactor this so the socket isn't an app dependency,
 			// instead the socket should only exist for the websocket client

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -27,6 +27,7 @@
 	import {findHttpService, findWebsocketService} from '$lib/ui/services';
 	import Contextmenu from '$lib/ui/contextmenu/Contextmenu.svelte';
 	import {components} from '$lib/app/components';
+	import {mutations} from '$lib/app/mutations';
 	import AppContextmenu from '$lib/app/contextmenu/AppContextmenu.svelte';
 	import ActingPersonaContextmenu from '$lib/app/contextmenu/ActingPersonaContextmenu.svelte';
 	import LinkContextmenu from '$lib/app/contextmenu/LinkContextmenu.svelte';
@@ -55,13 +56,13 @@
 	const ui = toUi(session, initialMobileValue, components);
 	setUi(ui);
 
-	const dispatch = toDispatch(ui, (e) =>
+	const dispatch = toDispatch(ui, mutations, (e) =>
 		websocketClient.find(e) ? websocketClient : httpClient.find(e) ? httpClient : null,
 	);
 	const websocketClient = toWebsocketApiClient(
 		findWebsocketService,
 		socket.send,
-		toDispatchBroadcastMessage(ui, dispatch),
+		toDispatchBroadcastMessage(ui, mutations, dispatch),
 	);
 	const httpClient = toHttpApiClient(findHttpService);
 	const app = setApp({ui, dispatch, devmode, socket});


### PR DESCRIPTION
Simplifies the role of `ui.ts` to just store and expose data now that mutations are a separate concept. It now has no knowledge of mutations at all. This makes `dispatch` responsible for looking up and applying mutations rather than pushing that concern downstream to `ui.ts`, so now `dispatch` is more clearly the point of orchestration.