### PR TITLE
improve contextmenu link styling

### DIFF
--- a/src/lib/app/contextmenu/LinkContextmenu.svelte
+++ b/src/lib/app/contextmenu/LinkContextmenu.svelte
@@ -8,19 +8,23 @@
 	// TODO refactor this after upgrading SvelteKit to where `$page` has `url`
 	// TODO move or upstream? rename? `printUrl`
 	const formatUrl = (url: string): string => {
-		const formatted = stripStart(stripStart(url, 'https://'), 'http://'); // TODO probably leave http but not locally
+		const formatted = stripStart(stripStart(url, 'https://'), 'http://');
 		return formatted.startsWith($page.url.host + '/')
 			? stripStart(formatted, $page.url.host)
 			: formatted;
 	};
+
+	$: text = formatUrl(href);
+	$: external = !(text.startsWith('.') || text.startsWith('/'));
+	$: rel = external ? 'noreferrer' : undefined;
 </script>
 
+<!-- TODO this doesn't work with the keyboard controls, need to use `menuitem` -->
 <!-- TODO could do more if we had the original `target` element (but it might go stale on $contextmenu?) -->
-<!-- TODO if it's an external link, add `target="_blank" rel="noreferrer"` -->
 <li role="none">
-	<a {href}>
+	<a {href} {rel}>
 		<UnicodeIcon icon="🔗" />
-		<span class="text">{formatUrl(href)}</span>
+		<span class="text">{text}</span>
 	</a>
 </li>
 
@@ -29,11 +33,18 @@
 		display: flex;
 		align-items: center;
 		width: 100%;
-		padding: var(--spacing_sm);
+	}
+	a:hover {
+		text-decoration: none;
+	}
+	a:hover .text {
+		text-decoration: underline;
 	}
 	.text {
-		padding-left: var(--spacing_sm);
+		padding: 0 var(--spacing_sm);
 		overflow: hidden;
 		overflow-wrap: break-word;
+		text-overflow: ellipsis;
+		white-space: nowrap;
 	}
 </style>

--- a/src/lib/app/contextmenu/LinkContextmenu.svelte
+++ b/src/lib/app/contextmenu/LinkContextmenu.svelte
@@ -43,7 +43,6 @@
 	.text {
 		padding: 0 var(--spacing_sm);
 		overflow: hidden;
-		overflow-wrap: break-word;
 		text-overflow: ellipsis;
 		white-space: nowrap;
 	}

--- a/src/lib/ui/UnicodeIcon.svelte
+++ b/src/lib/ui/UnicodeIcon.svelte
@@ -3,13 +3,14 @@
 	export let label: string | undefined = undefined;
 </script>
 
-<span aria-label={label}>{icon}</span>
+<div aria-label={label}>{icon}</div>
 
 <style>
-	span {
+	div {
 		display: flex;
 		align-items: center;
 		justify-content: center;
+		flex-shrink: 0;
 		width: var(--icon_size);
 		height: var(--icon_size);
 	}

--- a/src/lib/ui/contextmenu/contextmenu.ts
+++ b/src/lib/ui/contextmenu/contextmenu.ts
@@ -193,7 +193,7 @@ export const onContextmenu = (
 	contextmenu: ContextmenuStore,
 	excludeEl?: HTMLElement,
 	LinkContextmenu?: typeof SvelteComponent,
-): undefined | false => {
+): void => {
 	if (e.shiftKey) return;
 	e.stopPropagation();
 	e.preventDefault();
@@ -202,7 +202,6 @@ export const onContextmenu = (
 	if (!items || isEditable(target) || excludeEl?.contains(target)) return;
 	// TODO dispatch a UI event, like OpenContextmenu
 	contextmenu.open(items, e.clientX, e.clientY);
-	return false; // TODO remove this if it doesn't fix FF mobile (and update the `false` return value)
 };
 
 const queryContextmenuItems = (


### PR DESCRIPTION
Tweaks the contextmenu styling for links to look like the other menu entries.

Also removes a hack for Firefox Mobile that appears unnecessary.