### PR TITLE
remove border radius from luggage and marquee buttons

### DIFF
--- a/src/lib/ui/CommunityNav.svelte
+++ b/src/lib/ui/CommunityNav.svelte
@@ -70,6 +70,7 @@
 		align-items: center;
 	}
 	.persona-group {
+		width: 100%;
 		margin-bottom: var(--navbar_size);
 	}
 	.persona-group:last-child {

--- a/src/lib/ui/Luggage.svelte
+++ b/src/lib/ui/Luggage.svelte
@@ -24,5 +24,6 @@
 	}
 	button {
 		height: var(--navbar_size);
+		border-radius: 0;
 	}
 </style>

--- a/src/lib/ui/MarqueeButton.svelte
+++ b/src/lib/ui/MarqueeButton.svelte
@@ -26,6 +26,7 @@
 		position: absolute;
 		right: 0;
 		top: 0;
+		border-radius: 0;
 		/* TODO this is janky because it can go offscreen for a bit,
 		though it's a nice idea because it maintains object permanence */
 		/* transition: transform var(--duration_1) ease-out; */


### PR DESCRIPTION
Makes the luggage and marquee buttons square. I tried making just the top corner have zero radius, but it looks a bit strange, and the community/space links all have square corners, so I think this is better.

I don't love how the outline style for the focused element gets cut off for various reasons, like going off the page (see the community links) or being overlapped by other elements (see the space links), but I'm not sure what to do about it.