### PR TITLE
Add delete modal friction

### DIFF
--- a/src/lib/app/contextmenu/CommunityContextmenu.svelte
+++ b/src/lib/app/contextmenu/CommunityContextmenu.svelte
@@ -10,6 +10,7 @@
 	import SpaceInput from '$lib/ui/SpaceInput.svelte';
 	import MembershipInput from '$lib/ui/MembershipInput.svelte';
 	import CommunityEditor from '$lib/ui/CommunityEditor.svelte';
+	import CommunityDelete from '$lib/ui/CommunityDelete.svelte';
 
 	const {dispatch} = getApp();
 
@@ -51,7 +52,11 @@
 				<span class="title">Invite Members</span>
 			</ContextmenuEntry>
 			<ContextmenuEntry
-				action={() => dispatch.DeleteCommunity({community_id: $community.community_id})}
+				action={() =>
+					dispatch.OpenDialog({
+						Component: CommunityDelete,
+						props: {persona, community, done: () => dispatch.CloseDialog()},
+					})}
 			>
 				<span class="title">Delete Community</span>
 			</ContextmenuEntry>

--- a/src/lib/app/contextmenu/EntityContextmenu.svelte
+++ b/src/lib/app/contextmenu/EntityContextmenu.svelte
@@ -28,7 +28,7 @@
 		>
 			<span class="title">Edit Entity</span>
 		</ContextmenuEntry>
-		<ContextmenuEntry action={() => dispatch.SoftDeleteEntity({entity_id: $entity.entity_id})}>
+		<ContextmenuEntry action={() => dispatch.EraseEntity({entity_id: $entity.entity_id})}>
 			<span class="title">Delete Entity</span>
 		</ContextmenuEntry>
 	</svelte:fragment>

--- a/src/lib/app/eventTypes.ts
+++ b/src/lib/app/eventTypes.ts
@@ -37,7 +37,7 @@ export interface EventParamsByName {
 	UpdateEntity: UpdateEntityParams;
 	ReadEntities: ReadEntitiesParams;
 	QueryEntities: QueryEntitiesParams;
-	SoftDeleteEntity: SoftDeleteEntityParams;
+	EraseEntity: EraseEntityParams;
 	DeleteEntities: DeleteEntitiesParams;
 	CreateTie: CreateTieParams;
 	ReadTies: ReadTiesParams;
@@ -73,7 +73,7 @@ export interface EventResponseByName {
 	CreateEntity: CreateEntityResponse;
 	UpdateEntity: UpdateEntityResponse;
 	ReadEntities: ReadEntitiesResponse;
-	SoftDeleteEntity: SoftDeleteEntityResponse;
+	EraseEntity: EraseEntityResponse;
 	DeleteEntities: DeleteEntitiesResponse;
 	CreateTie: CreateTieResponse;
 	ReadTies: ReadTiesResponse;
@@ -253,11 +253,11 @@ export interface QueryEntitiesParams {
 	space_id: number;
 }
 
-export interface SoftDeleteEntityParams {
+export interface EraseEntityParams {
 	entity_id: number;
 }
-export type SoftDeleteEntityResponse = null;
-export type SoftDeleteEntityResponseResult = ApiResult<SoftDeleteEntityResponse>;
+export type EraseEntityResponse = null;
+export type EraseEntityResponseResult = ApiResult<EraseEntityResponse>;
 
 export interface DeleteEntitiesParams {
 	entity_ids: number[];
@@ -356,7 +356,7 @@ export interface Dispatch {
 	UpdateEntity: (params: UpdateEntityParams) => Promise<UpdateEntityResponseResult>;
 	ReadEntities: (params: ReadEntitiesParams) => Promise<ReadEntitiesResponseResult>;
 	QueryEntities: (params: QueryEntitiesParams) => Readable<Readable<Entity>[]>;
-	SoftDeleteEntity: (params: SoftDeleteEntityParams) => Promise<SoftDeleteEntityResponseResult>;
+	EraseEntity: (params: EraseEntityParams) => Promise<EraseEntityResponseResult>;
 	DeleteEntities: (params: DeleteEntitiesParams) => Promise<DeleteEntitiesResponseResult>;
 	CreateTie: (params: CreateTieParams) => Promise<CreateTieResponseResult>;
 	ReadTies: (params: ReadTiesParams) => Promise<ReadTiesResponseResult>;
@@ -432,9 +432,9 @@ export interface Mutations {
 		ctx: DispatchContext<ReadEntitiesParams, ReadEntitiesResponseResult>,
 	) => Promise<ReadEntitiesResponseResult>;
 	QueryEntities: (ctx: DispatchContext<QueryEntitiesParams, void>) => Readable<Readable<Entity>[]>;
-	SoftDeleteEntity: (
-		ctx: DispatchContext<SoftDeleteEntityParams, SoftDeleteEntityResponseResult>,
-	) => Promise<SoftDeleteEntityResponseResult>;
+	EraseEntity: (
+		ctx: DispatchContext<EraseEntityParams, EraseEntityResponseResult>,
+	) => Promise<EraseEntityResponseResult>;
 	DeleteEntities: (
 		ctx: DispatchContext<DeleteEntitiesParams, DeleteEntitiesResponseResult>,
 	) => Promise<DeleteEntitiesResponseResult>;

--- a/src/lib/app/events.ts
+++ b/src/lib/app/events.ts
@@ -21,7 +21,7 @@ import {
 	UpdateEntity,
 	ReadEntities,
 	QueryEntities,
-	SoftDeleteEntity,
+	EraseEntity,
 	DeleteEntities,
 } from '$lib/vocab/entity/entityEvents';
 import {CreateTie, ReadTies, DeleteTie} from '$lib/vocab/tie/tieEvents';
@@ -65,7 +65,7 @@ export const eventInfos: EventInfo[] = [
 	UpdateEntity,
 	ReadEntities,
 	QueryEntities,
-	SoftDeleteEntity,
+	EraseEntity,
 	DeleteEntities,
 	// tieEvents
 	CreateTie,

--- a/src/lib/app/mutations.ts
+++ b/src/lib/app/mutations.ts
@@ -11,7 +11,7 @@ import {CreateMembership, DeleteMembership} from '$lib/vocab/membership/membersh
 import {
 	CreateEntity,
 	UpdateEntity,
-	SoftDeleteEntity,
+	EraseEntity,
 	DeleteEntities,
 	ReadEntities,
 	QueryEntities,
@@ -50,7 +50,7 @@ export const mutations: Record<string, Mutation> = {
 	// entityMutations
 	CreateEntity,
 	UpdateEntity,
-	SoftDeleteEntity,
+	EraseEntity,
 	DeleteEntities,
 	ReadEntities,
 	QueryEntities,

--- a/src/lib/server/random.ts
+++ b/src/lib/server/random.ts
@@ -121,7 +121,7 @@ export const randomEventParams = async (
 				data: randomEntityData(),
 			};
 		}
-		case 'SoftDeleteEntity': {
+		case 'EraseEntity': {
 			return {
 				entity_id: (await random.entity(persona, account, community, space)).entity.entity_id,
 			};

--- a/src/lib/server/services.ts
+++ b/src/lib/server/services.ts
@@ -17,7 +17,7 @@ import {
 	readEntitiesService,
 	createEntityService,
 	updateEntityService,
-	softDeleteEntityService,
+	eraseEntityService,
 	deleteEntitiesService,
 } from '$lib/vocab/entity/entityServices';
 import {
@@ -42,7 +42,7 @@ export const services: Map<string, Service<any, any>> = new Map(
 		createSpaceService,
 		createEntityService,
 		updateEntityService,
-		softDeleteEntityService,
+		eraseEntityService,
 		deleteEntitiesService,
 		readCommunityService,
 		readCommunitiesService,

--- a/src/lib/ui/CommunityDelete.svelte
+++ b/src/lib/ui/CommunityDelete.svelte
@@ -7,6 +7,7 @@
 	import CommunityAvatar from '$lib/ui/CommunityAvatar.svelte';
 	import type {Community} from '$lib/vocab/community/community';
 	import type {Persona} from '$lib/vocab/persona/persona';
+	import PendingButton from '@feltcoop/felt/ui/PendingButton.svelte';
 
 	const {dispatch} = getApp();
 
@@ -15,10 +16,12 @@
 	export let done: (() => void) | undefined = undefined;
 
 	let errorMessage: string | undefined;
+	let pending = false;
 	let lockText = '';
 	$: locked = lockText.toLowerCase().trim() !== $community.name.toLowerCase();
 
 	const deleteCommunity = async () => {
+		pending = true;
 		errorMessage = '';
 		const result = await dispatch.DeleteCommunity({
 			community_id: $community.community_id,
@@ -28,6 +31,7 @@
 		} else {
 			errorMessage = result.message;
 		}
+		pending = false;
 	};
 
 	const onKeydown = async (e: KeyboardEvent) => {
@@ -59,8 +63,8 @@
 			placeholder=">enter name to unlock button"
 			bind:value={lockText}
 		/>
-		<button disabled={locked} type="button" on:click={deleteCommunity} on:keydown={onKeydown}>
+		<PendingButton {pending} disabled={locked || pending} on:click={deleteCommunity}>
 			Delete space
-		</button>
+		</PendingButton>>
 	</form>
 </div>

--- a/src/lib/ui/CommunityDelete.svelte
+++ b/src/lib/ui/CommunityDelete.svelte
@@ -33,13 +33,6 @@
 		}
 		pending = false;
 	};
-
-	const onKeydown = async (e: KeyboardEvent) => {
-		if (!locked && e.key === 'Enter') {
-			e.preventDefault();
-			await deleteCommunity();
-		}
-	};
 </script>
 
 <div class="markup">

--- a/src/lib/ui/CommunityDelete.svelte
+++ b/src/lib/ui/CommunityDelete.svelte
@@ -33,6 +33,13 @@
 		}
 		pending = false;
 	};
+
+	const onKeydown = async (e: KeyboardEvent) => {
+		if (!locked && e.key === 'Enter') {
+			e.preventDefault();
+			await deleteCommunity();
+		}
+	};
 </script>
 
 <div class="markup">
@@ -55,6 +62,7 @@
 			name="name"
 			placeholder=">enter name to unlock button"
 			bind:value={lockText}
+			on:keydown={onKeydown}
 		/>
 		<PendingButton {pending} disabled={locked || pending} on:click={deleteCommunity}>
 			Delete space

--- a/src/lib/ui/CommunityDelete.svelte
+++ b/src/lib/ui/CommunityDelete.svelte
@@ -15,8 +15,8 @@
 	export let done: (() => void) | undefined = undefined;
 
 	let errorMessage: string | undefined;
-	let locked = true;
 	let lockText = '';
+	$: locked = lockText.toLowerCase().trim() !== $community.name.toLowerCase();
 
 	const deleteCommunity = async () => {
 		errorMessage = '';
@@ -35,10 +35,6 @@
 			e.preventDefault();
 			await deleteCommunity();
 		}
-	};
-
-	const checkLocked = async () => {
-		lockText === $community.name ? (locked = false) : (locked = true);
 	};
 </script>
 
@@ -61,7 +57,6 @@
 			id="name"
 			name="name"
 			placeholder=">enter name to unlock button"
-			on:input={checkLocked}
 			bind:value={lockText}
 		/>
 		<button disabled={locked} type="button" on:click={deleteCommunity} on:keydown={onKeydown}>

--- a/src/lib/ui/CommunityDelete.svelte
+++ b/src/lib/ui/CommunityDelete.svelte
@@ -31,7 +31,7 @@
 	};
 
 	const onKeydown = async (e: KeyboardEvent) => {
-		if (e.key === 'Enter') {
+		if (!locked && e.key === 'Enter') {
 			e.preventDefault();
 			await deleteCommunity();
 		}

--- a/src/lib/ui/CommunityDelete.svelte
+++ b/src/lib/ui/CommunityDelete.svelte
@@ -3,8 +3,6 @@
 	import Message from '@feltcoop/felt/ui/Message.svelte';
 
 	import {getApp} from '$lib/ui/app';
-	import type {Space} from '$lib/vocab/space/space';
-	import SpaceName from '$lib/ui/SpaceName.svelte';
 	import PersonaAvatar from '$lib/ui/PersonaAvatar.svelte';
 	import CommunityAvatar from '$lib/ui/CommunityAvatar.svelte';
 	import type {Community} from '$lib/vocab/community/community';
@@ -12,7 +10,6 @@
 
 	const {dispatch} = getApp();
 
-	export let space: Readable<Space>;
 	export let community: Readable<Community>;
 	export let persona: Readable<Persona>;
 	export let done: (() => void) | undefined = undefined;
@@ -21,10 +18,10 @@
 	let locked = true;
 	let lockText = '';
 
-	const deleteSpace = async () => {
+	const deleteCommunity = async () => {
 		errorMessage = '';
-		const result = await dispatch.DeleteSpace({
-			space_id: $space.space_id,
+		const result = await dispatch.DeleteCommunity({
+			community_id: $community.community_id,
 		});
 		if (result.ok) {
 			done?.();
@@ -36,20 +33,17 @@
 	const onKeydown = async (e: KeyboardEvent) => {
 		if (e.key === 'Enter') {
 			e.preventDefault();
-			await deleteSpace();
+			await deleteCommunity();
 		}
 	};
 
 	const checkLocked = async () => {
-		lockText === $space.name ? (locked = false) : (locked = true);
+		lockText === $community.name ? (locked = false) : (locked = true);
 	};
 </script>
 
 <div class="markup">
-	<h1>Delete Space?</h1>
-	<section class="row" style:font-size="var(--font_size_xl)">
-		<SpaceName {space} />
-	</section>
+	<h1>Delete Community?</h1>
 	<section class="row">
 		<span class="spaced">in</span>
 		<CommunityAvatar {community} />
@@ -70,7 +64,7 @@
 			on:input={checkLocked}
 			bind:value={lockText}
 		/>
-		<button disabled={locked} type="button" on:click={deleteSpace} on:keydown={onKeydown}>
+		<button disabled={locked} type="button" on:click={deleteCommunity} on:keydown={onKeydown}>
 			Delete space
 		</button>
 	</form>

--- a/src/lib/ui/SpaceDelete.svelte
+++ b/src/lib/ui/SpaceDelete.svelte
@@ -9,6 +9,7 @@
 	import CommunityAvatar from '$lib/ui/CommunityAvatar.svelte';
 	import type {Community} from '$lib/vocab/community/community';
 	import type {Persona} from '$lib/vocab/persona/persona';
+	import PendingButton from '@feltcoop/felt/ui/PendingButton.svelte';
 
 	const {dispatch} = getApp();
 
@@ -16,12 +17,14 @@
 	export let community: Readable<Community>;
 	export let persona: Readable<Persona>;
 	export let done: (() => void) | undefined = undefined;
+	export let pending = false;
 
 	let errorMessage: string | undefined;
 	let lockText = '';
 	$: locked = lockText.toLowerCase().trim() !== $space.name.toLowerCase();
 
 	const deleteSpace = async () => {
+		pending = true;
 		errorMessage = '';
 		const result = await dispatch.DeleteSpace({
 			space_id: $space.space_id,
@@ -31,13 +34,7 @@
 		} else {
 			errorMessage = result.message;
 		}
-	};
-
-	const onKeydown = async (e: KeyboardEvent) => {
-		if (!locked && e.key === 'Enter') {
-			e.preventDefault();
-			await deleteSpace();
-		}
+		pending = false;
 	};
 </script>
 
@@ -65,8 +62,9 @@
 			placeholder=">enter name to unlock button"
 			bind:value={lockText}
 		/>
-		<button disabled={locked} type="button" on:click={deleteSpace} on:keydown={onKeydown}>
+
+		<PendingButton {pending} disabled={locked || pending} on:click={deleteSpace}>
 			Delete space
-		</button>
+		</PendingButton>
 	</form>
 </div>

--- a/src/lib/ui/SpaceDelete.svelte
+++ b/src/lib/ui/SpaceDelete.svelte
@@ -36,6 +36,13 @@
 		}
 		pending = false;
 	};
+
+	const onKeydown = async (e: KeyboardEvent) => {
+		if (!locked && e.key === 'Enter') {
+			e.preventDefault();
+			await deleteSpace();
+		}
+	};
 </script>
 
 <div class="markup">
@@ -61,6 +68,7 @@
 			name="name"
 			placeholder=">enter name to unlock button"
 			bind:value={lockText}
+			on:keydown={onKeydown}
 		/>
 
 		<PendingButton {pending} disabled={locked || pending} on:click={deleteSpace}>

--- a/src/lib/ui/SpaceDelete.svelte
+++ b/src/lib/ui/SpaceDelete.svelte
@@ -18,8 +18,8 @@
 	export let done: (() => void) | undefined = undefined;
 
 	let errorMessage: string | undefined;
-	let locked = true;
 	let lockText = '';
+	$: locked = lockText.toLowerCase().trim() !== $space.name.toLowerCase();
 
 	const deleteSpace = async () => {
 		errorMessage = '';
@@ -38,10 +38,6 @@
 			e.preventDefault();
 			await deleteSpace();
 		}
-	};
-
-	const checkLocked = async () => {
-		lockText === $space.name ? (locked = false) : (locked = true);
 	};
 </script>
 
@@ -67,7 +63,6 @@
 			id="name"
 			name="name"
 			placeholder=">enter name to unlock button"
-			on:input={checkLocked}
 			bind:value={lockText}
 		/>
 		<button disabled={locked} type="button" on:click={deleteSpace} on:keydown={onKeydown}>

--- a/src/lib/ui/SpaceDelete.svelte
+++ b/src/lib/ui/SpaceDelete.svelte
@@ -34,7 +34,7 @@
 	};
 
 	const onKeydown = async (e: KeyboardEvent) => {
-		if (e.key === 'Enter') {
+		if (!locked && e.key === 'Enter') {
 			e.preventDefault();
 			await deleteSpace();
 		}

--- a/src/lib/vocab/entity/EntityRepo.ts
+++ b/src/lib/vocab/entity/EntityRepo.ts
@@ -70,8 +70,8 @@ export class EntityRepo extends PostgresRepo {
 		return {ok: true, value: result[0]};
 	}
 
-	//This function is a idempotent soft delete, that leaves behind a Tombstone entity per Activity-Streams spec
-	async softDeleteById(entity_id: number): Promise<Result<object>> {
+	//This function is an idempotent soft delete, that leaves behind a Tombstone entity per Activity-Streams spec
+	async eraseById(entity_id: number): Promise<Result<object>> {
 		log.trace('[deleteById]', entity_id);
 		const data = await this.db.sql<any[]>`
 			UPDATE entities

--- a/src/lib/vocab/entity/entityEvents.ts
+++ b/src/lib/vocab/entity/entityEvents.ts
@@ -112,12 +112,12 @@ export const QueryEntities: ClientEventInfo = {
 	returns: 'Readable<Readable<Entity>[]>',
 };
 
-export const SoftDeleteEntity: ServiceEventInfo = {
+export const EraseEntity: ServiceEventInfo = {
 	type: 'ServiceEvent',
-	name: 'SoftDeleteEntity',
+	name: 'EraseEntity',
 	broadcast: true,
 	params: {
-		$id: '/schemas/SoftDeleteEntityParams.json',
+		$id: '/schemas/EraseEntityParams.json',
 		type: 'object',
 		properties: {
 			entity_id: {type: 'number'},
@@ -126,12 +126,12 @@ export const SoftDeleteEntity: ServiceEventInfo = {
 		additionalProperties: false,
 	},
 	response: {
-		$id: '/schemas/SoftDeleteEntityResponse.json',
+		$id: '/schemas/EraseEntityResponse.json',
 		type: 'null',
 	},
-	returns: 'Promise<SoftDeleteEntityResponseResult>',
+	returns: 'Promise<EraseEntityResponseResult>',
 	route: {
-		path: '/api/v1/entities/:entity_id/soft',
+		path: '/api/v1/entities/:entity_id/erase',
 		method: 'DELETE',
 	},
 };

--- a/src/lib/vocab/entity/entityMutations.ts
+++ b/src/lib/vocab/entity/entityMutations.ts
@@ -28,7 +28,7 @@ export const UpdateEntity: Mutations['UpdateEntity'] = async ({invoke, ui: {enti
 	return result;
 };
 
-export const SoftDeleteEntity: Mutations['SoftDeleteEntity'] = async ({invoke}) => {
+export const EraseEntity: Mutations['EraseEntity'] = async ({invoke}) => {
 	const result = await invoke();
 	if (!result.ok) return result;
 	//update state here

--- a/src/lib/vocab/entity/entityServices.ts
+++ b/src/lib/vocab/entity/entityServices.ts
@@ -6,8 +6,8 @@ import type {
 	ReadEntitiesResponseResult,
 	UpdateEntityParams,
 	UpdateEntityResponseResult,
-	SoftDeleteEntityParams,
-	SoftDeleteEntityResponseResult,
+	EraseEntityParams,
+	EraseEntityResponseResult,
 	DeleteEntitiesParams,
 	DeleteEntitiesResponseResult,
 } from '$lib/app/eventTypes';
@@ -15,7 +15,7 @@ import {
 	ReadEntities,
 	UpdateEntity,
 	CreateEntity,
-	SoftDeleteEntity,
+	EraseEntity,
 	DeleteEntities,
 } from '$lib/vocab/entity/entityEvents';
 
@@ -93,13 +93,10 @@ export const updateEntityService: Service<UpdateEntityParams, UpdateEntityRespon
 };
 
 //soft deletes a single entity, leaving behind a Tombstone entity
-export const softDeleteEntityService: Service<
-	SoftDeleteEntityParams,
-	SoftDeleteEntityResponseResult
-> = {
-	event: SoftDeleteEntity,
+export const eraseEntityService: Service<EraseEntityParams, EraseEntityResponseResult> = {
+	event: EraseEntity,
 	perform: async ({repos, params}) => {
-		const result = await repos.entity.softDeleteById(params.entity_id);
+		const result = await repos.entity.eraseById(params.entity_id);
 		if (!result.ok) {
 			return {ok: false, status: 500, message: 'failed to soft delete entity'};
 		}


### PR DESCRIPTION
This PR adds some friction to the existing SpaceDelete modal, as well as adding one for CommunityDelete too.

Since Entities are a little more lightweight, I didn't add one there. I did rename the SoftDelete endpoint to match our Delete::Erase nomenclature though.

1 note: I'm not 100% sure on the input check logic in the modals. It doesn't seem to immediately parse the name, so I may have chosen the wrong event?