### PR TITLE
Directory PHASE 3

### DIFF
--- a/src/lib/app/eventTypes.ts
+++ b/src/lib/app/eventTypes.ts
@@ -235,6 +235,7 @@ export interface ReadEntitiesParams {
 }
 export interface ReadEntitiesResponse {
 	entities: Entity[];
+	ties: Tie[];
 }
 export type ReadEntitiesResponseResult = ApiResult<ReadEntitiesResponse>;
 

--- a/src/lib/vocab/entity/EntityRepo.ts
+++ b/src/lib/vocab/entity/EntityRepo.ts
@@ -46,6 +46,19 @@ export class EntityRepo extends PostgresRepo {
 		return {ok: true, value: entities};
 	}
 
+	// TODO maybe `EntityQuery`?
+	async findBySet(entityIdSet: number[]): Promise<Result<{value: Entity[]}>> {
+		if (entityIdSet.length === 0) return {ok: true, value: []};
+		log.trace('[findBySet]', entityIdSet);
+		const entities = await this.db.sql<Entity[]>`
+			SELECT entity_id, data, actor_id, space_id, created, updated 
+			FROM entities WHERE entity_id IN ${this.db.sql(entityIdSet)}
+			ORDER BY created ASC
+		`;
+		log.trace('entity count:', entities.length);
+		return {ok: true, value: entities};
+	}
+
 	async updateEntityData(entity_id: number, data: EntityData): Promise<Result<{value: Entity}>> {
 		log.trace('[updateEntityData]', entity_id);
 		const result = await this.db.sql<Entity[]>`

--- a/src/lib/vocab/entity/entityEvents.ts
+++ b/src/lib/vocab/entity/entityEvents.ts
@@ -80,8 +80,9 @@ export const ReadEntities: ServiceEventInfo = {
 		type: 'object',
 		properties: {
 			entities: {type: 'array', items: {$ref: '/schemas/Entity.json', tsType: 'Entity'}},
+			ties: {type: 'array', items: {$ref: '/schemas/Tie.json', tsType: 'Tie'}},
 		},
-		required: ['entities'],
+		required: ['entities', 'ties'],
 		additionalProperties: false,
 	},
 	returns: 'Promise<ReadEntitiesResponseResult>',

--- a/src/lib/vocab/entity/entityServices.ts
+++ b/src/lib/vocab/entity/entityServices.ts
@@ -23,11 +23,29 @@ import {
 export const readEntitiesService: Service<ReadEntitiesParams, ReadEntitiesResponseResult> = {
 	event: ReadEntities,
 	perform: async ({repos, params}) => {
-		const findEntitiesResult = await repos.entity.filterBySpace(params.space_id);
+		// could update the interface to just expect the client to provide the dir id
+		// but didn't want to mess with the interface for now.
+		const findSpaceResult = await repos.space.findById(params.space_id);
+		if (!findSpaceResult.ok) {
+			return {ok: false, status: 500, message: 'error looking up space'};
+		}
+		const findTiesResult = await repos.tie.filterBySourceId(findSpaceResult.value.directory_id);
+		if (!findTiesResult.ok) {
+			return {ok: false, status: 500, message: 'error searching space directory'};
+		}
+		//TODO stop filtering directory until we fix entity indexing by space_id
+		const entitySet = findTiesResult.value.flatMap((t) =>
+			[t.source_id, t.dest_id].filter((x) => x !== findSpaceResult.value.directory_id),
+		);
+		const findEntitiesResult = await repos.entity.findBySet(entitySet);
 		if (!findEntitiesResult.ok) {
 			return {ok: false, status: 500, message: 'error searching for entities'};
 		}
-		return {ok: true, status: 200, value: {entities: findEntitiesResult.value}};
+		return {
+			ok: true,
+			status: 200,
+			value: {entities: findEntitiesResult.value, ties: findTiesResult.value},
+		};
 	},
 };
 


### PR DESCRIPTION
This PR tries to touch as little of the interface as possible, while replacing the query for Entities with the new directory crawl query.

Some future work off of this:
Move Entity stores away from indexing off of space_id
Modify event to expect both entities & ties to return