### PR TITLE
Directory part 2

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: ['**']
 
 jobs:
   build:

--- a/src/lib/app/eventTypes.ts
+++ b/src/lib/app/eventTypes.ts
@@ -214,6 +214,8 @@ export interface CreateEntityParams {
 	actor_id: number;
 	space_id: number;
 	data: EntityData;
+	source_id: number;
+	type?: string;
 }
 export interface CreateEntityResponse {
 	entity: Entity;

--- a/src/lib/db/migrations/00020-tie-entities-directory.js
+++ b/src/lib/db/migrations/00020-tie-entities-directory.js
@@ -1,0 +1,23 @@
+///** @param {import('postgres').Sql<any>} sql */
+/** @param {any} sql */
+export const up = async (sql) => {
+	const spaces = await sql`
+		SELECT * FROM spaces;
+	`;
+
+	for (const space of spaces) {
+		// eslint-disable-next-line no-await-in-loop
+		await sql`
+		WITH spaceEntities (entity_id) 
+		AS (SELECT entity_id FROM entities e WHERE e.space_id = ${space.space_id} AND e.data ->> 'type' != 'Directory')
+		INSERT INTO ties (source_id, dest_id, type)
+		SELECT ${space.directory_id},entity_id,'HasItem' FROM spaceEntities 		
+		WHERE spaceEntities.entity_id NOT IN (
+			SELECT t.dest_id 
+			FROM ties t 
+			JOIN spaceEntities 
+			ON spaceEntities.entity_id = t.dest_id
+		) ;
+		`;
+	}
+};

--- a/src/lib/server/random.ts
+++ b/src/lib/server/random.ts
@@ -100,7 +100,7 @@ export const randomEventParams = async (
 		case 'CreateEntity': {
 			if (!persona) ({persona} = await random.persona(account));
 			if (!space) ({space} = await random.space(persona, account, community));
-			return randomEntityParams(persona.persona_id, space.space_id);
+			return randomEntityParams(persona.persona_id, space.space_id, space.directory_id);
 		}
 		case 'ReadEntities': {
 			if (!space) ({space} = await random.space(persona, account, community));

--- a/src/lib/server/servicesIntegration.test.ts
+++ b/src/lib/server/servicesIntegration.test.ts
@@ -77,13 +77,23 @@ test_servicesIntegration('create, change, and delete some data from repos', asyn
 	const entityData2: NoteEntityData = {type: 'Note', content: 'entity: 2'};
 	const {entity: entity1} = unwrap(
 		await createEntityService.perform({
-			params: {actor_id: persona.persona_id, space_id: space.space_id, data: entityData1},
+			params: {
+				actor_id: persona.persona_id,
+				space_id: space.space_id,
+				data: entityData1,
+				source_id: space.directory_id,
+			},
 			...serviceRequest,
 		}),
 	);
 	const {entity: entity2} = unwrap(
 		await createEntityService.perform({
-			params: {actor_id: persona.persona_id, space_id: space.space_id, data: entityData2},
+			params: {
+				actor_id: persona.persona_id,
+				space_id: space.space_id,
+				data: entityData2,
+				source_id: space.directory_id,
+			},
 			...serviceRequest,
 		}),
 	);

--- a/src/lib/ui/EntityInput.svelte
+++ b/src/lib/ui/EntityInput.svelte
@@ -17,6 +17,7 @@
 	$: actor_id = $selectedPersona!.persona_id;
 	$: selectedSpace = $spaceSelection;
 	$: space_id = $selectedSpace!.space_id;
+	$: source_id = $selectedSpace!.directory_id;
 
 	let name = '';
 	let status: AsyncStatus = 'initial'; // TODO refactor
@@ -38,6 +39,7 @@
 			actor_id,
 			space_id,
 			data: {type: 'Collection', name},
+			source_id,
 		});
 		status = 'success'; // TODO handle failure (also refactor to be generic)
 		if (result.ok) {

--- a/src/lib/ui/view/Board.svelte
+++ b/src/lib/ui/view/Board.svelte
@@ -24,6 +24,7 @@
 			space_id: $space.space_id,
 			data: {type: 'Note', content},
 			actor_id: $persona.persona_id,
+			source_id: $space.directory_id,
 		});
 		text = '';
 	};

--- a/src/lib/ui/view/Forum.svelte
+++ b/src/lib/ui/view/Forum.svelte
@@ -24,6 +24,7 @@
 			space_id: $space.space_id,
 			data: {type: 'Note', content},
 			actor_id: $persona.persona_id,
+			source_id: $space.directory_id,
 		});
 		text = '';
 	};

--- a/src/lib/ui/view/Notes.svelte
+++ b/src/lib/ui/view/Notes.svelte
@@ -24,6 +24,7 @@
 			space_id: $space.space_id,
 			data: {type: 'Note', content},
 			actor_id: $persona.persona_id,
+			source_id: $space.directory_id,
 		});
 		text = '';
 	};

--- a/src/lib/ui/view/Room.svelte
+++ b/src/lib/ui/view/Room.svelte
@@ -24,6 +24,7 @@
 			space_id: $space.space_id,
 			data: {type: 'Note', content},
 			actor_id: $persona.persona_id,
+			source_id: $space.directory_id,
 		});
 		text = '';
 	};

--- a/src/lib/ui/view/Todo.svelte
+++ b/src/lib/ui/view/Todo.svelte
@@ -68,19 +68,12 @@
 		if (!content || !selectedList) return;
 
 		//TODO better error handling
-		//TODO create api call to do this in one step?
-		const entityResult = await dispatch.CreateEntity({
+		await dispatch.CreateEntity({
 			space_id: $space.space_id,
 			data: {type: 'Note', content, checked: false},
 			actor_id: $persona.persona_id,
+			source_id: selectedList.entity_id,
 		});
-		if (entityResult.ok) {
-			await dispatch.CreateTie({
-				source_id: selectedList.entity_id,
-				dest_id: entityResult.value.entity.entity_id,
-				type: 'HasItem',
-			});
-		}
 		text = '';
 	};
 	const onKeydown = async (e: KeyboardEvent) => {

--- a/src/lib/vocab/entity/entityEvents.ts
+++ b/src/lib/vocab/entity/entityEvents.ts
@@ -11,8 +11,10 @@ export const CreateEntity: ServiceEventInfo = {
 			actor_id: {type: 'number'},
 			space_id: {type: 'number'},
 			data: {type: 'object', tsType: 'EntityData'},
+			source_id: {type: 'number'},
+			type: {type: 'string'},
 		},
-		required: ['actor_id', 'space_id', 'data'],
+		required: ['actor_id', 'space_id', 'data', 'source_id'],
 		additionalProperties: false,
 	},
 	response: {

--- a/src/lib/vocab/entity/entityServices.ts
+++ b/src/lib/vocab/entity/entityServices.ts
@@ -43,6 +43,17 @@ export const createEntityService: Service<CreateEntityParams, CreateEntityRespon
 		if (!insertEntitiesResult.ok) {
 			return {ok: false, status: 500, message: 'failed to create entity'};
 		}
+
+		const insertTieResult = await repos.tie.create(
+			params.source_id,
+			insertEntitiesResult.value.entity_id,
+			params.type ? params.type : 'HasItem',
+		);
+
+		if (!insertTieResult.ok) {
+			return {ok: false, status: 500, message: 'failed to tie entity to graph'};
+		}
+
 		return {ok: true, status: 200, value: {entity: insertEntitiesResult.value}};
 	},
 };

--- a/src/lib/vocab/random.ts
+++ b/src/lib/vocab/random.ts
@@ -66,10 +66,15 @@ export const randomSpaceParams = (community_id: number): CreateSpaceParams => ({
 	url: randomSpaceUrl(),
 	icon: randomSpaceIcon(),
 });
-export const randomEntityParams = (actor_id: number, space_id: number): CreateEntityParams => ({
+export const randomEntityParams = (
+	actor_id: number,
+	space_id: number,
+	source_id: number,
+): CreateEntityParams => ({
 	actor_id,
 	space_id,
 	data: randomEntityData(),
+	source_id,
 });
 
 // TODO maybe compute in relation to `RandomVocabContext`
@@ -179,7 +184,7 @@ export class RandomVocabContext {
 		if (!persona) ({persona} = await this.persona(account));
 		if (!community) ({community} = await this.community(persona, account));
 		if (!space) ({space} = await this.space(persona, account, community));
-		const params = randomEntityParams(persona.persona_id, space.space_id);
+		const params = randomEntityParams(persona.persona_id, space.space_id, space.directory_id);
 		const entity = unwrap(
 			await this.db.repos.entity.create(params.actor_id, params.data, params.space_id),
 		);

--- a/src/lib/vocab/tie/TieRepo.test.ts
+++ b/src/lib/vocab/tie/TieRepo.test.ts
@@ -1,5 +1,7 @@
 import {suite} from 'uvu';
 import * as assert from 'uvu/assert';
+import {unwrap} from '@feltcoop/felt';
+import {isDeepStrictEqual} from 'util';
 
 import {setupDb, teardownDb, type TestDbContext} from '$lib/util/testDbHelpers';
 import type {TestAppContext} from '$lib/util/testAppHelpers';
@@ -19,41 +21,29 @@ test__TieRepo('check tie queries', async ({db, random}) => {
 	const {entity: entityPost} = await random.entity(persona, account, community, space);
 	const {entity: entityReply} = await random.entity(persona, account, community, space);
 
-	const result1 = await db.repos.tie.create(
-		entityDir.entity_id,
-		entityThread.entity_id,
-		'HasThread',
+	const tie1 = unwrap(
+		await db.repos.tie.create(entityDir.entity_id, entityThread.entity_id, 'HasThread'),
 	);
-	assert.ok(result1.ok);
 
-	const result2 = await db.repos.tie.create(
-		entityThread.entity_id,
-		entityPost.entity_id,
-		'HasPost',
+	const tie2 = unwrap(
+		await db.repos.tie.create(entityThread.entity_id, entityPost.entity_id, 'HasPost'),
 	);
-	assert.ok(result2.ok);
 
-	const result3 = await db.repos.tie.create(
-		entityPost.entity_id,
-		entityReply.entity_id,
-		'HasReply',
+	const tie3 = unwrap(
+		await db.repos.tie.create(entityPost.entity_id, entityReply.entity_id, 'HasReply'),
 	);
-	assert.ok(result3.ok);
 
-	const query1 = await db.repos.tie.filterBySpace(space.space_id);
-	assert.ok(query1.ok);
-	assert.equal(query1.value.length, 7);
-	assert.ok(query1.value.includes(result1.value));
-	assert.ok(query1.value.includes(result2.value));
-	assert.ok(query1.value.includes(result3.value));
+	const query1 = unwrap(await db.repos.tie.filterBySpace(space.space_id));
+	assert.equal(query1.length, 7);
+	assert.ok(query1.find((t) => isDeepStrictEqual(t, tie1)));
+	assert.ok(query1.find((t) => isDeepStrictEqual(t, tie2)));
+	assert.ok(query1.find((t) => isDeepStrictEqual(t, tie3)));
 
-	const query2 = await db.repos.tie.filterBySourceId(entityDir.entity_id);
-	assert.ok(query2.ok);
-	assert.equal(query2.value.length, 7);
-
-	assert.ok(query2.value.includes(result1.value));
-	assert.ok(query2.value.includes(result2.value));
-	assert.ok(query2.value.includes(result3.value));
+	const query2 = unwrap(await db.repos.tie.filterBySourceId(entityDir.entity_id));
+	assert.equal(query2.length, 3);
+	assert.ok(query2.find((t) => isDeepStrictEqual(t, tie1)));
+	assert.ok(query2.find((t) => isDeepStrictEqual(t, tie2)));
+	assert.ok(query2.find((t) => isDeepStrictEqual(t, tie3)));
 });
 
 test__TieRepo.run();


### PR DESCRIPTION
This PR handles Part 2 of the directory architectural refactor.

It introduces a migration query that connects all orphan entities (i.e. all those without a tie where they are the dest, i.e. any top level or non connected entities) and ties them to their space's Directory (introduced in  #300 )

It also expands the CreateEntity service params to include a `source_id` attribute & option `type` (which defaults to HasItem) to make sure no Entity is created as an orphan from here out.

Lastly, it updates all uses of CreateEntity on the front end to now include the directory_id in the call (except in Todo, where we get to condense some existing Tie logic down to a single call! 🎉 )