### PR TITLE
improve schema hack

### DIFF
--- a/src/lib/util/ajv.ts
+++ b/src/lib/util/ajv.ts
@@ -13,14 +13,12 @@ export const ajv = (opts?: Options): Ajv => {
 	ajvInstance.addKeyword('tsType').addKeyword('tsImport');
 	addFormats(ajvInstance);
 	const registered = new Set<string>();
-	for (const schema of schemas) {
-		traverse(schema, (key, value, obj) => {
-			if (key === '$id' && !registered.has(value)) {
-				registered.add(value);
-				ajvInstance!.addSchema(obj);
-			}
-		});
-	}
+	traverse(schemas, (key, value, obj) => {
+		if (key === '$id' && !registered.has(value)) {
+			registered.add(value);
+			ajvInstance!.addSchema(obj);
+		}
+	});
 	return ajvInstance;
 };
 

--- a/src/lib/util/ajv.ts
+++ b/src/lib/util/ajv.ts
@@ -12,12 +12,12 @@ export const ajv = (opts?: Options): Ajv => {
 	ajvInstance = new Ajv(opts);
 	ajvInstance.addKeyword('tsType').addKeyword('tsImport');
 	addFormats(ajvInstance);
-	const addedSchemas = new Set<string>();
+	const registered = new Set<string>();
 	for (const schema of schemas) {
 		//TODO BIG HACK HERE; should use references in anyOf, and then call `addSchema` with only `schema`
 		traverse(schema, (key, value, obj) => {
-			if (key === '$id' && !addedSchemas.has(value)) {
-				addedSchemas.add(value);
+			if (key === '$id' && !registered.has(value)) {
+				registered.add(value);
 				ajvInstance!.addSchema(obj);
 			}
 		});

--- a/src/lib/util/ajv.ts
+++ b/src/lib/util/ajv.ts
@@ -14,7 +14,6 @@ export const ajv = (opts?: Options): Ajv => {
 	addFormats(ajvInstance);
 	const registered = new Set<string>();
 	for (const schema of schemas) {
-		//TODO BIG HACK HERE; should use references in anyOf, and then call `addSchema` with only `schema`
 		traverse(schema, (key, value, obj) => {
 			if (key === '$id' && !registered.has(value)) {
 				registered.add(value);


### PR DESCRIPTION
Cleans up a hack we had. I don't love how it traverses every key of every schema, but this ensures all `$id` schemas get discovered and registered.