### PR TITLE
use services in random

### DIFF
--- a/src/lib/server/servicesIntegration.test.ts
+++ b/src/lib/server/servicesIntegration.test.ts
@@ -4,7 +4,6 @@ import {unwrap} from '@feltcoop/felt';
 
 import {setupDb, teardownDb, type TestDbContext} from '$lib/util/testDbHelpers';
 import {toDefaultSpaces} from '$lib/vocab/space/defaultSpaces';
-import type {NoteEntityData} from '$lib/vocab/entity/entityData';
 import {SessionApiMock} from '$lib/server/SessionApiMock';
 import {
 	readCommunitiesService,
@@ -16,7 +15,7 @@ import {
 	readSpaceService,
 	readSpacesService,
 } from '$lib/vocab/space/spaceServices';
-import {createEntityService, readEntitiesService} from '$lib/vocab/entity/entityServices';
+import {readEntitiesService} from '$lib/vocab/entity/entityServices';
 import {isHomeSpace} from '$lib/vocab/space/spaceHelpers';
 import {
 	createMembershipService,
@@ -67,26 +66,9 @@ test_servicesIntegration('services integration test', async ({db, random}) => {
 	const defaultSpaces = toDefaultSpaces(community);
 	const defaultSpaceCount = defaultSpaces.length;
 
-	const entityData1: NoteEntityData = {type: 'Note', content: 'this is entity 1'};
-	const entityData2: NoteEntityData = {type: 'Note', content: 'entity: 2'};
-	const {entity: entity1} = unwrap(
-		await createEntityService.perform({
-			params: {actor_id: persona.persona_id, space_id: space.space_id, data: entityData1},
-			...serviceRequest,
-		}),
-	);
-	const {entity: entity2} = unwrap(
-		await createEntityService.perform({
-			params: {actor_id: persona.persona_id, space_id: space.space_id, data: entityData2},
-			...serviceRequest,
-		}),
-	);
-	assert.is(entity1.actor_id, persona.persona_id);
-	assert.is(entity2.actor_id, persona.persona_id);
-	assert.is(entity1.space_id, space.space_id);
-	assert.is(entity2.space_id, space.space_id);
-	assert.equal(entity1.data, entityData1);
-	assert.equal(entity2.data, entityData2);
+	// create some entities
+	const {entity: entity1} = await random.entity(persona, account, community, space);
+	const {entity: entity2} = await random.entity(persona, account, community, space);
 
 	// do queries
 	//

--- a/src/lib/server/servicesIntegration.test.ts
+++ b/src/lib/server/servicesIntegration.test.ts
@@ -70,6 +70,8 @@ test_servicesIntegration('services integration test', async ({db, random}) => {
 	const {entity: entity1} = await random.entity(persona, account, community, space);
 	const {entity: entity2} = await random.entity(persona, account, community, space);
 
+	// TODO create some ties
+
 	// do queries
 	//
 	//

--- a/src/lib/server/servicesIntegration.test.ts
+++ b/src/lib/server/servicesIntegration.test.ts
@@ -55,19 +55,13 @@ test_servicesIntegration('create, change, and delete some data from repos', asyn
 
 	// create a persona
 	const {persona, community: personaHomeCommunity} = unwrap(
-		await createAccountPersonaService.perform({
-			params: randomPersonaParams(),
-			...serviceRequest,
-		}),
+		await createAccountPersonaService.perform({params: randomPersonaParams(), ...serviceRequest}),
 	);
 	assert.ok(personaHomeCommunity);
 
 	// create a second persona
 	const {persona: persona2} = unwrap(
-		await createAccountPersonaService.perform({
-			params: randomPersonaParams(),
-			...serviceRequest,
-		}),
+		await createAccountPersonaService.perform({params: randomPersonaParams(), ...serviceRequest}),
 	);
 
 	// create community
@@ -189,10 +183,7 @@ test_servicesIntegration('create, change, and delete some data from repos', asyn
 			.filter((s) => !isHomeSpace(s))
 			.map(async (space) =>
 				unwrap(
-					await deleteSpaceService.perform({
-						params: {space_id: space.space_id},
-						...serviceRequest,
-					}),
+					await deleteSpaceService.perform({params: {space_id: space.space_id}, ...serviceRequest}),
 				),
 			),
 	);

--- a/src/lib/server/servicesIntegration.test.ts
+++ b/src/lib/server/servicesIntegration.test.ts
@@ -21,10 +21,16 @@ import {
 } from '$lib/vocab/community/communityServices';
 import {
 	createSpaceService,
+	deleteSpaceService,
 	readSpaceService,
 	readSpacesService,
 } from '$lib/vocab/space/spaceServices';
 import {createEntityService, readEntitiesService} from '$lib/vocab/entity/entityServices';
+import {isHomeSpace} from '$lib/vocab/space/spaceHelpers';
+import {
+	createMembershipService,
+	deleteMembershipService,
+} from '$lib/vocab/membership/membershipServices';
 
 /* test_servicesIntegration */
 const test_servicesIntegration = suite<TestDbContext>('repos');
@@ -47,24 +53,40 @@ test_servicesIntegration('create, change, and delete some data from repos', asyn
 		session: new SessionApiMock(),
 	};
 
-	// TODO create 2 personas
-	const personaParams = randomPersonaParams();
+	// create a persona
 	const {persona, community: personaHomeCommunity} = unwrap(
 		await createAccountPersonaService.perform({
-			params: {name: personaParams.name},
+			params: randomPersonaParams(),
 			...serviceRequest,
 		}),
 	);
 	assert.ok(personaHomeCommunity);
 
-	const communityParams = randomCommunityParams(persona.persona_id);
-	const {community} = unwrap(
-		await createCommunityService.perform({
-			params: {name: communityParams.name, persona_id: communityParams.persona_id},
+	// create a second persona
+	const {persona: persona2} = unwrap(
+		await createAccountPersonaService.perform({
+			params: randomPersonaParams(),
 			...serviceRequest,
 		}),
 	);
 
+	// create community
+	const {community} = unwrap(
+		await createCommunityService.perform({
+			params: randomCommunityParams(persona.persona_id),
+			...serviceRequest,
+		}),
+	);
+
+	// join the community with the second persona
+	unwrap(
+		await createMembershipService.perform({
+			params: {community_id: community.community_id, persona_id: persona2.persona_id},
+			...serviceRequest,
+		}),
+	);
+
+	// create a space
 	const spaceParams = randomSpaceParams(community.community_id);
 	const {space} = unwrap(
 		await createSpaceService.perform({params: spaceParams, ...serviceRequest}),
@@ -132,20 +154,21 @@ test_servicesIntegration('create, change, and delete some data from repos', asyn
 			...serviceRequest,
 		}),
 	);
-	assert.equal(filterCommunitiesValue.length, 2);
+	assert.equal(filterCommunitiesValue.length, 3);
 
 	// TODO add a service event?
-	const filterPersonasValue = unwrap(await db.repos.persona.filterByAccount(account.account_id));
-	assert.is(filterPersonasValue.length, 1);
-	assert.equal(filterPersonasValue, [persona]);
+	assert.equal(
+		unwrap(await db.repos.persona.filterByAccount(account.account_id)).sort((a, b) =>
+			a.created < b.created ? -1 : 1,
+		),
+		[persona, persona2],
+	);
 
 	// TODO add a service event?
-	const findAccountByIdValue = unwrap(await db.repos.account.findById(account.account_id));
-	assert.is(findAccountByIdValue.name, account.name);
+	assert.is(unwrap(await db.repos.account.findById(account.account_id)).name, account.name);
 
 	// TODO add a service event?
-	const findAccountByNameValue = unwrap(await db.repos.account.findByName(account.name));
-	assert.is(findAccountByNameValue.name, account.name);
+	assert.is(unwrap(await db.repos.account.findByName(account.name)).name, account.name);
 
 	// do changes
 	//
@@ -160,39 +183,57 @@ test_servicesIntegration('create, change, and delete some data from repos', asyn
 	// );
 	// assert.ok(deleteFileResult.ok);
 
+	// delete spaces except the home space
 	await Promise.all(
-		filterSpacesValue.map(async (space) => unwrap(await db.repos.space.deleteById(space.space_id))),
+		filterSpacesValue
+			.filter((s) => !isHomeSpace(s))
+			.map(async (space) =>
+				unwrap(
+					await deleteSpaceService.perform({
+						params: {space_id: space.space_id},
+						...serviceRequest,
+					}),
+				),
+			),
 	);
-	const deletedSpaceResult = await db.repos.space.filterByCommunity(community.community_id);
-	assert.is(unwrap(deletedSpaceResult).length, 0);
+	assert.is(unwrap(await db.repos.space.filterByCommunity(community.community_id)).length, 1);
 
+	// delete membership
+	assert.is(
+		unwrap(await db.repos.membership.filterByCommunityId(community.community_id)).length,
+		3,
+	);
+	unwrap(
+		await deleteMembershipService.perform({
+			params: {persona_id: persona2.persona_id, community_id: community.community_id},
+			...serviceRequest,
+		}),
+	);
 	assert.is(
 		unwrap(await db.repos.membership.filterByCommunityId(community.community_id)).length,
 		2,
 	);
-	const deletedMembershipResult = await db.repos.membership.deleteById(
-		persona.persona_id,
-		community.community_id,
-	);
-	assert.ok(deletedMembershipResult.ok);
 	assert.is(
-		unwrap(await db.repos.membership.filterByCommunityId(community.community_id)).length,
+		unwrap(
+			await db.repos.membership.filterAccountPersonaMembershipsByCommunityId(
+				community.community_id,
+			),
+		).length,
 		1,
 	);
 
-	// TODO delete communities here
-	const deleteCommunitiesResult = await deleteCommunityService.perform({
-		params: {community_id: community.community_id},
-		...serviceRequest,
-	});
-	assert.ok(deleteCommunitiesResult.ok);
-
+	// delete community
+	unwrap(
+		await deleteCommunityService.perform({
+			params: {community_id: community.community_id},
+			...serviceRequest,
+		}),
+	);
 	const readCommunityResult = await readCommunityService.perform({
 		params: {community_id: community.community_id},
 		...serviceRequest,
 	});
 	assert.is(readCommunityResult.status, 404);
-
 	assert.is(
 		unwrap(await db.repos.membership.filterByCommunityId(community.community_id)).length,
 		0,

--- a/src/lib/ui/view/Home.svelte
+++ b/src/lib/ui/view/Home.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import {getApp} from '$lib/ui/app';
 	import {getViewContext} from '$lib/vocab/view/view';
-	import Forum from '$lib/ui/Forum.svelte';
+	import Forum from '$lib/ui/view/Forum.svelte';
 	import PersonaAvatar from '$lib/ui/PersonaAvatar.svelte';
 
 	const viewContext = getViewContext();

--- a/src/lib/ui/view/Home.svelte
+++ b/src/lib/ui/view/Home.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import {getApp} from '$lib/ui/app';
 	import {getViewContext} from '$lib/vocab/view/view';
-	import Forum from './Forum.svelte';
-	import PersonaAvatar from '../PersonaAvatar.svelte';
+	import Forum from '$lib/ui/Forum.svelte';
+	import PersonaAvatar from '$lib/ui/PersonaAvatar.svelte';
 
 	const viewContext = getViewContext();
 	$: ({community} = $viewContext);

--- a/src/lib/vocab/community/communityServices.test.ts
+++ b/src/lib/vocab/community/communityServices.test.ts
@@ -3,7 +3,7 @@ import * as assert from 'uvu/assert';
 
 import {setupDb, teardownDb, type TestDbContext} from '$lib/util/testDbHelpers';
 import type {TestAppContext} from '$lib/util/testAppHelpers';
-import {deleteCommunityService} from './communityServices';
+import {deleteCommunityService} from '$lib/vocab/community/communityServices';
 import {SessionApiMock} from '$lib/server/SessionApiMock';
 
 /* test_communityServices */

--- a/src/lib/vocab/entity/entityServices.test.ts
+++ b/src/lib/vocab/entity/entityServices.test.ts
@@ -1,0 +1,34 @@
+import {suite} from 'uvu';
+import * as assert from 'uvu/assert';
+
+import {setupDb, teardownDb, type TestDbContext} from '$lib/util/testDbHelpers';
+import type {TestAppContext} from '$lib/util/testAppHelpers';
+import type {NoteEntityData} from '$lib/vocab/entity/entityData';
+
+/* test_entityServices */
+const test_entityServices = suite<TestDbContext & TestAppContext>('communityRepo');
+
+test_entityServices.before(setupDb);
+test_entityServices.after(teardownDb);
+
+test_entityServices('create entities with data', async ({random}) => {
+	const {space, persona, account, community} = await random.space();
+
+	const entityData1: NoteEntityData = {type: 'Note', content: 'this is entity 1'};
+	const entityData2: NoteEntityData = {type: 'Note', content: 'entity: 2'};
+	const {entity: entity1} = await random.entity(persona, account, community, space, {
+		data: entityData1,
+	});
+	const {entity: entity2} = await random.entity(persona, account, community, space, {
+		data: entityData2,
+	});
+	assert.is(entity1.actor_id, persona.persona_id);
+	assert.is(entity2.actor_id, persona.persona_id);
+	assert.is(entity1.space_id, space.space_id);
+	assert.is(entity2.space_id, space.space_id);
+	assert.equal(entity1.data, entityData1);
+	assert.equal(entity2.data, entityData2);
+});
+
+test_entityServices.run();
+/* test_entityServices */

--- a/src/lib/vocab/random.ts
+++ b/src/lib/vocab/random.ts
@@ -12,6 +12,7 @@ import type {
 	CreateEntityParams,
 	CreateSpaceParams,
 	CreateMembershipParams,
+	CreateTieParams,
 } from '$lib/app/eventTypes';
 import type {Database} from '$lib/db/Database';
 import type {EntityData} from '$lib/vocab/entity/entityData';
@@ -24,6 +25,7 @@ import {createCommunityService} from '$lib/vocab/community/communityServices';
 import {createSpaceService} from '$lib/vocab/space/spaceServices';
 import type {Membership} from '$lib/vocab/membership/membership';
 import {createEntityService} from '$lib/vocab/entity/entityServices';
+import {createTieService} from '$lib/vocab/tie/tieServices';
 
 const session = new SessionApiMock();
 
@@ -38,6 +40,7 @@ export const randomSpaceIcon = (): string => '🥥';
 export const randomSpaceName = randomString;
 export const randomViewData = (): ViewData => parseView('<Room />');
 export const randomEntityData = (): EntityData => ({type: 'Note', content: randomString()});
+export const randomTieType = randomString;
 export const randomAccountParams = (): CreateAccountParams => ({
 	name: randomAccountName(),
 	password: randomPassword(),
@@ -71,6 +74,11 @@ export const randomEntityParams = (actor_id: number, space_id: number): CreateEn
 	actor_id,
 	space_id,
 	data: randomEntityData(),
+});
+export const randomTieParams = (source_id: number, dest_id: number): CreateTieParams => ({
+	source_id,
+	dest_id,
+	type: randomTieType(),
 });
 
 // TODO maybe compute in relation to `RandomVocabContext`
@@ -199,6 +207,7 @@ export class RandomVocabContext {
 		account?: Account,
 		community?: Community,
 		space?: Space,
+		tieType?: Tie['type'],
 	): Promise<{
 		tie: Tie;
 		sourceEntity: Entity;
@@ -215,8 +224,15 @@ export class RandomVocabContext {
 		if (!sourceEntity)
 			({entity: sourceEntity} = await this.entity(persona, account, community, space));
 		if (!destEntity) ({entity: destEntity} = await this.entity(persona, account, community, space));
-		const tie = unwrap(
-			await this.db.repos.tie.create(sourceEntity.entity_id, destEntity.entity_id, 'HasItem'),
+		const params = randomTieParams(sourceEntity.entity_id, destEntity.entity_id);
+		if (tieType) params.type = tieType;
+		const {tie} = unwrap(
+			await createTieService.perform({
+				params,
+				account_id: account.account_id,
+				repos: this.db.repos,
+				session,
+			}),
 		);
 		return {tie, sourceEntity, destEntity, persona, account, community, space};
 	}

--- a/src/lib/vocab/random.ts
+++ b/src/lib/vocab/random.ts
@@ -207,7 +207,7 @@ export class RandomVocabContext {
 		account?: Account,
 		community?: Community,
 		space?: Space,
-		tieType?: Tie['type'],
+		type?: Tie['type'],
 	): Promise<{
 		tie: Tie;
 		sourceEntity: Entity;
@@ -225,7 +225,7 @@ export class RandomVocabContext {
 			({entity: sourceEntity} = await this.entity(persona, account, community, space));
 		if (!destEntity) ({entity: destEntity} = await this.entity(persona, account, community, space));
 		const params = randomTieParams(sourceEntity.entity_id, destEntity.entity_id);
-		if (tieType) params.type = tieType;
+		if (type) params.type = type;
 		const {tie} = unwrap(
 			await createTieService.perform({
 				params,


### PR DESCRIPTION
Changes the random vocab to use `createEntityService` and `createTieService` instead of the repos. Also extracts some logic from the service integration test to a new `entityServices.test.ts`, and simplifies the service integration tests to use `random` instead of duplicating the same logic -- random previously used repos, but now that it uses services there's no reason for the integration test to be more complicated.