### PR TITLE
fix tie repo test in directory-part-2 branch

### DIFF
--- a/src/lib/vocab/tie/TieRepo.test.ts
+++ b/src/lib/vocab/tie/TieRepo.test.ts
@@ -1,5 +1,7 @@
 import {suite} from 'uvu';
 import * as assert from 'uvu/assert';
+import {unwrap} from '@feltcoop/felt';
+import {isDeepStrictEqual} from 'util';
 
 import {setupDb, teardownDb, type TestDbContext} from '$lib/util/testDbHelpers';
 import type {TestAppContext} from '$lib/util/testAppHelpers';
@@ -19,41 +21,29 @@ test__TieRepo('check tie queries', async ({db, random}) => {
 	const {entity: entityPost} = await random.entity(persona, account, community, space);
 	const {entity: entityReply} = await random.entity(persona, account, community, space);
 
-	const result1 = await db.repos.tie.create(
-		entityDir.entity_id,
-		entityThread.entity_id,
-		'HasThread',
+	const tie1 = unwrap(
+		await db.repos.tie.create(entityDir.entity_id, entityThread.entity_id, 'HasThread'),
 	);
-	assert.ok(result1.ok);
 
-	const result2 = await db.repos.tie.create(
-		entityThread.entity_id,
-		entityPost.entity_id,
-		'HasPost',
+	const tie2 = unwrap(
+		await db.repos.tie.create(entityThread.entity_id, entityPost.entity_id, 'HasPost'),
 	);
-	assert.ok(result2.ok);
 
-	const result3 = await db.repos.tie.create(
-		entityPost.entity_id,
-		entityReply.entity_id,
-		'HasReply',
+	const tie3 = unwrap(
+		await db.repos.tie.create(entityPost.entity_id, entityReply.entity_id, 'HasReply'),
 	);
-	assert.ok(result3.ok);
 
-	const query1 = await db.repos.tie.filterBySpace(space.space_id);
-	assert.ok(query1.ok);
-	assert.equal(query1.value.length, 7);
-	assert.ok(query1.value.includes(result1.value));
-	assert.ok(query1.value.includes(result2.value));
-	assert.ok(query1.value.includes(result3.value));
+	const query1 = unwrap(await db.repos.tie.filterBySpace(space.space_id));
+	assert.equal(query1.length, 7);
+	assert.ok(query1.find((t) => isDeepStrictEqual(t, tie1)));
+	assert.ok(query1.find((t) => isDeepStrictEqual(t, tie2)));
+	assert.ok(query1.find((t) => isDeepStrictEqual(t, tie3)));
 
-	const query2 = await db.repos.tie.filterBySourceId(entityDir.entity_id);
-	assert.ok(query2.ok);
-	assert.equal(query2.value.length, 7);
-
-	assert.ok(query2.value.includes(result1.value));
-	assert.ok(query2.value.includes(result2.value));
-	assert.ok(query2.value.includes(result3.value));
+	const query2 = unwrap(await db.repos.tie.filterBySourceId(entityDir.entity_id));
+	assert.equal(query2.length, 3);
+	assert.ok(query2.find((t) => isDeepStrictEqual(t, tie1)));
+	assert.ok(query2.find((t) => isDeepStrictEqual(t, tie2)));
+	assert.ok(query2.find((t) => isDeepStrictEqual(t, tie3)));
 });
 
 test__TieRepo.run();


### PR DESCRIPTION
Fixes the test assertions in #322 . The problem is `includes` compares by reference not value. This uses `.find` and the Node builtin `isDeepStrictEqual`. Also changed the second count assertion from 7 to 3 and used `unwrap` for concision.