### PR TITLE
add tie entity ids helper

### DIFF
--- a/src/lib/vocab/entity/entityServices.test.ts
+++ b/src/lib/vocab/entity/entityServices.test.ts
@@ -1,14 +1,13 @@
 import {suite} from 'uvu';
 import * as assert from 'uvu/assert';
+import {unwrap} from '@feltcoop/felt';
 
 import {setupDb, teardownDb, type TestDbContext} from '$lib/util/testDbHelpers';
 import type {TestAppContext} from '$lib/util/testAppHelpers';
 import type {NoteEntityData} from '$lib/vocab/entity/entityData';
 import {toServiceRequest} from '$lib/util/testHelpers';
-
 import {ReadEntitiesPaginatedService} from '$lib/vocab/entity/entityServices';
-import {unwrap} from '@feltcoop/felt';
-import type {Entity} from './entity';
+import type {Entity} from '$lib/vocab/entity/entity';
 import {DEFAULT_PAGE_SIZE} from '$lib/server/constants';
 import {validateSchema} from '$lib/util/ajv';
 

--- a/src/lib/vocab/entity/entityServices.ts
+++ b/src/lib/vocab/entity/entityServices.ts
@@ -21,7 +21,7 @@ import {
 	EraseEntity,
 	DeleteEntities,
 } from '$lib/vocab/entity/entityEvents';
-import {toTieEntityIds} from '../tie/tieHelpers';
+import {toTieEntityIds} from '$lib/vocab/tie/tieHelpers';
 
 // TODO rename to `getEntities`? `loadEntities`?
 export const readEntitiesService: Service<ReadEntitiesParams, ReadEntitiesResponseResult> = {

--- a/src/lib/vocab/entity/entityServices.ts
+++ b/src/lib/vocab/entity/entityServices.ts
@@ -21,6 +21,7 @@ import {
 	EraseEntity,
 	DeleteEntities,
 } from '$lib/vocab/entity/entityEvents';
+import {toTieEntityIds} from '../tie/tieHelpers';
 
 // TODO rename to `getEntities`? `loadEntities`?
 export const readEntitiesService: Service<ReadEntitiesParams, ReadEntitiesResponseResult> = {
@@ -38,11 +39,7 @@ export const readEntitiesService: Service<ReadEntitiesParams, ReadEntitiesRespon
 		}
 		//TODO stop filtering directory until we fix entity indexing by space_id
 		const entityIds = Array.from(
-			new Set(
-				findTiesResult.value.flatMap((t) =>
-					[t.source_id, t.dest_id].filter((x) => x !== findSpaceResult.value.directory_id),
-				),
-			),
+			toTieEntityIds(findTiesResult.value, (id) => id !== findSpaceResult.value.directory_id),
 		);
 		const findEntitiesResult = await repos.entity.findByIds(entityIds);
 		if (!findEntitiesResult.ok) {
@@ -72,11 +69,7 @@ export const ReadEntitiesPaginatedService: Service<
 		}
 		//TODO stop filtering directory until we fix entity indexing by space_id
 		const entityIds = Array.from(
-			new Set(
-				findTiesResult.value.flatMap((t) =>
-					[t.source_id, t.dest_id].filter((x) => x !== params.source_id),
-				),
-			),
+			toTieEntityIds(findTiesResult.value, (id) => id !== params.source_id),
 		);
 		const findEntitiesResult = await repos.entity.findByIds(entityIds);
 		if (!findEntitiesResult.ok) {

--- a/src/lib/vocab/entity/entityServices.ts
+++ b/src/lib/vocab/entity/entityServices.ts
@@ -38,10 +38,9 @@ export const readEntitiesService: Service<ReadEntitiesParams, ReadEntitiesRespon
 			return {ok: false, status: 500, message: 'error searching space directory'};
 		}
 		//TODO stop filtering directory until we fix entity indexing by space_id
-		const entityIds = Array.from(
-			toTieEntityIds(findTiesResult.value, (id) => id !== findSpaceResult.value.directory_id),
-		);
-		const findEntitiesResult = await repos.entity.findByIds(entityIds);
+		const entityIds = toTieEntityIds(findTiesResult.value);
+		entityIds.delete(findSpaceResult.value.directory_id);
+		const findEntitiesResult = await repos.entity.findByIds(Array.from(entityIds));
 		if (!findEntitiesResult.ok) {
 			return {ok: false, status: 500, message: 'error searching for entities'};
 		}
@@ -68,10 +67,9 @@ export const ReadEntitiesPaginatedService: Service<
 			return {ok: false, status: 500, message: 'error searching directory'};
 		}
 		//TODO stop filtering directory until we fix entity indexing by space_id
-		const entityIds = Array.from(
-			toTieEntityIds(findTiesResult.value, (id) => id !== params.source_id),
-		);
-		const findEntitiesResult = await repos.entity.findByIds(entityIds);
+		const entityIds = toTieEntityIds(findTiesResult.value);
+		entityIds.delete(params.source_id);
+		const findEntitiesResult = await repos.entity.findByIds(Array.from(entityIds));
 		if (!findEntitiesResult.ok) {
 			return {ok: false, status: 500, message: 'error searching for entities'};
 		}

--- a/src/lib/vocab/tie/tieHelpers.ts
+++ b/src/lib/vocab/tie/tieHelpers.ts
@@ -1,0 +1,13 @@
+import type {Tie} from './tie';
+
+export const toTieEntityIds = (
+	ties: Tie[],
+	filter?: (entity_id: number) => boolean,
+): Set<number> => {
+	const ids = new Set<number>();
+	for (const {source_id, dest_id} of ties) {
+		if (!filter || filter(source_id)) ids.add(source_id);
+		if (!filter || filter(dest_id)) ids.add(dest_id);
+	}
+	return ids;
+};

--- a/src/lib/vocab/tie/tieHelpers.ts
+++ b/src/lib/vocab/tie/tieHelpers.ts
@@ -1,13 +1,10 @@
 import type {Tie} from './tie';
 
-export const toTieEntityIds = (
-	ties: Tie[],
-	filter?: (entity_id: number) => boolean,
-): Set<number> => {
+export const toTieEntityIds = (ties: Tie[]): Set<number> => {
 	const ids = new Set<number>();
 	for (const {source_id, dest_id} of ties) {
-		if (!filter || filter(source_id)) ids.add(source_id);
-		if (!filter || filter(dest_id)) ids.add(dest_id);
+		ids.add(source_id);
+		ids.add(dest_id);
 	}
 	return ids;
 };

--- a/src/lib/vocab/tie/tieHelpers.ts
+++ b/src/lib/vocab/tie/tieHelpers.ts
@@ -1,4 +1,4 @@
-import type {Tie} from './tie';
+import type {Tie} from '$lib/vocab/tie/tie';
 
 export const toTieEntityIds = (ties: Tie[]): Set<number> => {
 	const ids = new Set<number>();


### PR DESCRIPTION
Adds a helper for extracting unique ids from ties. Even if the code that uses it is temporary, I thought it was worthwhile, but I'm alright with closing this issue and not merging. This helper and pattern does a lot less work than the previous version.