### PR TITLE
fix repo delete method return values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@feltcoop/felt": "^0.22.1",
+        "@feltcoop/felt": "^0.25.0",
         "@polka/send-type": "^0.5.2",
         "@ryanatkn/json-schema-to-typescript": "^11.1.2",
         "ajv": "^8.10.0",
@@ -140,9 +140,9 @@
       }
     },
     "node_modules/@feltcoop/felt": {
-      "version": "0.22.1",
-      "resolved": "https://registry.npmjs.org/@feltcoop/felt/-/felt-0.22.1.tgz",
-      "integrity": "sha512-ruxcMUO2N8flpe/wbdHUpv8zGzZizabqwkZGDy5ptNsuwUtfiFkKkSF5IEZHtHnVcANioyPiUKANarQbrPjy4Q==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@feltcoop/felt/-/felt-0.25.0.tgz",
+      "integrity": "sha512-6DdKmViClBwCK70NuP8Fy0ookXFkn1FfLu32vm1lheYA2toM1FPnsV6j3B2JqiKVQ/1+JiqYHPRiHvbOT177Qw==",
       "dependencies": {
         "@lukeed/uuid": "^2.0.0"
       },
@@ -3686,9 +3686,9 @@
       "requires": {}
     },
     "@feltcoop/felt": {
-      "version": "0.22.1",
-      "resolved": "https://registry.npmjs.org/@feltcoop/felt/-/felt-0.22.1.tgz",
-      "integrity": "sha512-ruxcMUO2N8flpe/wbdHUpv8zGzZizabqwkZGDy5ptNsuwUtfiFkKkSF5IEZHtHnVcANioyPiUKANarQbrPjy4Q==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@feltcoop/felt/-/felt-0.25.0.tgz",
+      "integrity": "sha512-6DdKmViClBwCK70NuP8Fy0ookXFkn1FfLu32vm1lheYA2toM1FPnsV6j3B2JqiKVQ/1+JiqYHPRiHvbOT177Qw==",
       "requires": {
         "@lukeed/uuid": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@feltcoop/felt": "^0.22.1",
+    "@feltcoop/felt": "^0.25.0",
     "@polka/send-type": "^0.5.2",
     "@ryanatkn/json-schema-to-typescript": "^11.1.2",
     "ajv": "^8.10.0",

--- a/src/lib/db/create/create.task.ts
+++ b/src/lib/db/create/create.task.ts
@@ -13,6 +13,6 @@ export const task: Task<DbCreateTaskArgs> = {
 		await invokeTask('lib/db/destroy');
 		await invokeTask('lib/db/migrate');
 		if (seed) await invokeTask('lib/db/seed');
-		unobtainDb(); // eslint-disable-line @typescript-eslint/no-floating-promises
+		unobtainDb();
 	},
 };

--- a/src/lib/db/destroy.task.ts
+++ b/src/lib/db/destroy.task.ts
@@ -15,6 +15,6 @@ export const task: Task = {
 			grant all on schema public to ${defaultPostgresOptions.username};
 			grant all on schema public to public;
 		`);
-		unobtainDb(); // eslint-disable-line @typescript-eslint/no-floating-promises
+		unobtainDb();
 	},
 };

--- a/src/lib/db/seed.task.ts
+++ b/src/lib/db/seed.task.ts
@@ -8,6 +8,6 @@ export const task: Task = {
 	run: async () => {
 		const [db, unobtainDb] = obtainDb();
 		await seed(db);
-		unobtainDb(); // eslint-disable-line @typescript-eslint/no-floating-promises
+		unobtainDb();
 	},
 };

--- a/src/lib/server/servicesIntegration.test.ts
+++ b/src/lib/server/servicesIntegration.test.ts
@@ -161,7 +161,10 @@ test_servicesIntegration('create, change, and delete some data from repos', asyn
 	// assert.ok(deleteFileResult.ok);
 
 	await Promise.all(
-		filterSpacesValue.map(async (space) => unwrap(await db.repos.space.deleteById(space.space_id))),
+		filterSpacesValue.map(
+			// TODO BLOCK remove typecast after upgrading Felt: https://github.com/feltcoop/felt/pull/188
+			async (space) => unwrap((await db.repos.space.deleteById(space.space_id)) as any),
+		),
 	);
 	const deletedSpaceResult = await db.repos.space.filterByCommunity(community.community_id);
 	assert.is(unwrap(deletedSpaceResult).length, 0);

--- a/src/lib/server/servicesIntegration.test.ts
+++ b/src/lib/server/servicesIntegration.test.ts
@@ -162,7 +162,7 @@ test_servicesIntegration('create, change, and delete some data from repos', asyn
 
 	await Promise.all(
 		filterSpacesValue.map(
-			// TODO BLOCK remove typecast after upgrading Felt: https://github.com/feltcoop/felt/pull/188
+			// TODO remove typecast after upgrading Felt: https://github.com/feltcoop/felt/pull/188
 			async (space) => unwrap((await db.repos.space.deleteById(space.space_id)) as any),
 		),
 	);

--- a/src/lib/server/servicesIntegration.test.ts
+++ b/src/lib/server/servicesIntegration.test.ts
@@ -161,10 +161,7 @@ test_servicesIntegration('create, change, and delete some data from repos', asyn
 	// assert.ok(deleteFileResult.ok);
 
 	await Promise.all(
-		filterSpacesValue.map(
-			// TODO remove typecast after upgrading Felt: https://github.com/feltcoop/felt/pull/188
-			async (space) => unwrap((await db.repos.space.deleteById(space.space_id)) as any),
-		),
+		filterSpacesValue.map(async (space) => unwrap(await db.repos.space.deleteById(space.space_id))),
 	);
 	const deletedSpaceResult = await db.repos.space.filterByCommunity(community.community_id);
 	assert.is(unwrap(deletedSpaceResult).length, 0);

--- a/src/lib/ui/MainNav.svelte
+++ b/src/lib/ui/MainNav.svelte
@@ -77,11 +77,11 @@
 		transform-origin: top left;
 		background-color: var(--tint_light);
 		transform: translate3d(-100%, 0, 0) scale3d(1, 1, 1);
-		transition: transform var(--transition_duration_1) ease-out;
+		transition: transform var(--duration_1) ease-out;
 	}
 	.expanded .main-nav {
 		transform: translate3d(0, 0, 0) scale3d(1, 1, 1);
-		transition-duration: var(--transition_duration_2);
+		transition-duration: var(--duration_2);
 	}
 	.main-nav-bg {
 		z-index: 2;
@@ -98,7 +98,7 @@
 	}
 	:global(.mobile) .main-nav-bg {
 		display: block;
-		animation: fade-in var(--transition_duration_3) ease-out;
+		animation: fade-in var(--duration_3) ease-out;
 	}
 	:global(.mobile) .main-nav-panel.expanded {
 		width: 0;

--- a/src/lib/ui/MarqueeButton.svelte
+++ b/src/lib/ui/MarqueeButton.svelte
@@ -28,10 +28,10 @@
 		top: 0;
 		/* TODO this is janky because it can go offscreen for a bit,
 		though it's a nice idea because it maintains object permanence */
-		/* transition: transform var(--transition_duration_1) ease-out; */
+		/* transition: transform var(--duration_1) ease-out; */
 	}
 	.content {
-		transition: transform var(--transition_duration_4) ease-in-out;
+		transition: transform var(--duration_4) ease-in-out;
 		transform: rotate(0deg);
 	}
 	.expanded .content {

--- a/src/lib/ui/PropertyEditor.svelte
+++ b/src/lib/ui/PropertyEditor.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import Message from '@feltcoop/felt/ui/Message.svelte';
 	import {identity} from '@feltcoop/felt/util/function.js';
-	import {type Result, ok} from '@feltcoop/felt';
+	import {type Result} from '@feltcoop/felt';
 
 	import {autofocus} from '$lib/ui/actions';
 
@@ -15,7 +15,9 @@
 		updated: TValue,
 		field: string,
 	) => Promise<Result<unknown, {message: string}>>;
-	export let parse: (serialized: string) => Result<{value: TValue}, {message: string}> = ok as any; // TODO type
+	export let parse: (serialized: string) => Result<{value: TValue}, {message: string}> = (
+		serialized,
+	) => ({ok: true, value: serialized as any});
 	export let serialize: (value: TValue, print?: boolean) => string = identity as any; // TODO type
 
 	let editing = false;

--- a/src/lib/ui/PropertyEditor.svelte
+++ b/src/lib/ui/PropertyEditor.svelte
@@ -17,7 +17,7 @@
 	) => Promise<Result<unknown, {message: string}>>;
 	export let parse: (serialized: string) => Result<{value: TValue}, {message: string}> = (
 		serialized,
-	) => ({ok: true, value: serialized as any});
+	) => ({ok: true, value: serialized as any}); // TODO consider extracting an `ok` helper
 	export let serialize: (value: TValue, print?: boolean) => string = identity as any; // TODO type
 
 	let editing = false;

--- a/src/lib/ui/Workspace.svelte
+++ b/src/lib/ui/Workspace.svelte
@@ -109,6 +109,6 @@
 	}
 	:global(.mobile) .marquee-bg {
 		display: block;
-		animation: fade-in var(--transition_duration_3) ease-out;
+		animation: fade-in var(--duration_3) ease-out;
 	}
 </style>

--- a/src/lib/ui/contextmenu/Contextmenu.svelte
+++ b/src/lib/ui/contextmenu/Contextmenu.svelte
@@ -31,7 +31,7 @@
 	};
 
 	const onWindowKeydown = (e: KeyboardEvent) => {
-		if (e.key === 'Escape' && !(e.target instanceof HTMLElement && isEditable(e.target))) {
+		if (e.key === 'Escape' && !isEditable(e.target)) {
 			contextmenu.close();
 			e.stopPropagation();
 		} else if (e.key === 'ArrowLeft') {

--- a/src/lib/vocab/community/CommunityRepo.ts
+++ b/src/lib/vocab/community/CommunityRepo.ts
@@ -86,7 +86,7 @@ export class CommunityRepo extends PostgresRepo {
 
 	async deleteById(
 		community_id: number,
-	): Promise<Result<{value: any[]}, {type: 'deletion_error'} & ErrorResponse>> {
+	): Promise<Result<object, {type: 'deletion_error'} & ErrorResponse>> {
 		log.trace('[deleteById]', community_id);
 		const data = await this.db.sql<any[]>`
 			DELETE FROM communities WHERE community_id=${community_id}
@@ -98,6 +98,6 @@ export class CommunityRepo extends PostgresRepo {
 				message: 'failed to hard delete entity',
 			};
 		}
-		return {ok: true, value: data};
+		return {ok: true};
 	}
 }

--- a/src/lib/vocab/entity/EntityRepo.ts
+++ b/src/lib/vocab/entity/EntityRepo.ts
@@ -56,7 +56,7 @@ export class EntityRepo extends PostgresRepo {
 	//This function is a idempotent soft delete, that leaves behind a Tombstone entity per Activity-Streams spec
 	async softDeleteById(
 		entity_id: number,
-	): Promise<Result<{value: any[]}, {type: 'deletion_error'} & ErrorResponse>> {
+	): Promise<Result<object, {type: 'deletion_error'} & ErrorResponse>> {
 		log.trace('[deleteById]', entity_id);
 		const data = await this.db.sql<any[]>`
 			UPDATE entities
@@ -70,13 +70,13 @@ export class EntityRepo extends PostgresRepo {
 				message: 'failed to delete entity',
 			};
 		}
-		return {ok: true, value: data};
+		return {ok: true};
 	}
 
 	//This function actually deletes the record in the DB
 	async hardDeleteById(
 		entity_id: number,
-	): Promise<Result<{value: any[]}, {type: 'deletion_error'} & ErrorResponse>> {
+	): Promise<Result<object, {type: 'deletion_error'} & ErrorResponse>> {
 		log.trace('[hardDeleteById]', entity_id);
 		const data = await this.db.sql<any[]>`
 			DELETE FROM entities WHERE ${entity_id}=entity_id
@@ -88,6 +88,6 @@ export class EntityRepo extends PostgresRepo {
 				message: 'failed to hard delete entity',
 			};
 		}
-		return {ok: true, value: data};
+		return {ok: true};
 	}
 }

--- a/src/lib/vocab/membership/MembershipRepo.ts
+++ b/src/lib/vocab/membership/MembershipRepo.ts
@@ -70,7 +70,7 @@ export class MembershipRepo extends PostgresRepo {
 	async deleteById(
 		persona_id: number,
 		community_id: number,
-	): Promise<Result<{value: any[]}, {type: 'deletion_error'} & ErrorResponse>> {
+	): Promise<Result<object, {type: 'deletion_error'} & ErrorResponse>> {
 		const data = await this.db.sql<any[]>`
 			DELETE FROM memberships 
 			WHERE ${persona_id}=persona_id AND ${community_id}=community_id
@@ -82,6 +82,6 @@ export class MembershipRepo extends PostgresRepo {
 				message: 'failed to delete membership',
 			};
 		}
-		return {ok: true, value: data};
+		return {ok: true};
 	}
 }

--- a/src/lib/vocab/space/SpaceRepo.ts
+++ b/src/lib/vocab/space/SpaceRepo.ts
@@ -127,7 +127,7 @@ export class SpaceRepo extends PostgresRepo {
 
 	async deleteById(
 		space_id: number,
-	): Promise<Result<{value: any[]}, {type: 'deletion_error'} & ErrorResponse>> {
+	): Promise<Result<object, {type: 'deletion_error'} & ErrorResponse>> {
 		log.trace('[deleteById]', space_id);
 		const data = await this.db.sql<any[]>`
 			DELETE FROM spaces WHERE space_id=${space_id}
@@ -139,6 +139,6 @@ export class SpaceRepo extends PostgresRepo {
 				message: 'failed to delete space',
 			};
 		}
-		return {ok: true, value: data};
+		return {ok: true};
 	}
 }

--- a/src/lib/vocab/tie/TieRepo.ts
+++ b/src/lib/vocab/tie/TieRepo.ts
@@ -54,7 +54,7 @@ export class TieRepo extends PostgresRepo {
 		source_id: number,
 		dest_id: number,
 		type: string,
-	): Promise<Result<{value: any[]}, {type: 'deletion_error'} & ErrorResponse>> {
+	): Promise<Result<object, {type: 'deletion_error'} & ErrorResponse>> {
 		log.trace('[deleteTie]', source_id, dest_id);
 		const data = await this.db.sql<any[]>`
 				DELETE FROM ties WHERE ${source_id}=source_id AND ${dest_id}=dest_id AND ${type}=type
@@ -66,6 +66,6 @@ export class TieRepo extends PostgresRepo {
 				message: 'failed to delete tie',
 			};
 		}
-		return {ok: true, value: data};
+		return {ok: true};
 	}
 }


### PR DESCRIPTION
Previously all of the repo methods had an incorrect type. They were returning an empty array (length=0) decorated by the Postgres driver with a `count`, which for these cases is always 1, and the count wasn't accessible on the type either.

For these cases there's no useful information to return, so I removed all of the returned data properties.

This exposed the fact that `unwrap` was too opinionated, so I changed it upstream in Felt to have an optional `value`. Will remove the typecast before merging after this PR is in: https://github.com/feltcoop/felt/pull/188

