### PR TITLE
remove test cache

### DIFF
--- a/src/lib/server/random.ts
+++ b/src/lib/server/random.ts
@@ -1,4 +1,4 @@
-import {randomBool, randomItem} from '@feltcoop/felt/util/random.js';
+import {randomBool} from '@feltcoop/felt/util/random.js';
 import {writable} from 'svelte/store';
 
 import type {EventInfo} from '$lib/vocab/event/event';
@@ -43,24 +43,21 @@ export const randomEventParams = async (
 			return null;
 		}
 		case 'CreateCommunity': {
-			if (!persona) persona = await random.persona(account);
+			if (!persona) ({persona} = await random.persona(account));
 			return randomCommunityParams(persona.persona_id);
 		}
 		case 'UpdateCommunitySettings': {
-			if (!persona) persona = await random.persona(account);
-			if (!community) community = await random.community(persona);
+			if (!community) ({community} = await random.community(persona, account));
 			return {community_id: community.community_id, settings: {hue: randomHue()}};
 		}
 		case 'ReadCommunity': {
-			if (!community) {
-				community = randomItem(random.communities) || (await random.community(persona, account));
-			}
+			if (!community) ({community} = await random.community(persona, account));
 			return {community_id: community.community_id};
 		}
 		case 'DeleteCommunity': {
 			do {
 				// eslint-disable-next-line no-await-in-loop
-				community = await random.community(persona, account);
+				({community} = await random.community(persona, account));
 			} while (community.type !== 'standard');
 			return {community_id: community.community_id};
 		}
@@ -71,96 +68,81 @@ export const randomEventParams = async (
 			return randomPersonaParams();
 		}
 		case 'CreateMembership': {
-			if (!persona) persona = await random.persona(account);
-			if (!community) community = await random.community(); // don't forward `persona`/`account` bc that's the service's job
+			if (!persona) ({persona} = await random.persona(account));
+			if (!community) ({community} = await random.community()); // don't forward `persona`/`account` bc that's the service's job
 			return randomMembershipParams(persona.persona_id, community.community_id);
 		}
 		case 'DeleteMembership': {
-			if (!persona) persona = await random.persona(account);
-			if (!community) community = await random.community(persona); // don't forward `persona`/`account` bc that's the service's job
+			if (!persona) ({persona} = await random.persona(account));
+			if (!community) ({community} = await random.community(persona));
 			return {persona_id: persona.persona_id, community_id: community.community_id};
 		}
 		case 'CreateSpace': {
-			if (!community) community = await random.community(persona, account);
+			if (!community) ({community} = await random.community(persona, account));
 			return randomSpaceParams(community.community_id);
 		}
 		case 'UpdateSpace': {
-			if (!space) space = await random.space(persona, account, community);
+			if (!space) ({space} = await random.space(persona, account, community));
 			return {space_id: space.space_id, name: randomSpaceName()};
 		}
 		case 'DeleteSpace': {
-			if (!space) space = await random.space(persona, account, community);
+			if (!space) ({space} = await random.space(persona, account, community));
 			return {space_id: space.space_id};
 		}
 		case 'ReadSpace': {
-			if (!space) {
-				space = randomItem(random.spaces) || (await random.space(persona, account, community));
-			}
+			if (!space) ({space} = await random.space(persona, account, community));
 			return {space_id: space.space_id};
 		}
 		case 'ReadSpaces': {
-			if (!community) {
-				community = randomItem(random.communities) || (await random.community(persona, account));
-			}
+			if (!community) ({community} = await random.community(persona, account));
 			return {community_id: community.community_id};
 		}
 		case 'CreateEntity': {
-			if (!persona) persona = await random.persona(account);
-			if (!space) space = await random.space(persona, account, community);
+			if (!persona) ({persona} = await random.persona(account));
+			if (!space) ({space} = await random.space(persona, account, community));
 			return randomEntityParams(persona.persona_id, space.space_id);
 		}
 		case 'ReadEntities': {
-			if (!space) {
-				space = randomItem(random.spaces) || (await random.space(persona, account, community));
-			}
+			if (!space) ({space} = await random.space(persona, account, community));
 			return {space_id: space.space_id};
 		}
 		case 'QueryEntities': {
 			return {
-				space_id: (randomItem(random.spaces) || (await random.space(persona, account, community)))
-					.space_id,
+				space_id: (await random.space(persona, account, community)).space.space_id,
 			};
 		}
 		case 'UpdateEntity': {
 			return {
-				entity_id: (
-					randomItem(random.entities) || (await random.entity(persona, account, community, space))
-				).entity_id,
+				entity_id: (await random.entity(persona, account, community, space)).entity.entity_id,
 				data: randomEntityData(),
 			};
 		}
 		case 'SoftDeleteEntity': {
 			return {
-				entity_id: (
-					randomItem(random.entities) || (await random.entity(persona, account, community, space))
-				).entity_id,
+				entity_id: (await random.entity(persona, account, community, space)).entity.entity_id,
 			};
 		}
 		case 'HardDeleteEntity': {
-			const entity = await random.entity(persona, account, community, space);
+			const {entity} = await random.entity(persona, account, community, space);
 			return {
 				entity_id: entity.entity_id,
 			};
 		}
 		case 'CreateTie': {
 			return {
-				source_id: (
-					randomItem(random.entities) || (await random.entity(persona, account, community, space))
-				).entity_id,
-				dest_id: (
-					randomItem(random.entities) || (await random.entity(persona, account, community, space))
-				).entity_id,
+				source_id: (await random.entity(persona, account, community, space)).entity.entity_id,
+				dest_id: (await random.entity(persona, account, community, space)).entity.entity_id,
 				type: 'HasReply',
 			};
 		}
 		case 'ReadTies': {
 			if (!space) {
-				space = randomItem(random.spaces) || (await random.space(persona, account, community));
+				({space} = await random.space(persona, account, community));
 			}
 			return {space_id: space.space_id};
 		}
 		case 'DeleteTie': {
-			const tie = randomItem(random.ties) || (await random.tie());
+			const {tie} = await random.tie(undefined, undefined, persona, account, community, space);
 			return {
 				source_id: tie.source_id,
 				dest_id: tie.dest_id,
@@ -192,26 +174,18 @@ export const randomEventParams = async (
 		}
 		case 'SelectPersona': {
 			return {
-				persona_id: (randomItem(random.personas) || (await random.persona(account))).persona_id,
+				persona_id: (await random.persona(account)).persona.persona_id,
 			};
 		}
 		case 'SelectCommunity': {
 			return {
-				// TODO refactor
-				community_id: await randomItem([
-					async () =>
-						(randomItem(random.communities) || (await random.community(persona, account)))
-							.community_id,
-					() => null,
-				])(),
+				community_id: (await random.community(persona, account)).community.community_id,
 			};
 		}
 		case 'SelectSpace': {
 			return {
-				community_id: (randomItem(random.communities) || (await random.community(persona, account)))
-					.community_id,
-				space_id: (randomItem(random.spaces) || (await random.space(persona, account, community)))
-					.space_id,
+				community_id: (await random.community(persona, account)).community.community_id,
+				space_id: (await random.space(persona, account, community)).space.space_id,
 			};
 		}
 		case 'ViewSpace': {

--- a/src/lib/server/random.ts
+++ b/src/lib/server/random.ts
@@ -138,7 +138,6 @@ export const randomEventParams = async (
 		}
 		case 'HardDeleteEntity': {
 			const entity = await random.entity(persona, account, community, space);
-			random.entities.pop();
 			return {
 				entity_id: entity.entity_id,
 			};

--- a/src/lib/vocab/community/CommunityRepo.test.ts
+++ b/src/lib/vocab/community/CommunityRepo.test.ts
@@ -13,7 +13,7 @@ test__CommunityRepo.after(teardownDb);
 
 test__CommunityRepo('updateSettings', async ({db}) => {
 	const random = new RandomVocabContext(db);
-	const community = await random.community();
+	const {community} = await random.community();
 	assert.type(community.settings, 'object');
 	assert.type(community.settings.hue, 'number');
 	const newHue = community.settings.hue === 1 ? 2 : 1;

--- a/src/lib/vocab/community/communityServices.test.ts
+++ b/src/lib/vocab/community/communityServices.test.ts
@@ -15,8 +15,7 @@ test_communityServices.after(teardownDb);
 
 test_communityServices('unable to delete personal community', async ({db}) => {
 	const random = new RandomVocabContext(db);
-	const account = await random.account();
-	const persona = await random.persona();
+	const {persona, account} = await random.persona();
 
 	const deleteCommunityResult = await deleteCommunityService.perform({
 		repos: db.repos,

--- a/src/lib/vocab/entity/EntityRepo.test.ts
+++ b/src/lib/vocab/entity/EntityRepo.test.ts
@@ -13,10 +13,10 @@ test__EntityRepo.after(teardownDb);
 
 test__EntityRepo('entites return sorted by created', async ({db}) => {
 	const random = new RandomVocabContext(db);
-	const space = await random.space();
-	const entity0 = await random.entity(undefined, undefined, undefined, space);
-	const entity1 = await random.entity(undefined, undefined, undefined, space);
-	const entity2 = await random.entity(undefined, undefined, undefined, space);
+	const {space, persona, account} = await random.space();
+	const {entity: entity0} = await random.entity(persona, account, undefined, space);
+	const {entity: entity1} = await random.entity(persona, account, undefined, space);
+	const {entity: entity2} = await random.entity(persona, account, undefined, space);
 
 	assert.equal(entity0.space_id, entity1.space_id);
 	assert.equal(entity1.space_id, entity2.space_id);

--- a/src/lib/vocab/random.ts
+++ b/src/lib/vocab/random.ts
@@ -86,23 +86,17 @@ export interface RandomVocab {
 export class RandomVocabContext {
 	constructor(private db: Database) {}
 
-	accounts: Account[] = [];
-	personas: Persona[] = [];
-	communities: Community[] = [];
-	spaces: Space[] = [];
-	entities: Entity[] = [];
-	ties: Tie[] = [];
-
 	async account(): Promise<Account> {
 		const params = randomAccountParams();
 		const account = unwrap(await this.db.repos.account.create(params.name, params.password));
-		this.accounts.push(account);
 		return account;
 	}
 
-	async persona(account?: Account): Promise<Persona> {
+	async persona(
+		account?: Account,
+	): Promise<{persona: Persona; personalCommunity: Community; account: Account}> {
 		if (!account) account = await this.account();
-		const {community, persona} = unwrap(
+		const {persona, community: personalCommunity} = unwrap(
 			await createAccountPersonaService.perform({
 				params: {name: randomPersonaParams().name},
 				account_id: account.account_id,
@@ -110,14 +104,15 @@ export class RandomVocabContext {
 				session,
 			}),
 		);
-		this.communities.push(community);
-		this.personas.push(persona);
-		return persona;
+		return {persona, personalCommunity, account};
 	}
 
-	async community(persona?: Persona, account?: Account): Promise<Community> {
+	async community(
+		persona?: Persona,
+		account?: Account,
+	): Promise<{community: Community; persona: Persona; account: Account}> {
 		if (!account) account = await this.account();
-		if (!persona) persona = await this.persona(account);
+		if (!persona) ({persona, account} = await this.persona(account));
 		const params = randomCommunityParams(persona.persona_id);
 		const {community} = unwrap(
 			await createCommunityService.perform({
@@ -127,14 +122,17 @@ export class RandomVocabContext {
 				session,
 			}),
 		);
-		this.communities.push(community);
-		return community;
+		return {community, persona, account};
 	}
 
-	async space(persona?: Persona, account?: Account, community?: Community): Promise<Space> {
+	async space(
+		persona?: Persona,
+		account?: Account,
+		community?: Community,
+	): Promise<{space: Space; persona: Persona; account: Account; community: Community}> {
 		if (!account) account = await this.account();
-		if (!persona) persona = await this.persona(account);
-		if (!community) community = await this.community(persona, account);
+		if (!persona) ({persona} = await this.persona(account));
+		if (!community) ({community} = await this.community(persona, account));
 		const params = randomSpaceParams(community.community_id);
 		const space = unwrap(
 			await this.db.repos.space.create(
@@ -145,8 +143,7 @@ export class RandomVocabContext {
 				params.community_id,
 			),
 		);
-		this.spaces.push(space);
-		return space;
+		return {space, persona, account, community};
 	}
 
 	async entity(
@@ -154,26 +151,50 @@ export class RandomVocabContext {
 		account?: Account,
 		community?: Community,
 		space?: Space,
-	): Promise<Entity> {
+	): Promise<{
+		entity: Entity;
+		persona: Persona;
+		account: Account;
+		community: Community;
+		space: Space;
+	}> {
 		if (!account) account = await this.account();
-		if (!persona) persona = await this.persona(account);
-		if (!community) community = await this.community(persona, account);
-		if (!space) space = await this.space(persona, account, community);
+		if (!persona) ({persona} = await this.persona(account));
+		if (!community) ({community} = await this.community(persona, account));
+		if (!space) ({space} = await this.space(persona, account, community));
 		const params = randomEntityParams(persona.persona_id, space.space_id);
 		const entity = unwrap(
 			await this.db.repos.entity.create(params.actor_id, params.space_id, params.data),
 		);
-		this.entities.push(entity);
-		return entity;
+		return {entity, persona, account, community, space};
 	}
 
-	async tie(sourceEntity?: Entity, destEntity?: Entity): Promise<Tie> {
-		if (!sourceEntity) sourceEntity = await this.entity();
-		if (!destEntity) destEntity = await this.entity();
+	async tie(
+		sourceEntity?: Entity,
+		destEntity?: Entity,
+		persona?: Persona,
+		account?: Account,
+		community?: Community,
+		space?: Space,
+	): Promise<{
+		tie: Tie;
+		sourceEntity: Entity;
+		destEntity: Entity;
+		persona: Persona;
+		account: Account;
+		community: Community;
+		space: Space;
+	}> {
+		if (!account) account = await this.account();
+		if (!persona) ({persona} = await this.persona(account));
+		if (!community) ({community} = await this.community(persona, account));
+		if (!space) ({space} = await this.space(persona, account, community));
+		if (!sourceEntity)
+			({entity: sourceEntity} = await this.entity(persona, account, community, space));
+		if (!destEntity) ({entity: destEntity} = await this.entity(persona, account, community, space));
 		const tie = unwrap(
 			await this.db.repos.tie.create(sourceEntity.entity_id, destEntity.entity_id, 'HasItem'),
 		);
-		this.ties.push(tie);
-		return tie;
+		return {tie, sourceEntity, destEntity, persona, account, community, space};
 	}
 }

--- a/src/lib/vocab/random.ts
+++ b/src/lib/vocab/random.ts
@@ -21,6 +21,7 @@ import type {Tie} from '$lib/vocab/tie/tie';
 import {createAccountPersonaService} from '$lib/vocab/persona/personaServices';
 import {SessionApi} from '$lib/server/SessionApi';
 import {createCommunityService} from '$lib/vocab/community/communityServices';
+import type {Membership} from '$lib/vocab/membership/membership';
 
 const session = new SessionApi(null);
 
@@ -92,11 +93,20 @@ export class RandomVocabContext {
 		return account;
 	}
 
-	async persona(
-		account?: Account,
-	): Promise<{persona: Persona; personalCommunity: Community; account: Account}> {
+	async persona(account?: Account): Promise<{
+		persona: Persona;
+		personalCommunity: Community;
+		membership: Membership;
+		spaces: Space[];
+		account: Account;
+	}> {
 		if (!account) account = await this.account();
-		const {persona, community: personalCommunity} = unwrap(
+		const {
+			persona,
+			community: personalCommunity,
+			membership,
+			spaces,
+		} = unwrap(
 			await createAccountPersonaService.perform({
 				params: {name: randomPersonaParams().name},
 				account_id: account.account_id,
@@ -104,17 +114,24 @@ export class RandomVocabContext {
 				session,
 			}),
 		);
-		return {persona, personalCommunity, account};
+		return {persona, personalCommunity, membership, spaces, account};
 	}
 
 	async community(
 		persona?: Persona,
 		account?: Account,
-	): Promise<{community: Community; persona: Persona; account: Account}> {
+	): Promise<{
+		community: Community;
+		communityPersona: Persona;
+		memberships: Membership[];
+		spaces: Space[];
+		persona: Persona;
+		account: Account;
+	}> {
 		if (!account) account = await this.account();
 		if (!persona) ({persona, account} = await this.persona(account));
 		const params = randomCommunityParams(persona.persona_id);
-		const {community} = unwrap(
+		const {community, communityPersona, memberships, spaces} = unwrap(
 			await createCommunityService.perform({
 				params,
 				account_id: account.account_id,
@@ -122,7 +139,7 @@ export class RandomVocabContext {
 				session,
 			}),
 		);
-		return {community, persona, account};
+		return {community, communityPersona, memberships, spaces, persona, account};
 	}
 
 	async space(

--- a/src/lib/vocab/space/spaceServices.test.ts
+++ b/src/lib/vocab/space/spaceServices.test.ts
@@ -15,9 +15,7 @@ test__spaceServices.after(teardownDb);
 
 test__spaceServices('delete a space in multiple communities', async ({db}) => {
 	const random = new RandomVocabContext(db);
-	const account = await random.account();
-	const community1 = await random.community();
-	const space = await random.space(undefined, account, community1);
+	const {space, account} = await random.space();
 
 	const deleteResult = await deleteSpaceService.perform({
 		repos: db.repos,

--- a/src/lib/vocab/tie/TieRepo.test.ts
+++ b/src/lib/vocab/tie/TieRepo.test.ts
@@ -15,14 +15,11 @@ test__TieRepo('check tie queries', async ({db}) => {
 	//Gen space
 	//Gen dir entity -> thread entity -> post -> reply
 	const random = new RandomVocabContext(db);
-	const account = await random.account();
-	const persona = await random.persona(account);
-	const community = await random.community(persona, account);
-	const space = await random.space(persona, account, community);
-	const entityDir = await random.entity(persona, account, community, space);
-	const entityThread = await random.entity(persona, account, community, space);
-	const entityPost = await random.entity(persona, account, community, space);
-	const entityReply = await random.entity(persona, account, community, space);
+	const {persona, account, community, space} = await random.space();
+	const {entity: entityDir} = await random.entity(persona, account, community, space);
+	const {entity: entityThread} = await random.entity(persona, account, community, space);
+	const {entity: entityPost} = await random.entity(persona, account, community, space);
+	const {entity: entityReply} = await random.entity(persona, account, community, space);
 
 	const result1 = await db.repos.tie.create(
 		entityDir.entity_id,


### PR DESCRIPTION
Removes the caching in the random vocab context class. Updates the random helpers to return the objects that they create, and which makes them more verbose, but then uses those objects in the tests where possible, making the tests happily less verbose.