### PR TITLE
sort spaces in space nav

### DIFF
--- a/src/lib/ui/MainNav.svelte
+++ b/src/lib/ui/MainNav.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import {get} from 'svelte/store';
+
 	import CommunityNav from '$lib/ui/CommunityNav.svelte';
 	import SpaceNav from '$lib/ui/SpaceNav.svelte';
 	import Avatar from '$lib/ui/Avatar.svelte';
@@ -27,6 +29,13 @@
 	$: selectedCommunitySpaces =
 		selectedCommunity && $spacesByCommunityId.get($selectedCommunity!.community_id);
 
+	// TODO how to do this without using `get`?
+	$: selectedAndSelectedCommunitySpaces = selectedCommunitySpaces?.sort((_a, _b) => {
+		const a = get(_a);
+		const b = get(_b);
+		return a.url === '/' ? -1 : b.url === '/' ? 1 : a.created < b.created ? -1 : 1;
+	});
+
 	// TODO refactor to some client view-model for the account
 	$: hue = randomHue(toName($selectedPersona));
 </script>
@@ -46,11 +55,11 @@
 		</div>
 		<div class="explorer">
 			<CommunityNav />
-			{#if selectedPersona && selectedCommunity && selectedCommunitySpaces && selectedSpace}
+			{#if selectedPersona && selectedCommunity && selectedAndSelectedCommunitySpaces && selectedSpace}
 				<SpaceNav
 					persona={selectedPersona}
 					community={selectedCommunity}
-					spaces={selectedCommunitySpaces}
+					spaces={selectedAndSelectedCommunitySpaces}
 					{selectedSpace}
 				/>
 			{/if}

--- a/src/lib/ui/MainNav.svelte
+++ b/src/lib/ui/MainNav.svelte
@@ -30,7 +30,7 @@
 		selectedCommunity && $spacesByCommunityId.get($selectedCommunity!.community_id);
 
 	// TODO how to do this without using `get`?
-	$: selectedAndSelectedCommunitySpaces = selectedCommunitySpaces?.sort((_a, _b) => {
+	$: sortedSelectedCommunitySpaces = selectedCommunitySpaces?.sort((_a, _b) => {
 		const a = get(_a);
 		const b = get(_b);
 		return a.url === '/' ? -1 : b.url === '/' ? 1 : a.created < b.created ? -1 : 1;
@@ -55,11 +55,11 @@
 		</div>
 		<div class="explorer">
 			<CommunityNav />
-			{#if selectedPersona && selectedCommunity && selectedAndSelectedCommunitySpaces && selectedSpace}
+			{#if selectedPersona && selectedCommunity && sortedSelectedCommunitySpaces && selectedSpace}
 				<SpaceNav
 					persona={selectedPersona}
 					community={selectedCommunity}
-					spaces={selectedAndSelectedCommunitySpaces}
+					spaces={sortedSelectedCommunitySpaces}
 					{selectedSpace}
 				/>
 			{/if}

--- a/src/lib/ui/MainNav.svelte
+++ b/src/lib/ui/MainNav.svelte
@@ -33,7 +33,7 @@
 	$: sortedSelectedCommunitySpaces = selectedCommunitySpaces?.sort((_a, _b) => {
 		const a = get(_a);
 		const b = get(_b);
-		return a.url === '/' ? -1 : b.url === '/' ? 1 : a.created < b.created ? -1 : 1;
+		return a.url === '/' ? -1 : b.url === '/' ? 1 : a.name < b.name ? -1 : 1;
 	});
 
 	// TODO refactor to some client view-model for the account

--- a/src/lib/ui/MainNav.svelte
+++ b/src/lib/ui/MainNav.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-	import {get} from 'svelte/store';
-
 	import CommunityNav from '$lib/ui/CommunityNav.svelte';
 	import SpaceNav from '$lib/ui/SpaceNav.svelte';
 	import Avatar from '$lib/ui/Avatar.svelte';
@@ -29,13 +27,6 @@
 	$: selectedCommunitySpaces =
 		selectedCommunity && $spacesByCommunityId.get($selectedCommunity!.community_id);
 
-	// TODO how to do this without using `get`?
-	$: sortedSelectedCommunitySpaces = selectedCommunitySpaces?.slice().sort((_a, _b) => {
-		const a = get(_a);
-		const b = get(_b);
-		return a.url === '/' ? -1 : b.url === '/' ? 1 : a.name < b.name ? -1 : 1;
-	});
-
 	// TODO refactor to some client view-model for the account
 	$: hue = randomHue(toName($selectedPersona));
 </script>
@@ -55,11 +46,11 @@
 		</div>
 		<div class="explorer">
 			<CommunityNav />
-			{#if selectedPersona && selectedCommunity && sortedSelectedCommunitySpaces && selectedSpace}
+			{#if selectedPersona && selectedCommunity && selectedCommunitySpaces && selectedSpace}
 				<SpaceNav
 					persona={selectedPersona}
 					community={selectedCommunity}
-					spaces={sortedSelectedCommunitySpaces}
+					spaces={selectedCommunitySpaces}
 					{selectedSpace}
 				/>
 			{/if}

--- a/src/lib/ui/MainNav.svelte
+++ b/src/lib/ui/MainNav.svelte
@@ -30,7 +30,7 @@
 		selectedCommunity && $spacesByCommunityId.get($selectedCommunity!.community_id);
 
 	// TODO how to do this without using `get`?
-	$: sortedSelectedCommunitySpaces = selectedCommunitySpaces?.sort((_a, _b) => {
+	$: sortedSelectedCommunitySpaces = selectedCommunitySpaces?.slice().sort((_a, _b) => {
 		const a = get(_a);
 		const b = get(_b);
 		return a.url === '/' ? -1 : b.url === '/' ? 1 : a.name < b.name ? -1 : 1;

--- a/src/lib/ui/WorkspaceHeader.svelte
+++ b/src/lib/ui/WorkspaceHeader.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import type {Readable} from 'svelte/store';
-	import {format} from 'date-fns';
 
 	import type {Space} from '$lib/vocab/space/space';
 	import type {Community} from '$lib/vocab/community/community';
@@ -30,7 +29,6 @@
 			/><span class="title">{$community.name}</span>{/if}{#if space}<SpaceIcon {space} />
 			<span class="title">{$space?.url.split('/').filter(Boolean).join(' / ') || ''}</span>{/if}
 	</li>
-	<li class="timestamp">created {space && $space && format(new Date($space.created), 'P')}</li>
 	<li class="marquee-button-placeholder" />
 </ul>
 
@@ -48,13 +46,6 @@
 	.breadcrumbs {
 		display: flex;
 		align-items: center;
-	}
-	.timestamp {
-		font-size: var(--font_size_md);
-		flex: 1;
-		display: flex;
-		justify-content: flex-end;
-		padding: 0 var(--spacing_lg);
 	}
 	.luggage-placeholder,
 	.marquee-button-placeholder {

--- a/src/lib/ui/ui.ts
+++ b/src/lib/ui/ui.ts
@@ -108,6 +108,11 @@ export const toUi = (
 						communitySpaces.push(space);
 					}
 				}
+				communitySpaces.sort((_a, _b) => {
+					const a = get(_a);
+					const b = get(_b);
+					return a.url === '/' ? -1 : b.url === '/' ? 1 : a.name < b.name ? -1 : 1;
+				});
 				map.set(community_id, communitySpaces);
 			}
 			return map;


### PR DESCRIPTION
- makes the space nav have a stable sort order -- the home space is first, followed by the spaces sorted by `name`
- removes the created timestamp from the workspace header -- the same value is visible on "Edit Community", and we talked about adding a contextmenu entry to view info like this for communities/spaces, "More Info" or something

future:

- let users specify the sort order for spaces