### PR TITLE
prefer specialized avatars when appropriate

### DIFF
--- a/src/lib/ui/Avatar.svelte
+++ b/src/lib/ui/Avatar.svelte
@@ -4,6 +4,7 @@
 	import {GUEST_PERSONA_NAME} from '$lib/vocab/persona/constants';
 	import type {EntityType} from '$lib/vocab/entity/entity.schema';
 	import {getApp} from '$lib/ui/app';
+	import type {ContextmenuItems} from '$lib/ui/contextmenu/contextmenu';
 
 	export let name: string = GUEST_PERSONA_NAME; // TODO should this handle "default" or "empty" or "blank" avatars?
 	export let icon: string | null = null;
@@ -11,7 +12,7 @@
 	export let showName = true;
 	export let showIcon = true;
 	export let type: EntityType = 'Persona';
-	export let contextmenuAction: any | undefined = undefined;
+	export let contextmenuAction: ContextmenuItems | null = null;
 
 	$: finalHue = hue ?? randomHue(name);
 

--- a/src/lib/ui/CommunityAvatar.svelte
+++ b/src/lib/ui/CommunityAvatar.svelte
@@ -4,10 +4,12 @@
 	import Avatar from '$lib/ui/Avatar.svelte';
 	import type {Community} from '$lib/vocab/community/community';
 	import CommunityContextmenu from '$lib/app/contextmenu/CommunityContextmenu.svelte';
+	import type {ContextmenuItems} from '$lib/ui/contextmenu/contextmenu';
 
 	export let community: Readable<Community>;
 	export let showName = true;
 	export let showIcon = true;
+	export let contextmenuAction: ContextmenuItems | null = [[CommunityContextmenu, {community}]];
 </script>
 
 <Avatar
@@ -16,5 +18,5 @@
 	hue={$community.settings.hue}
 	{showName}
 	{showIcon}
-	contextmenuAction={[[CommunityContextmenu, {community}]]}
+	{contextmenuAction}
 />

--- a/src/lib/ui/CommunityAvatar.svelte
+++ b/src/lib/ui/CommunityAvatar.svelte
@@ -9,7 +9,7 @@
 	export let community: Readable<Community>;
 	export let showName = true;
 	export let showIcon = true;
-	export let contextmenuAction: ContextmenuItems | null = [[CommunityContextmenu, {community}]];
+	export let contextmenuAction: ContextmenuItems | null | undefined = undefined;
 </script>
 
 <Avatar
@@ -18,5 +18,7 @@
 	hue={$community.settings.hue}
 	{showName}
 	{showIcon}
-	{contextmenuAction}
+	contextmenuAction={contextmenuAction === undefined
+		? [[CommunityContextmenu, {community}]]
+		: contextmenuAction}
 />

--- a/src/lib/ui/MainNav.svelte
+++ b/src/lib/ui/MainNav.svelte
@@ -41,7 +41,7 @@
 			<div class="icon-button button-placeholder" />
 			<!-- TODO or maybe `selectedPersona.id` ? can't be `$selectedPersona.persona_id` as a serial value -->
 			<button class="explorer-button" on:click={(e) => onContextmenu(e, contextmenu)}>
-				<PersonaAvatar persona={selectedPersona} />
+				<PersonaAvatar persona={selectedPersona} contextmenuAction={null} />
 			</button>
 		</div>
 		<div class="explorer">

--- a/src/lib/ui/MainNav.svelte
+++ b/src/lib/ui/MainNav.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 	import CommunityNav from '$lib/ui/CommunityNav.svelte';
 	import SpaceNav from '$lib/ui/SpaceNav.svelte';
-	import Avatar from '$lib/ui/Avatar.svelte';
+	import PersonaAvatar from '$lib/ui/PersonaAvatar.svelte';
 	import {getApp} from '$lib/ui/app';
 	import {randomHue} from '$lib/ui/color';
-	import {toName, toIcon} from '$lib/vocab/entity/entityHelpers';
+	import {toName} from '$lib/vocab/entity/entityHelpers';
 	import {onContextmenu} from '$lib/ui/contextmenu/contextmenu';
 
 	const {
@@ -41,7 +41,7 @@
 			<div class="icon-button button-placeholder" />
 			<!-- TODO or maybe `selectedPersona.id` ? can't be `$selectedPersona.persona_id` as a serial value -->
 			<button class="explorer-button" on:click={(e) => onContextmenu(e, contextmenu)}>
-				<Avatar name={toName($selectedPersona)} icon={toIcon($selectedPersona)} />
+				<PersonaAvatar persona={selectedPersona} />
 			</button>
 		</div>
 		<div class="explorer">

--- a/src/lib/ui/PersonaAvatar.svelte
+++ b/src/lib/ui/PersonaAvatar.svelte
@@ -10,7 +10,15 @@
 	export let persona: Readable<Persona>;
 	export let showName = true;
 	export let showIcon = true;
-	export let contextmenuAction: ContextmenuItems | null = [[PersonaContextmenu, {persona}]];
+	export let contextmenuAction: ContextmenuItems | null | undefined = undefined;
 </script>
 
-<Avatar name={toName($persona)} icon={toIcon($persona)} {showName} {showIcon} {contextmenuAction} />
+<Avatar
+	name={toName($persona)}
+	icon={toIcon($persona)}
+	{showName}
+	{showIcon}
+	contextmenuAction={contextmenuAction === undefined
+		? [[PersonaContextmenu, {persona}]]
+		: contextmenuAction}
+/>

--- a/src/lib/ui/PersonaAvatar.svelte
+++ b/src/lib/ui/PersonaAvatar.svelte
@@ -5,16 +5,12 @@
 	import {toName, toIcon} from '$lib/vocab/entity/entityHelpers';
 	import type {Persona} from '$lib/vocab/persona/persona';
 	import PersonaContextmenu from '$lib/app/contextmenu/PersonaContextmenu.svelte';
+	import type {ContextmenuItems} from '$lib/ui/contextmenu/contextmenu';
 
 	export let persona: Readable<Persona>;
 	export let showName = true;
 	export let showIcon = true;
+	export let contextmenuAction: ContextmenuItems | null = [[PersonaContextmenu, {persona}]];
 </script>
 
-<Avatar
-	name={toName($persona)}
-	icon={toIcon($persona)}
-	{showName}
-	{showIcon}
-	contextmenuAction={[[PersonaContextmenu, {persona}]]}
-/>
+<Avatar name={toName($persona)} icon={toIcon($persona)} {showName} {showIcon} {contextmenuAction} />

--- a/src/lib/ui/RoomItem.svelte
+++ b/src/lib/ui/RoomItem.svelte
@@ -3,9 +3,8 @@
 	import {format} from 'date-fns';
 
 	import type {Entity} from '$lib/vocab/entity/entity';
-	import Avatar from '$lib/ui/Avatar.svelte';
+	import PersonaAvatar from '$lib/ui/PersonaAvatar.svelte';
 	import {randomHue} from '$lib/ui/color';
-	import {toIcon, toName} from '$lib/vocab/entity/entityHelpers';
 	import {getApp} from '$lib/ui/app';
 	import PersonaContextmenu from '$lib/app/contextmenu/PersonaContextmenu.svelte';
 	import EntityContextmenu from '$lib/app/contextmenu/EntityContextmenu.svelte';
@@ -32,11 +31,11 @@ And then PersonaContextmenu would be only for *session* personas? `SessionPerson
 	]}
 >
 	<div class="signature">
-		<Avatar name={toName($persona)} icon={toIcon($persona)} showName={false} />
+		<PersonaAvatar {persona} showName={false} />
 	</div>
 	<div class="markup formatted">
 		<div class="signature">
-			<Avatar name={toName($persona)} icon={toIcon($persona)} showIcon={false} />
+			<PersonaAvatar {persona} showIcon={false} />
 			{format($entity.created, 'Pp')}
 		</div>
 		<div>

--- a/src/lib/ui/TodoItem.svelte
+++ b/src/lib/ui/TodoItem.svelte
@@ -3,9 +3,8 @@
 
 	import type {Entity} from '$lib/vocab/entity/entity';
 	import type {Tie} from '$lib/vocab/tie/tie';
-	import Avatar from '$lib/ui/Avatar.svelte';
+	import PersonaAvatar from '$lib/ui/PersonaAvatar.svelte';
 	import {randomHue} from '$lib/ui/color';
-	import {toIcon, toName} from '$lib/vocab/entity/entityHelpers';
 	import {getApp} from '$lib/ui/app';
 	import PersonaContextmenu from '$lib/app/contextmenu/PersonaContextmenu.svelte';
 	import EntityContextmenu from '$lib/app/contextmenu/EntityContextmenu.svelte';
@@ -86,7 +85,7 @@ And then PersonaContextmenu would be only for *session* personas? `SessionPerson
 				{/if}
 			</div>
 			<div class="signature">
-				<Avatar name={toName($persona)} icon={toIcon($persona)} showName={false} />
+				<PersonaAvatar {persona} showName={false} />
 			</div>
 		</div>
 		{#if items && selected}

--- a/src/lib/ui/WorkspaceHeader.svelte
+++ b/src/lib/ui/WorkspaceHeader.svelte
@@ -22,9 +22,11 @@
 >
 	<li class="luggage-placeholder" />
 	<li class="breadcrumbs">
-		{#if community && $community}<CommunityAvatar {community} showName={false} /><span class="title"
-				>{$community.name}</span
-			>{/if}{#if space}<SpaceIcon {space} />
+		{#if community && $community}<CommunityAvatar
+				{community}
+				showName={false}
+				contextmenuAction={null}
+			/><span class="title">{$community.name}</span>{/if}{#if space}<SpaceIcon {space} />
 			<span class="title">{$space?.url.split('/').filter(Boolean).join(' / ') || ''}</span>{/if}
 	</li>
 	<li class="marquee-button-placeholder" />

--- a/src/lib/ui/WorkspaceHeader.svelte
+++ b/src/lib/ui/WorkspaceHeader.svelte
@@ -4,7 +4,7 @@
 	import type {Space} from '$lib/vocab/space/space';
 	import type {Community} from '$lib/vocab/community/community';
 	import {getApp} from '$lib/ui/app';
-	import Avatar from '$lib/ui/Avatar.svelte';
+	import CommunityAvatar from '$lib/ui/CommunityAvatar.svelte';
 	import SpaceIcon from '$lib/ui/SpaceIcon.svelte';
 
 	const {
@@ -22,11 +22,9 @@
 >
 	<li class="luggage-placeholder" />
 	<li class="breadcrumbs">
-		{#if community && $community}<Avatar
-				name={$community.name}
-				showName={false}
-				type="Community"
-			/><span class="title">{$community.name}</span>{/if}{#if space}<SpaceIcon {space} />
+		{#if community && $community}<CommunityAvatar {community} showName={false} /><span class="title"
+				>{$community.name}</span
+			>{/if}{#if space}<SpaceIcon {space} />
 			<span class="title">{$space?.url.split('/').filter(Boolean).join(' / ') || ''}</span>{/if}
 	</li>
 	<li class="marquee-button-placeholder" />

--- a/src/lib/ui/contextmenu/contextmenu.ts
+++ b/src/lib/ui/contextmenu/contextmenu.ts
@@ -168,7 +168,7 @@ const CONTEXTMENU_DOM_QUERY = `[data-${CONTEXTMENU_DATASET_KEY}],a`;
 const contextmenuCache = new Map<string, ContextmenuItems>();
 let cacheKeyCounter = 0;
 
-const contextmenuAction = (el: HTMLElement | SVGElement, params: ContextmenuItems | undefined) => {
+const contextmenuAction = (el: HTMLElement | SVGElement, params: ContextmenuItems | null) => {
 	if (!params) return;
 	const key = cacheKeyCounter++ + '';
 	el.dataset[CONTEXTMENU_DATASET_KEY] = key;


### PR DESCRIPTION
Changes some usage of the plain `Avatar` to `CommunityAvatar` and `PersonaAvatar`. The main reason besides concision is that the latter have contextmenu behavior automatically.

Also changes their API to make the contextmenu optional. In some cases the contextmenu is already added because of a parent entity. I'm not sure if these can be de-duplicated automatically -- it may require explicitly adding a group param. (type isn't enough; you may have an entity/persona/etc in the context of another entity, and want to display both)

Some usage of `Avatar` is more appropriate, like if a `community` or `persona` object isn't available, like the icon preview when creating a new community.