### PR TITLE
use a menuitem instead of button for logout on contextmenu

### DIFF
--- a/src/lib/app/contextmenu/AppContextmenu.svelte
+++ b/src/lib/app/contextmenu/AppContextmenu.svelte
@@ -8,7 +8,6 @@
 	import UnicodeIcon from '$lib/ui/UnicodeIcon.svelte';
 	import About from '$lib/ui/About.svelte';
 	import {session} from '$app/stores';
-	import AccountForm from '$lib/ui/AccountForm.svelte';
 	import PersonaAvatar from '$lib/ui/PersonaAvatar.svelte';
 
 	const {
@@ -56,11 +55,9 @@
 			<span class="title">About</span>
 		</ContextmenuEntry>
 		{#if !$session.guest}
-			<li role="none">
-				<div>
-					<AccountForm guest={false} />
-				</div>
-			</li>
+			<ContextmenuEntry action={() => dispatch.LogoutAccount()}>
+				<span class="title">Log out</span>
+			</ContextmenuEntry>
 		{/if}
 	</svelte:fragment>
 </ContextmenuSubmenu>


### PR DESCRIPTION
Changes `Log out` to be a regular menuitem on the contextmenu instead of a button.

I looked into keeping this a `PendingButton`, but the contextmenu currently doesn't handle async actions. As soon as an item is activated, it closes the contextmenu. It seems likely we'll want to support async actions -- I'm going to look at that next, so this PR may be obsolete if that works out. The downside of this PR is that you don't see a spinner, and failure is silent.

Using a button in the contextmenu also gets tricky with styling -- it may be that the `LogoutForm` isn't appropriate here, and we need a separate `LogoutButton`. It may be that *all* contextmenu items should be buttons. In that case, any styling hacks we do now wouldn't be used later, so I think it's best to just punt.