### PR TITLE
extract websocket component

### DIFF
--- a/src/lib/ui/Marquee.svelte
+++ b/src/lib/ui/Marquee.svelte
@@ -7,7 +7,7 @@
 	import MarqueeNav from '$lib/ui/MarqueeNav.svelte';
 	import SpaceEditor from '$lib/ui/SpaceEditor.svelte';
 	import {getApp} from '$lib/ui/app';
-	import SocketConnection from '$lib/ui/SocketConnection.svelte';
+	import SocketConnectionControls from '$lib/ui/SocketConnectionControls.svelte';
 
 	const {
 		dispatch,
@@ -48,7 +48,7 @@
 			</section>
 		{/if}
 		<section>
-			<SocketConnection {socket} />
+			<SocketConnectionControls {socket} />
 		</section>
 	{/if}
 {/if}

--- a/src/lib/ui/SocketConnection.svelte
+++ b/src/lib/ui/SocketConnection.svelte
@@ -1,32 +1,25 @@
 <script lang="ts">
-	import {onMount} from 'svelte';
+	import {onDestroy} from 'svelte';
 	import {session} from '$app/stores';
+	import {browser} from '$app/env';
 
 	import type {SocketStore} from '$lib/ui/socket';
 
 	export let socket: SocketStore;
 	export let url: string;
 
-	$: guest = $session.guest;
+	$: ({guest} = $session);
 
-	let mounted = false;
-
-	onMount(() => {
-		mounted = true;
-		return () => {
-			socket.disconnect();
-		};
+	onDestroy(() => {
+		socket.disconnect();
 	});
 
 	// Keep the socket connected when logged in, and disconnect when logged out.
-	$: if (mounted) {
-		console.log(':CONNECTING');
+	$: if (browser) {
 		if (guest) {
 			socket.disconnect();
 		} else {
 			socket.connect(url);
 		}
-	} else {
-		console.log('NOT YET MOUNTED');
 	}
 </script>

--- a/src/lib/ui/SocketConnection.svelte
+++ b/src/lib/ui/SocketConnection.svelte
@@ -1,16 +1,32 @@
 <script lang="ts">
+	import {onMount} from 'svelte';
+	import {session} from '$app/stores';
+
 	import type {SocketStore} from '$lib/ui/socket';
 
 	export let socket: SocketStore;
+	export let url: string;
 
-	const connect = () => socket.connect($socket.url!); // TODO maybe make the socket state a union type for connected/disconnected states?
-	const disconnect = () => socket.disconnect();
+	$: guest = $session.guest;
+
+	let mounted = false;
+
+	onMount(() => {
+		mounted = true;
+		return () => {
+			socket.disconnect();
+		};
+	});
+
+	// Keep the socket connected when logged in, and disconnect when logged out.
+	$: if (mounted) {
+		console.log(':CONNECTING');
+		if (guest) {
+			socket.disconnect();
+		} else {
+			socket.connect(url);
+		}
+	} else {
+		console.log('NOT YET MOUNTED');
+	}
 </script>
-
-<form>
-	<input value={$socket.url} on:input={(e) => socket.updateUrl(e.currentTarget.value)} />
-	<button type="button" on:click={$socket.ws ? disconnect : connect}>
-		{#if $socket.ws}disconnect{:else}connect{/if}
-	</button>
-</form>
-<div>status: <code>'{$socket.status}'</code></div>

--- a/src/lib/ui/SocketConnectionControls.svelte
+++ b/src/lib/ui/SocketConnectionControls.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import type {SocketStore} from '$lib/ui/socket';
+
+	export let socket: SocketStore;
+
+	const connect = () => socket.connect($socket.url!); // TODO maybe make the socket state a union type for connected/disconnected states?
+	const disconnect = () => socket.disconnect();
+</script>
+
+<form>
+	<input value={$socket.url} on:input={(e) => socket.updateUrl(e.currentTarget.value)} />
+	<button type="button" on:click={$socket.ws ? disconnect : connect}>
+		{#if $socket.ws}disconnect{:else}connect{/if}
+	</button>
+</form>
+<div>status: <code>'{$socket.status}'</code></div>

--- a/src/lib/ui/socket.ts
+++ b/src/lib/ui/socket.ts
@@ -1,24 +1,14 @@
 import type {AsyncStatus} from '@feltcoop/felt';
-import {setContext, getContext} from 'svelte';
 
 import {writable, type Readable} from '@feltcoop/svelte-gettable-stores';
 import {Logger} from '@feltcoop/felt/util/log.js';
 
 const log = new Logger('[socket]');
 
-const KEY = Symbol();
-
 export const HEARTBEAT_INTERVAL = 300000;
 
 const RECONNECT_DELAY = 1000; // matches the current Vite/SvelteKit retry rate, but we use a counter to back off
 const RECONNECT_DELAY_MAX = 60000;
-
-export const getSocket = (): SocketStore => getContext(KEY);
-
-export const setSocket = (store: SocketStore): SocketStore => {
-	setContext(KEY, store);
-	return store;
-};
 
 // TODO consider extracting a higher order store or component
 // to handle reconnection and heartbeat. Connection? SocketConnection?

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -4,7 +4,6 @@
 	import {setDevmode} from '@feltcoop/felt/ui/devmode.js';
 	import DevmodeControls from '@feltcoop/felt/ui/DevmodeControls.svelte';
 	import FeltWindowHost from '@feltcoop/felt/ui/FeltWindowHost.svelte';
-	import {onMount} from 'svelte';
 	import {session, page} from '$app/stores';
 	import {browser} from '$app/env';
 	import Dialogs from '@feltcoop/felt/ui/dialog/Dialogs.svelte';
@@ -97,24 +96,6 @@
 	$: selectedPersona = $personaSelection; // must be after `updateStateFromPageParams`
 
 	$: syncUiToUrl(ui, dispatch, $page.params, $page.url);
-
-	let mounted = false;
-
-	onMount(() => {
-		mounted = true;
-		return () => {
-			socket.disconnect();
-		};
-	});
-
-	// Keep the socket connected when logged in, and disconnect when logged out.
-	$: if (mounted) {
-		if (guest) {
-			socket.disconnect();
-		} else {
-			socket.connect(WEBSOCKET_URL);
-		}
-	}
 
 	let clientWidth: number;
 	let clientHeight: number;

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -10,7 +10,7 @@
 	import Dialogs from '@feltcoop/felt/ui/dialog/Dialogs.svelte';
 	import {Logger} from '@feltcoop/felt/util/log.js';
 
-	import {setSocket, toSocketStore} from '$lib/ui/socket';
+	import {toSocketStore} from '$lib/ui/socket';
 	import Luggage from '$lib/ui/Luggage.svelte';
 	import MainNav from '$lib/ui/MainNav.svelte';
 	import Onboard from '$lib/ui/Onboard.svelte';
@@ -30,6 +30,7 @@
 	import {mutations} from '$lib/app/mutations';
 	import AppContextmenu from '$lib/app/contextmenu/AppContextmenu.svelte';
 	import ActingPersonaContextmenu from '$lib/app/contextmenu/ActingPersonaContextmenu.svelte';
+	import SocketConnection from '$lib/ui/SocketConnection.svelte';
 	import LinkContextmenu from '$lib/app/contextmenu/LinkContextmenu.svelte';
 	import ErrorMessage from '$lib/ui/ErrorMessage.svelte';
 	import {deserialize, deserializers} from '$lib/util/deserialize';
@@ -49,11 +50,9 @@
 	}
 
 	const devmode = setDevmode();
-	const socket = setSocket(
-		toSocketStore(
-			(message) => websocketClient.handle(message.data),
-			() => dispatch.Ping(),
-		),
+	const socket = toSocketStore(
+		(message) => websocketClient.handle(message.data),
+		() => dispatch.Ping(),
 	);
 	const ui = toUi(session, initialMobileValue, components, (errorMessage) => {
 		dispatch.OpenDialog({Component: ErrorMessage, props: {text: errorMessage}});
@@ -131,6 +130,8 @@
 <svelte:head>
 	<link rel="shortcut icon" href="/favicon.png" />
 </svelte:head>
+
+<SocketConnection {socket} url={WEBSOCKET_URL} />
 
 <div class="layout" class:mobile={$mobile} bind:clientHeight bind:clientWidth>
 	{#if !guest && !onboarding}


### PR DESCRIPTION
Renames `SocketConnection` to `SocketConnectionControls` and adds `SocketConnection` to extract a bit of logic out of the main layout. It should change no behavior, the idea is to keep the layout tidy and make the websocket less tightly coupled to it.