### PR TITLE
add RandomVocabContext to db test context

### DIFF
--- a/src/lib/app/events.test.ts
+++ b/src/lib/app/events.test.ts
@@ -5,7 +5,6 @@ import {noop} from '@feltcoop/felt/util/function.js';
 import {setupDb, teardownDb, type TestDbContext} from '$lib/util/testDbHelpers';
 import {validateSchema, toValidationErrorMessage} from '$lib/util/ajv';
 import {eventInfos} from '$lib/app/events';
-import {RandomVocabContext} from '$lib/vocab/random';
 import {randomEventParams} from '$lib/server/random';
 import type {TestAppContext} from '$lib/util/testAppHelpers';
 import {setupApp, teardownApp} from '$lib/util/testAppHelpers';
@@ -20,9 +19,7 @@ test__eventInfos.after(teardownDb);
 test__eventInfos.before(setupApp(noop as any)); // TODO either use `node-fetch` or mock
 test__eventInfos.after(teardownApp);
 
-test__eventInfos('dispatch random events in a client app', async ({db, app}) => {
-	const random = new RandomVocabContext(db);
-
+test__eventInfos('dispatch random events in a client app', async ({app, random}) => {
 	for (const eventInfo of eventInfos.values()) {
 		const account = await random.account();
 		const params = await randomEventParams(eventInfo, random, {account});

--- a/src/lib/server/services.test.ts
+++ b/src/lib/server/services.test.ts
@@ -6,7 +6,6 @@ import {setupDb, teardownDb, type TestDbContext} from '$lib/util/testDbHelpers';
 import {log} from '$lib/util/testHelpers';
 import {validateSchema, toValidationErrorMessage} from '$lib/util/ajv';
 import {services} from '$lib/server/services';
-import {RandomVocabContext} from '$lib/vocab/random';
 import {randomEventParams} from '$lib/server/random';
 import {SessionApiMock} from '$lib/server/SessionApiMock';
 
@@ -18,9 +17,7 @@ const test__services = suite<TestDbContext>('services');
 test__services.before(setupDb);
 test__services.after(teardownDb);
 
-test__services('perform services', async ({db}) => {
-	const random = new RandomVocabContext(db);
-
+test__services('perform services', async ({db, random}) => {
 	for (const service of services.values()) {
 		const account = await random.account();
 		const params = await randomEventParams(service.event, random, {account});

--- a/src/lib/util/testDbHelpers.ts
+++ b/src/lib/util/testDbHelpers.ts
@@ -3,6 +3,7 @@ import postgres from 'postgres';
 import {Database} from '$lib/db/Database';
 import {defaultPostgresOptions} from '$lib/db/postgres';
 import {installSourceMaps, log} from '$lib/util/testHelpers';
+import {RandomVocabContext} from '$lib/vocab/random';
 
 installSourceMaps();
 
@@ -12,10 +13,12 @@ installSourceMaps();
 
 export interface TestDbContext {
 	db: Database;
+	random: RandomVocabContext;
 }
 
 export const setupDb = async (context: TestDbContext): Promise<void> => {
 	context.db = new Database({sql: postgres(defaultPostgresOptions)});
+	context.random = new RandomVocabContext(context.db);
 };
 
 export const teardownDb = async (context: TestDbContext): Promise<void> => {

--- a/src/lib/vocab/community/CommunityRepo.test.ts
+++ b/src/lib/vocab/community/CommunityRepo.test.ts
@@ -2,7 +2,6 @@ import {suite} from 'uvu';
 import * as assert from 'uvu/assert';
 
 import {setupDb, teardownDb, type TestDbContext} from '$lib/util/testDbHelpers';
-import {RandomVocabContext} from '$lib/vocab/random';
 import type {TestAppContext} from '$lib/util/testAppHelpers';
 
 /* test__CommunityRepo */
@@ -11,8 +10,7 @@ const test__CommunityRepo = suite<TestDbContext & TestAppContext>('CommunityRepo
 test__CommunityRepo.before(setupDb);
 test__CommunityRepo.after(teardownDb);
 
-test__CommunityRepo('updateSettings', async ({db}) => {
-	const random = new RandomVocabContext(db);
+test__CommunityRepo('updateSettings', async ({db, random}) => {
 	const {community} = await random.community();
 	assert.type(community.settings, 'object');
 	assert.type(community.settings.hue, 'number');

--- a/src/lib/vocab/community/communityServices.test.ts
+++ b/src/lib/vocab/community/communityServices.test.ts
@@ -2,7 +2,6 @@ import {suite} from 'uvu';
 import * as assert from 'uvu/assert';
 
 import {setupDb, teardownDb, type TestDbContext} from '$lib/util/testDbHelpers';
-import {RandomVocabContext} from '$lib/vocab/random';
 import type {TestAppContext} from '$lib/util/testAppHelpers';
 import {deleteCommunityService} from './communityServices';
 import {SessionApiMock} from '$lib/server/SessionApiMock';
@@ -13,8 +12,7 @@ const test_communityServices = suite<TestDbContext & TestAppContext>('communityR
 test_communityServices.before(setupDb);
 test_communityServices.after(teardownDb);
 
-test_communityServices('unable to delete personal community', async ({db}) => {
-	const random = new RandomVocabContext(db);
+test_communityServices('unable to delete personal community', async ({db, random}) => {
 	const {persona, account} = await random.persona();
 
 	const deleteCommunityResult = await deleteCommunityService.perform({

--- a/src/lib/vocab/entity/EntityRepo.test.ts
+++ b/src/lib/vocab/entity/EntityRepo.test.ts
@@ -2,7 +2,6 @@ import {suite} from 'uvu';
 import * as assert from 'uvu/assert';
 
 import {setupDb, teardownDb, type TestDbContext} from '$lib/util/testDbHelpers';
-import {RandomVocabContext} from '$lib/vocab/random';
 import type {TestAppContext} from '$lib/util/testAppHelpers';
 
 /* test__EntityRepo */
@@ -11,8 +10,7 @@ const test__EntityRepo = suite<TestDbContext & TestAppContext>('EntityRepo');
 test__EntityRepo.before(setupDb);
 test__EntityRepo.after(teardownDb);
 
-test__EntityRepo('entites return sorted by created', async ({db}) => {
-	const random = new RandomVocabContext(db);
+test__EntityRepo('entites return sorted by created', async ({db, random}) => {
 	const {space, persona, account} = await random.space();
 	const {entity: entity0} = await random.entity(persona, account, undefined, space);
 	const {entity: entity1} = await random.entity(persona, account, undefined, space);

--- a/src/lib/vocab/membership/membershipServices.test.ts
+++ b/src/lib/vocab/membership/membershipServices.test.ts
@@ -2,7 +2,6 @@ import {suite} from 'uvu';
 import * as assert from 'uvu/assert';
 
 import {setupDb, teardownDb, type TestDbContext} from '$lib/util/testDbHelpers';
-import {RandomVocabContext} from '$lib/vocab/random';
 import type {TestAppContext} from '$lib/util/testAppHelpers';
 import {
 	createMembershipService,
@@ -24,8 +23,7 @@ const serviceRequest = (account_id: number, db: any) => {
 	};
 };
 
-test__membershipServices('disallow creating duplicate memberships', async ({db}) => {
-	const random = new RandomVocabContext(db);
+test__membershipServices('disallow creating duplicate memberships', async ({db, random}) => {
 	const {community, persona, account} = await random.community();
 
 	let errorMessage;
@@ -43,23 +41,24 @@ test__membershipServices('disallow creating duplicate memberships', async ({db})
 	if (errorMessage) throw Error(errorMessage);
 });
 
-test__membershipServices('disallow creating memberships for personal communities', async ({db}) => {
-	const random = new RandomVocabContext(db);
-	const {account, personalCommunity} = await random.persona();
-	const createMembershipResult = await createMembershipService.perform({
-		repos: db.repos,
-		account_id: account.account_id,
-		params: {
-			community_id: personalCommunity.community_id,
-			persona_id: (await random.persona()).persona.persona_id,
-		},
-		session: new SessionApiMock(),
-	});
-	assert.ok(!createMembershipResult.ok);
-});
+test__membershipServices(
+	'disallow creating memberships for personal communities',
+	async ({db, random}) => {
+		const {account, personalCommunity} = await random.persona();
+		const createMembershipResult = await createMembershipService.perform({
+			repos: db.repos,
+			account_id: account.account_id,
+			params: {
+				community_id: personalCommunity.community_id,
+				persona_id: (await random.persona()).persona.persona_id,
+			},
+			session: new SessionApiMock(),
+		});
+		assert.ok(!createMembershipResult.ok);
+	},
+);
 
-test__membershipServices('delete a membership in a community', async ({db}) => {
-	const random = new RandomVocabContext(db);
+test__membershipServices('delete a membership in a community', async ({db, random}) => {
 	const {community, persona, account} = await random.community();
 
 	const deleteResult = await deleteMembershipService.perform({
@@ -77,8 +76,7 @@ test__membershipServices('delete a membership in a community', async ({db}) => {
 	assert.ok(!findSpaceResult.ok);
 });
 
-test__membershipServices('fail to delete a personal membership', async ({db}) => {
-	const random = new RandomVocabContext(db);
+test__membershipServices('fail to delete a personal membership', async ({db, random}) => {
 	const {persona, account} = await random.persona();
 
 	const deleteResult = await deleteMembershipService.perform({
@@ -96,8 +94,7 @@ test__membershipServices('fail to delete a personal membership', async ({db}) =>
 	assert.ok(findSpaceResult.ok);
 });
 
-test__membershipServices('fail to delete a community persona membership', async ({db}) => {
-	const random = new RandomVocabContext(db);
+test__membershipServices('fail to delete a community persona membership', async ({db, random}) => {
 	const {community, communityPersona, account} = await random.community();
 
 	const deleteResult = await deleteMembershipService.perform({
@@ -115,51 +112,55 @@ test__membershipServices('fail to delete a community persona membership', async 
 	assert.ok(findSpaceResult.ok);
 });
 
-test__membershipServices('delete orphaned communities on last member leaving', async ({db}) => {
-	//Need a community with two account members
-	const random = new RandomVocabContext(db);
-	const {persona: persona1, account} = await random.persona();
-	const {community} = await random.community(persona1);
-	const {persona: persona2} = await random.persona();
-	const membershipResult = await createMembershipService.perform({
-		params: {persona_id: persona2.persona_id, community_id: community.community_id},
-		...serviceRequest(account.account_id, db),
-	});
-	assert.ok(membershipResult.ok);
-	let communityMemberships = await db.repos.membership.filterByCommunityId(community.community_id);
-	assert.ok(communityMemberships.ok);
-	assert.is(communityMemberships.value.length, 3);
+test__membershipServices(
+	'delete orphaned communities on last member leaving',
+	async ({db, random}) => {
+		//Need a community with two account members
+		const {persona: persona1, account} = await random.persona();
+		const {community} = await random.community(persona1);
+		const {persona: persona2} = await random.persona();
+		const membershipResult = await createMembershipService.perform({
+			params: {persona_id: persona2.persona_id, community_id: community.community_id},
+			...serviceRequest(account.account_id, db),
+		});
+		assert.ok(membershipResult.ok);
+		let communityMemberships = await db.repos.membership.filterByCommunityId(
+			community.community_id,
+		);
+		assert.ok(communityMemberships.ok);
+		assert.is(communityMemberships.value.length, 3);
 
-	//Delete 1 account member, the community still exists
-	let deleteResult = await deleteMembershipService.perform({
-		repos: db.repos,
-		params: {persona_id: persona2.persona_id, community_id: community.community_id},
-		account_id: account.account_id,
-		session: new SessionApiMock(),
-	});
-	assert.ok(deleteResult.ok);
-	communityMemberships = await db.repos.membership.filterByCommunityId(community.community_id);
-	assert.ok(communityMemberships.ok);
-	assert.is(communityMemberships.value.length, 2);
-	let communityRecord = await db.repos.community.findById(community.community_id);
-	assert.ok(communityRecord.ok);
+		//Delete 1 account member, the community still exists
+		let deleteResult = await deleteMembershipService.perform({
+			repos: db.repos,
+			params: {persona_id: persona2.persona_id, community_id: community.community_id},
+			account_id: account.account_id,
+			session: new SessionApiMock(),
+		});
+		assert.ok(deleteResult.ok);
+		communityMemberships = await db.repos.membership.filterByCommunityId(community.community_id);
+		assert.ok(communityMemberships.ok);
+		assert.is(communityMemberships.value.length, 2);
+		let communityRecord = await db.repos.community.findById(community.community_id);
+		assert.ok(communityRecord.ok);
 
-	//Delete last account member, the community is deleted
-	deleteResult = await deleteMembershipService.perform({
-		repos: db.repos,
-		params: {persona_id: persona1.persona_id, community_id: community.community_id},
-		account_id: account.account_id,
-		session: new SessionApiMock(),
-	});
+		//Delete last account member, the community is deleted
+		deleteResult = await deleteMembershipService.perform({
+			repos: db.repos,
+			params: {persona_id: persona1.persona_id, community_id: community.community_id},
+			account_id: account.account_id,
+			session: new SessionApiMock(),
+		});
 
-	assert.ok(deleteResult.ok);
-	communityMemberships = await db.repos.membership.filterByCommunityId(community.community_id);
-	assert.ok(communityMemberships.ok);
-	assert.is(communityMemberships.value.length, 0);
-	communityRecord = await db.repos.community.findById(community.community_id);
-	assert.ok(!communityRecord.ok);
-	assert.is(communityRecord.type, 'no_community_found');
-});
+		assert.ok(deleteResult.ok);
+		communityMemberships = await db.repos.membership.filterByCommunityId(community.community_id);
+		assert.ok(communityMemberships.ok);
+		assert.is(communityMemberships.value.length, 0);
+		communityRecord = await db.repos.community.findById(community.community_id);
+		assert.ok(!communityRecord.ok);
+		assert.is(communityRecord.type, 'no_community_found');
+	},
+);
 
 test__membershipServices.run();
 /* test__membershipServices */

--- a/src/lib/vocab/persona/personaService.test.ts
+++ b/src/lib/vocab/persona/personaService.test.ts
@@ -2,7 +2,6 @@ import {suite} from 'uvu';
 import * as assert from 'uvu/assert';
 
 import {setupDb, teardownDb, type TestDbContext} from '$lib/util/testDbHelpers';
-import {RandomVocabContext} from '$lib/vocab/random';
 import type {TestAppContext} from '$lib/util/testAppHelpers';
 import {createAccountPersonaService} from '$lib/vocab/persona/personaServices';
 import {randomEventParams} from '$lib/server/random';
@@ -15,9 +14,8 @@ const test__personaService = suite<TestDbContext & TestAppContext>('personaServi
 test__personaService.before(setupDb);
 test__personaService.after(teardownDb);
 
-test__personaService('create a persona & test collisions', async ({db}) => {
+test__personaService('create a persona & test collisions', async ({db, random}) => {
 	//STEP 1: get a server, account, and event context lined up
-	const random = new RandomVocabContext(db);
 	const account = await random.account();
 	const params = await randomEventParams(CreateAccountPersona, random);
 	params.name = params.name.toLowerCase();

--- a/src/lib/vocab/space/spaceServices.test.ts
+++ b/src/lib/vocab/space/spaceServices.test.ts
@@ -2,7 +2,6 @@ import {suite} from 'uvu';
 import * as assert from 'uvu/assert';
 
 import {setupDb, teardownDb, type TestDbContext} from '$lib/util/testDbHelpers';
-import {RandomVocabContext} from '$lib/vocab/random';
 import type {TestAppContext} from '$lib/util/testAppHelpers';
 import {deleteSpaceService} from '$lib/vocab/space/spaceServices';
 import {SessionApiMock} from '$lib/server/SessionApiMock';
@@ -13,8 +12,7 @@ const test__spaceServices = suite<TestDbContext & TestAppContext>('spaceServices
 test__spaceServices.before(setupDb);
 test__spaceServices.after(teardownDb);
 
-test__spaceServices('delete a space in multiple communities', async ({db}) => {
-	const random = new RandomVocabContext(db);
+test__spaceServices('delete a space in multiple communities', async ({db, random}) => {
 	const {space, account} = await random.space();
 
 	const deleteResult = await deleteSpaceService.perform({

--- a/src/lib/vocab/tie/TieRepo.test.ts
+++ b/src/lib/vocab/tie/TieRepo.test.ts
@@ -2,7 +2,6 @@ import {suite} from 'uvu';
 import * as assert from 'uvu/assert';
 
 import {setupDb, teardownDb, type TestDbContext} from '$lib/util/testDbHelpers';
-import {RandomVocabContext} from '$lib/vocab/random';
 import type {TestAppContext} from '$lib/util/testAppHelpers';
 
 /* test__TieRepo */
@@ -11,10 +10,9 @@ const test__TieRepo = suite<TestDbContext & TestAppContext>('TieRepo');
 test__TieRepo.before(setupDb);
 test__TieRepo.after(teardownDb);
 
-test__TieRepo('check tie queries', async ({db}) => {
+test__TieRepo('check tie queries', async ({db, random}) => {
 	//Gen space
 	//Gen dir entity -> thread entity -> post -> reply
-	const random = new RandomVocabContext(db);
 	const {persona, account, community, space} = await random.space();
 	const {entity: entityDir} = await random.entity(persona, account, community, space);
 	const {entity: entityThread} = await random.entity(persona, account, community, space);


### PR DESCRIPTION
Simplifies tests to always receive an optional `RandomVocabContext` along with the `db` in the test context. It's an extremely lightlweight class now that it does no caching, so it just makes code more concise.