### PR TITLE
use SessionApiMock for tests and seed

### DIFF
--- a/src/lib/db/seed.ts
+++ b/src/lib/db/seed.ts
@@ -12,8 +12,8 @@ import type {CreateCommunityParams} from '$lib/app/eventTypes';
 import type {Persona} from '$lib/vocab/persona/persona';
 import type {ViewData} from '$lib/vocab/view/view';
 import {createAccountPersonaService} from '$lib/vocab/persona/personaServices';
-import {SessionApi} from '$lib/server/SessionApi';
 import {createCommunityService} from '$lib/vocab/community/communityServices';
+import {SessionApiMock} from '$lib/server/SessionApiMock';
 
 /* eslint-disable no-await-in-loop */
 
@@ -21,7 +21,7 @@ import {createCommunityService} from '$lib/vocab/community/communityServices';
 
 const log = new Logger([cyan('[seed]')]);
 
-const session = new SessionApi(null);
+const session = new SessionApiMock();
 
 export const seed = async (db: Database): Promise<void> => {
 	const {sql} = db;

--- a/src/lib/server/servicesIntegration.test.ts
+++ b/src/lib/server/servicesIntegration.test.ts
@@ -12,7 +12,7 @@ import {
 import {toDefaultSpaces} from '$lib/vocab/space/defaultSpaces';
 import type {NoteEntityData} from '$lib/vocab/entity/entityData';
 import {createAccountPersonaService} from '$lib/vocab/persona/personaServices';
-import {SessionApi} from '$lib/server/SessionApi';
+import {SessionApiMock} from '$lib/server/SessionApiMock';
 import {
 	createCommunityService,
 	readCommunitiesService,
@@ -44,7 +44,7 @@ test_servicesIntegration('create, change, and delete some data from repos', asyn
 	const serviceRequest = {
 		account_id: account.account_id,
 		repos: db.repos,
-		session: new SessionApi(null),
+		session: new SessionApiMock(),
 	};
 
 	// TODO create 2 personas

--- a/src/lib/vocab/membership/membershipServices.test.ts
+++ b/src/lib/vocab/membership/membershipServices.test.ts
@@ -10,7 +10,6 @@ import {
 	deleteMembershipService,
 } from '$lib/vocab/membership/membershipServices';
 import {SessionApiMock} from '$lib/server/SessionApiMock';
-import {SessionApi} from '$lib/server/SessionApi';
 
 /* test__membershipServices */
 const test__membershipServices = suite<TestDbContext & TestAppContext>('membershipServices');
@@ -22,7 +21,7 @@ const serviceRequest = (account_id: number, db: any) => {
 	return {
 		account_id,
 		repos: db.repos,
-		session: new SessionApi(null),
+		session: new SessionApiMock(),
 	};
 };
 

--- a/src/lib/vocab/random.ts
+++ b/src/lib/vocab/random.ts
@@ -19,10 +19,10 @@ import {parseView, type ViewData} from '$lib/vocab/view/view';
 import type {Entity} from '$lib/vocab/entity/entity';
 import type {Tie} from '$lib/vocab/tie/tie';
 import {createAccountPersonaService} from '$lib/vocab/persona/personaServices';
-import {SessionApi} from '$lib/server/SessionApi';
+import {SessionApiMock} from '$lib/server/SessionApiMock';
 import {createCommunityService} from '$lib/vocab/community/communityServices';
 
-const session = new SessionApi(null);
+const session = new SessionApiMock();
 
 // TODO automate these from schemas, also use seeded rng
 export const randomString = (): string => Math.random().toString().slice(2);


### PR DESCRIPTION
Tiny change that uses the mock version of the session API in tests and db seed. The `new SessionApi(null)` is intended for websocket usage, and we may want to make that explicit with its own class and rely on typesafety instead of its current runtime `null` checks.