### PR TITLE
add `data.space_id` for directory entities

### DIFF
--- a/src/lib/app/eventTypes.gen.ts
+++ b/src/lib/app/eventTypes.gen.ts
@@ -39,7 +39,7 @@ import type {Membership} from '$lib/vocab/membership/membership';
 import type {Space} from '$lib/vocab/space/space';
 import type {Entity} from '$lib/vocab/entity/entity';
 import type {Tie} from '$lib/vocab/tie/tie';
-import type {EntityData} from '$lib/vocab/entity/entityData';
+import type {EntityData, DirectoryEntityData} from '$lib/vocab/entity/entityData';
 import type {DispatchContext} from '$lib/app/dispatch';
 
 /* eslint-disable @typescript-eslint/no-empty-interface, @typescript-eslint/array-type */

--- a/src/lib/app/eventTypes.ts
+++ b/src/lib/app/eventTypes.ts
@@ -11,7 +11,7 @@ import type {Membership} from '$lib/vocab/membership/membership';
 import type {Space} from '$lib/vocab/space/space';
 import type {Entity} from '$lib/vocab/entity/entity';
 import type {Tie} from '$lib/vocab/tie/tie';
-import type {EntityData} from '$lib/vocab/entity/entityData';
+import type {EntityData, DirectoryEntityData} from '$lib/vocab/entity/entityData';
 import type {DispatchContext} from '$lib/app/dispatch';
 
 /* eslint-disable @typescript-eslint/no-empty-interface, @typescript-eslint/array-type */
@@ -259,7 +259,7 @@ export interface CreateSpaceParams {
 }
 export interface CreateSpaceResponse {
 	space: Space;
-	directory: Entity;
+	directory: Entity & {data: DirectoryEntityData};
 }
 export type CreateSpaceResponseResult = ApiResult<CreateSpaceResponse>;
 

--- a/src/lib/app/eventTypes.ts
+++ b/src/lib/app/eventTypes.ts
@@ -259,6 +259,7 @@ export interface CreateSpaceParams {
 }
 export interface CreateSpaceResponse {
 	space: Space;
+	directory: Entity;
 }
 export type CreateSpaceResponseResult = ApiResult<CreateSpaceResponse>;
 

--- a/src/lib/db/migrations/00025-directory-data-space-community-ids.js
+++ b/src/lib/db/migrations/00025-directory-data-space-community-ids.js
@@ -1,0 +1,6 @@
+/** @param {import('postgres').Sql<any>} sql */
+export const up = async (sql) => {
+	// TODO BLOCK for every `space.directory_id` set `entity.data.community_id` and `entity.data.space_id`
+	// await sql`
+	// `;
+};

--- a/src/lib/db/migrations/00025-directory-data-space-community-ids.js
+++ b/src/lib/db/migrations/00025-directory-data-space-community-ids.js
@@ -1,10 +1,10 @@
 /** @param {import('postgres').Sql<any>} sql */
 export const up = async (sql) => {
 	const spaces = await sql`
-		SELECT space_id,community_id,directory_id FROM spaces;
+		SELECT space_id,directory_id FROM spaces;
 	`;
 
-	// Add `space_id` and `community_id` to directory data:
+	// Add `space_id` to directory data:
 	for (const space of spaces) {
 		// eslint-disable-next-line no-await-in-loop
 		const [directory] = await sql`
@@ -13,7 +13,6 @@ export const up = async (sql) => {
 		const data = {
 			...directory.data,
 			space_id: space.space_id,
-			community_id: space.community_id,
 			name: undefined, // remove `name` from directories
 		};
 		// eslint-disable-next-line no-await-in-loop

--- a/src/lib/db/migrations/00025-directory-data-space-community-ids.js
+++ b/src/lib/db/migrations/00025-directory-data-space-community-ids.js
@@ -1,6 +1,26 @@
 /** @param {import('postgres').Sql<any>} sql */
 export const up = async (sql) => {
-	// TODO BLOCK for every `space.directory_id` set `entity.data.community_id` and `entity.data.space_id`
-	// await sql`
-	// `;
+	const spaces = await sql`
+		SELECT space_id,community_id,directory_id FROM spaces;
+	`;
+
+	// Add `space_id` and `community_id` to directory data:
+	for (const space of spaces) {
+		// eslint-disable-next-line no-await-in-loop
+		const [directory] = await sql`
+			SELECT data FROM entities WHERE entity_id=${space.directory_id};
+		`;
+		const data = {
+			...directory.data,
+			space_id: space.space_id,
+			community_id: space.community_id,
+			name: undefined, // remove `name` from directories
+		};
+		// eslint-disable-next-line no-await-in-loop
+		await sql`
+			UPDATE entities
+			SET data=${data}
+			WHERE entity_id=${space.directory_id}
+		`;
+	}
 };

--- a/src/lib/util/randomVocab.ts
+++ b/src/lib/util/randomVocab.ts
@@ -15,7 +15,7 @@ import type {
 	CreateTieParams,
 } from '$lib/app/eventTypes';
 import type {Database} from '$lib/db/Database';
-import type {EntityData} from '$lib/vocab/entity/entityData';
+import type {DirectoryEntityData, EntityData} from '$lib/vocab/entity/entityData';
 import type {Entity} from '$lib/vocab/entity/entity';
 import type {Tie} from '$lib/vocab/tie/tie';
 import {CreateAccountPersonaService} from '$lib/vocab/persona/personaServices';
@@ -158,7 +158,7 @@ export class RandomVocabContext {
 		community?: Community,
 	): Promise<{
 		space: Space;
-		directory: Entity;
+		directory: Entity & {data: DirectoryEntityData};
 		persona: Persona;
 		account: Account;
 		community: Community;

--- a/src/lib/util/randomVocab.ts
+++ b/src/lib/util/randomVocab.ts
@@ -156,12 +156,18 @@ export class RandomVocabContext {
 		persona?: Persona,
 		account?: Account,
 		community?: Community,
-	): Promise<{space: Space; persona: Persona; account: Account; community: Community}> {
+	): Promise<{
+		space: Space;
+		directory: Entity;
+		persona: Persona;
+		account: Account;
+		community: Community;
+	}> {
 		if (!account) account = await this.account();
 		if (!persona) ({persona} = await this.persona(account));
 		if (!community) ({community} = await this.community(persona, account));
 		const params = randomSpaceParams(persona.persona_id, community.community_id);
-		const {space} = unwrap(
+		const {space, directory} = unwrap(
 			await CreateSpaceService.perform({
 				params,
 				account_id: account.account_id,
@@ -169,7 +175,7 @@ export class RandomVocabContext {
 				session,
 			}),
 		);
-		return {space, persona, account, community};
+		return {space, directory, persona, account, community};
 	}
 
 	//TODO do we need space now? Should be source_id

--- a/src/lib/vocab/entity/entityData.ts
+++ b/src/lib/vocab/entity/entityData.ts
@@ -9,8 +9,8 @@ export interface BaseEntityData {
 	content?: string;
 	name?: string;
 	checked?: boolean;
-	community_id?: number; // populated for directories, `undefined` for all other entities
-	space_id?: number; // populated for directories, `undefined` for all other entities
+	community_id?: number; // populated for directories, absent for all other entities
+	space_id?: number; // populated for directories, absent for all other entities
 }
 
 export interface NoteEntityData extends BaseEntityData {

--- a/src/lib/vocab/entity/entityData.ts
+++ b/src/lib/vocab/entity/entityData.ts
@@ -9,6 +9,8 @@ export interface BaseEntityData {
 	content?: string;
 	name?: string;
 	checked?: boolean;
+	community_id?: number; // populated for directories, `undefined` for all other entities
+	space_id?: number; // populated for directories, `undefined` for all other entities
 }
 
 export interface NoteEntityData extends BaseEntityData {

--- a/src/lib/vocab/entity/entityData.ts
+++ b/src/lib/vocab/entity/entityData.ts
@@ -1,4 +1,5 @@
 export type EntityData =
+	| DirectoryEntityData
 	| NoteEntityData
 	| ArticleEntityData
 	| CollectionEntityData
@@ -9,8 +10,12 @@ export interface BaseEntityData {
 	content?: string;
 	name?: string;
 	checked?: boolean;
-	community_id?: number; // populated for directories, absent for all other entities
-	space_id?: number; // populated for directories, absent for all other entities
+}
+
+export interface DirectoryEntityData extends BaseEntityData {
+	type: 'Collection';
+	community_id: number;
+	space_id: number;
 }
 
 export interface NoteEntityData extends BaseEntityData {

--- a/src/lib/vocab/entity/entityData.ts
+++ b/src/lib/vocab/entity/entityData.ts
@@ -14,7 +14,6 @@ export interface BaseEntityData {
 
 export interface DirectoryEntityData extends BaseEntityData {
 	type: 'Collection';
-	community_id: number;
 	space_id: number;
 }
 

--- a/src/lib/vocab/space/spaceEvents.ts
+++ b/src/lib/vocab/space/spaceEvents.ts
@@ -23,7 +23,7 @@ export const CreateSpace: ServiceEventInfo = {
 		type: 'object',
 		properties: {
 			space: {$ref: '/schemas/Space.json', tsType: 'Space'},
-			directory: {$ref: '/schemas/Entity.json', tsType: 'Entity'},
+			directory: {$ref: '/schemas/Entity.json', tsType: 'Entity & {data: DirectoryEntityData}'}, // TODO make this a generic instead?
 		},
 		required: ['space', 'directory'],
 		additionalProperties: false,

--- a/src/lib/vocab/space/spaceEvents.ts
+++ b/src/lib/vocab/space/spaceEvents.ts
@@ -23,8 +23,9 @@ export const CreateSpace: ServiceEventInfo = {
 		type: 'object',
 		properties: {
 			space: {$ref: '/schemas/Space.json', tsType: 'Space'},
+			directory: {$ref: '/schemas/Entity.json', tsType: 'Entity'},
 		},
-		required: ['space'],
+		required: ['space', 'directory'],
 		additionalProperties: false,
 	},
 	returns: 'Promise<CreateSpaceResponseResult>',

--- a/src/lib/vocab/space/spaceServices.test.ts
+++ b/src/lib/vocab/space/spaceServices.test.ts
@@ -1,5 +1,6 @@
 import {suite} from 'uvu';
 import {unwrap, unwrapError} from '@feltcoop/felt';
+import * as assert from 'uvu/assert';
 
 import {setupDb, teardownDb, type TestDbContext} from '$lib/util/testDbHelpers';
 import type {TestAppContext} from '$lib/util/testAppHelpers';
@@ -11,6 +12,12 @@ const test__spaceServices = suite<TestDbContext & TestAppContext>('spaceServices
 
 test__spaceServices.before(setupDb);
 test__spaceServices.after(teardownDb);
+
+test__spaceServices('create a space with directory data', async ({random}) => {
+	const {space, directory} = await random.space();
+	assert.is(space.space_id, directory.data.space_id);
+	assert.is(space.community_id, directory.data.community_id);
+});
 
 test__spaceServices('delete a space in multiple communities', async ({db, random}) => {
 	const {space, account} = await random.space();

--- a/src/lib/vocab/space/spaceServices.test.ts
+++ b/src/lib/vocab/space/spaceServices.test.ts
@@ -16,7 +16,6 @@ test__spaceServices.after(teardownDb);
 test__spaceServices('space directory data has community and space ids', async ({random}) => {
 	const {space, directory} = await random.space();
 	assert.is(space.space_id, directory.data.space_id);
-	assert.is(space.community_id, directory.data.community_id);
 });
 
 test__spaceServices('delete a space in multiple communities', async ({db, random}) => {

--- a/src/lib/vocab/space/spaceServices.test.ts
+++ b/src/lib/vocab/space/spaceServices.test.ts
@@ -13,7 +13,7 @@ const test__spaceServices = suite<TestDbContext & TestAppContext>('spaceServices
 test__spaceServices.before(setupDb);
 test__spaceServices.after(teardownDb);
 
-test__spaceServices('create a space with directory data', async ({random}) => {
+test__spaceServices('space directory data has community and space ids', async ({random}) => {
 	const {space, directory} = await random.space();
 	assert.is(space.space_id, directory.data.space_id);
 	assert.is(space.community_id, directory.data.community_id);

--- a/src/lib/vocab/space/spaceServices.ts
+++ b/src/lib/vocab/space/spaceServices.ts
@@ -56,10 +56,9 @@ export const CreateSpaceService: ServiceByName['CreateSpace'] = {
 	// TODO verify `params.persona_id` is  one of the `account_id`'s personas
 	perform: async ({repos, params}) => {
 		log.trace('[CreateSpace] validating space url uniqueness');
-		const findByCommunityUrlResult = await repos.space.findByCommunityUrl(
-			params.community_id,
-			params.url,
-		);
+		const {community_id} = params;
+
+		const findByCommunityUrlResult = await repos.space.findByCommunityUrl(community_id, params.url);
 
 		if (!findByCommunityUrlResult.ok) {
 			log.trace('[CreateSpace] error validating unique url for new space');
@@ -72,9 +71,9 @@ export const CreateSpaceService: ServiceByName['CreateSpace'] = {
 		}
 
 		log.trace('[CreateSpace] finding community space for dir actor');
-		const communityPersona = await repos.persona.findByCommunityId(params.community_id);
+		const communityPersona = await repos.persona.findByCommunityId(community_id);
 		if (!communityPersona.ok) {
-			log.error('[CreateSpace] error finding persona for provided community', params.community_id);
+			log.error('[CreateSpace] error finding persona for provided community', community_id);
 			return {ok: false, status: 500, message: 'error looking up community persona'};
 		}
 
@@ -82,26 +81,38 @@ export const CreateSpaceService: ServiceByName['CreateSpace'] = {
 		const createDirectoryResult = await repos.entity.create(communityPersona.value.persona_id, {
 			type: 'Collection',
 			name: 'directory',
+			community_id,
+			// `space_id` gets added below, after the space is created
 		});
 		if (!createDirectoryResult.ok) {
 			log.error('[CreateSpace] error creating directory for space', params.name);
 			return {ok: false, status: 500, message: 'error creating directory for space'};
 		}
+		const directory = createDirectoryResult.value;
 
-		log.trace('[CreateSpace] creating space for community', params.community_id);
+		log.trace('[CreateSpace] creating space for community', community_id);
 		const createSpaceResult = await repos.space.create(
 			params.name,
 			params.view,
 			params.url,
 			params.icon,
-			params.community_id,
+			community_id,
 			createDirectoryResult.value.entity_id,
 		);
 		if (!createSpaceResult.ok) {
 			log.trace('[CreateSpace] error searching for community spaces');
 			return {ok: false, status: 500, message: 'error searching for community spaces'};
 		}
-		return {ok: true, status: 200, value: {space: createSpaceResult.value}};
+		const space = createSpaceResult.value;
+
+		// set `directory.data.space_id` now that the space has been created
+		// TODO for merge, `const updatedDirectory = `
+		await repos.entity.updateEntityData(directory.entity_id, {
+			...directory.data,
+			space_id: space.space_id,
+		});
+
+		return {ok: true, status: 200, value: {space}};
 	},
 };
 

--- a/src/lib/vocab/space/spaceServices.ts
+++ b/src/lib/vocab/space/spaceServices.ts
@@ -97,7 +97,7 @@ export const CreateSpaceService: ServiceByName['CreateSpace'] = {
 			params.url,
 			params.icon,
 			community_id,
-			createDirectoryResult.value.entity_id,
+			directory.entity_id,
 		);
 		if (!createSpaceResult.ok) {
 			log.trace('[CreateSpace] error searching for community spaces');
@@ -106,13 +106,16 @@ export const CreateSpaceService: ServiceByName['CreateSpace'] = {
 		const space = createSpaceResult.value;
 
 		// set `directory.data.space_id` now that the space has been created
-		// TODO for merge, `const updatedDirectory = `
-		await repos.entity.updateEntityData(directory.entity_id, {
+		const updatedDirectoryResult = await repos.entity.updateEntityData(directory.entity_id, {
 			...directory.data,
 			space_id: space.space_id,
 		});
+		if (!updatedDirectoryResult.ok) {
+			log.trace('[CreateSpace] error updating the directory for space');
+			return {ok: false, status: 500, message: 'error updating directory with new space'};
+		}
 
-		return {ok: true, status: 200, value: {space}};
+		return {ok: true, status: 200, value: {space, directory: updatedDirectoryResult.value}};
 	},
 };
 

--- a/src/lib/vocab/space/spaceServices.ts
+++ b/src/lib/vocab/space/spaceServices.ts
@@ -125,8 +125,8 @@ export const CreateSpaceService: ServiceByName['CreateSpace'] = {
 export const UpdateSpaceService: ServiceByName['UpdateSpace'] = {
 	event: UpdateSpace,
 	perform: async ({repos, params}) => {
-		const {space_id, ...uninitialized} = params;
-		const updateEntitiesResult = await repos.space.update(space_id, uninitialized);
+		const {space_id, ...partial} = params;
+		const updateEntitiesResult = await repos.space.update(space_id, partial);
 		if (!updateEntitiesResult.ok) {
 			log.trace('[UpdateSpace] error updating space');
 			return {ok: false, status: 500, message: 'failed to update space'};


### PR DESCRIPTION
- [x] create directories with `data.space_id`
- [x] test
- [x] add migration

We should be able to detect directories with type safety via `'space_id' in $entity.data`, they continue to have `type: 'Collection'` but no longer have `name: 'directory'`.