### PR TITLE
fix create space redirect

### DIFF
--- a/src/lib/ui/SpaceInput.svelte
+++ b/src/lib/ui/SpaceInput.svelte
@@ -66,7 +66,7 @@
 		if (result.ok) {
 			errorMessage = null;
 			name = '';
-			void goto(
+			await goto(
 				toSpaceUrl($community, result.value.space, $page.url.searchParams, {
 					persona: sessionPersonaIndices.get().get(personaById.get($persona.persona_id)!) + '',
 				}),

--- a/src/lib/ui/SpaceInput.svelte
+++ b/src/lib/ui/SpaceInput.svelte
@@ -2,6 +2,8 @@
 	import type {Readable} from '@feltcoop/svelte-gettable-stores';
 	import PendingButton from '@feltcoop/felt/ui/PendingButton.svelte';
 	import Message from '@feltcoop/felt/ui/Message.svelte';
+	import {goto} from '$app/navigation';
+	import {page} from '$app/stores';
 
 	import type {Community} from '$lib/vocab/community/community.js';
 	import {autofocus} from '$lib/ui/actions';
@@ -11,11 +13,15 @@
 	import CommunityAvatar from '$lib/ui/CommunityAvatar.svelte';
 	import type {Persona} from '$lib/vocab/persona/persona';
 	import {parseSpaceIcon} from '$lib/vocab/space/spaceHelpers';
+	import {toSpaceUrl} from '$lib/ui/url';
 
 	// TODO does this belong in `view`?
 	const creatableViewTemplates = viewTemplates.filter((v) => v.creatable !== false);
 
-	const {dispatch} = getApp();
+	const {
+		dispatch,
+		ui: {sessionPersonaIndices, personaById},
+	} = getApp();
 
 	export let persona: Readable<Persona>;
 	export let community: Readable<Community>;
@@ -48,13 +54,11 @@
 		if (pending) return;
 		pending = true;
 		errorMessage = null;
-		//Needs to collect url(i.e. name for now), type (currently default application/json), & content (hardcoded JSON struct)
-		const url = `/${name}`;
 		const result = await dispatch.CreateSpace({
 			persona_id: $persona.persona_id,
 			community_id: $community.community_id,
 			name,
-			url,
+			url: `/${name}`,
 			icon: iconResult.value,
 			view: selectedViewTemplate.view,
 		});
@@ -62,6 +66,11 @@
 		if (result.ok) {
 			errorMessage = null;
 			name = '';
+			void goto(
+				toSpaceUrl($community, result.value.space, $page.url.searchParams, {
+					persona: sessionPersonaIndices.get().get(personaById.get($persona.persona_id)!) + '',
+				}),
+			);
 			done?.();
 		} else {
 			errorMessage = result.message;

--- a/src/lib/ui/SpaceInput.svelte
+++ b/src/lib/ui/SpaceInput.svelte
@@ -20,7 +20,7 @@
 
 	const {
 		dispatch,
-		ui: {sessionPersonaIndices, personaById},
+		ui: {sessionPersonaIndices},
 	} = getApp();
 
 	export let persona: Readable<Persona>;
@@ -68,7 +68,7 @@
 			name = '';
 			await goto(
 				toSpaceUrl($community, result.value.space, $page.url.searchParams, {
-					persona: sessionPersonaIndices.get().get(personaById.get($persona.persona_id)!) + '',
+					persona: sessionPersonaIndices.get().get(persona) + '',
 				}),
 			);
 			done?.();

--- a/src/lib/ui/SpaceInput.svelte
+++ b/src/lib/ui/SpaceInput.svelte
@@ -68,7 +68,7 @@
 			name = '';
 			await goto(
 				toSpaceUrl($community, result.value.space, $page.url.searchParams, {
-					persona: sessionPersonaIndices.get().get(persona) + '',
+					persona: $sessionPersonaIndices.get(persona) + '',
 				}),
 			);
 			done?.();

--- a/src/lib/vocab/space/spaceMutations.ts
+++ b/src/lib/vocab/space/spaceMutations.ts
@@ -1,30 +1,16 @@
 import {writable} from '@feltcoop/svelte-gettable-stores';
-import {get} from 'svelte/store';
 import {goto} from '$app/navigation';
-import {page} from '$app/stores';
 
 import type {Mutations} from '$lib/app/eventTypes';
 import {isHomeSpace} from '$lib/vocab/space/spaceHelpers';
-import {toSpaceUrl} from '$lib/ui/url';
 
-export const CreateSpace: Mutations['CreateSpace'] = async ({
-	invoke,
-	params,
-	ui: {spaceById, spaces, communityById, sessionPersonaIndices, personaById},
-}) => {
+export const CreateSpace: Mutations['CreateSpace'] = async ({invoke, ui: {spaceById, spaces}}) => {
 	const result = await invoke();
 	if (!result.ok) return result;
 	const {space: $space} = result.value;
 	const space = writable($space);
-	const community = communityById.get($space.community_id)!;
-	const $community = community.get();
 	spaceById.set($space.space_id, space);
 	spaces.mutate(($spaces) => $spaces.push(space));
-	await goto(
-		toSpaceUrl($community, $space, get(page).url.searchParams, {
-			persona: sessionPersonaIndices.get().get(personaById.get(params.persona_id)!) + '',
-		}),
-	);
 	return result;
 };
 


### PR DESCRIPTION
Currently we do a URL redirect in the `CreateSpace` mutation to go to the newly created space, but there's two problems with it:

- it errors and doesn't work (it's not worth checking but I'm fairly certain a recent SvelteKit upgrade broke it -- the problem is `page` from `'$app/stores'` uses `getContext` under the hood which can only be called during component initialization)
- it's not the right UX because `CreateSpace` events may be broadcasted -- you don't want someone else making a space to change your location!

I think it makes sense to generally put redirects in the components, so this moves it and I looked at others. There's at least 2 more instances of this that may be broken and/or the wrong UX. I'll look at those in a followup.