### PR TITLE
shrink the member item persona icons

### DIFF
--- a/src/lib/ui/MarqueeNav.svelte
+++ b/src/lib/ui/MarqueeNav.svelte
@@ -21,7 +21,7 @@
 		height: var(--navbar_size);
 		background-color: var(--tint_dark_1);
 		padding-right: var(--navbar_size); /* placeholder for button, which is rendered elsewhere */
-		padding-left: var(--spacing_lg);
+		padding-left: var(--spacing_md);
 	}
 	.icon {
 		font-size: var(--font_size_lg);

--- a/src/lib/ui/MemberItem.svelte
+++ b/src/lib/ui/MemberItem.svelte
@@ -18,3 +18,10 @@
 >
 	<PersonaAvatar {persona} />
 </li>
+
+<style>
+	li {
+		--icon_size: var(--icon_size_sm);
+		padding: var(--spacing_xs3) var(--spacing_xs);
+	}
+</style>


### PR DESCRIPTION
Persona icons in the community member list were a bit big, now they're smaller and spaced apart with padding.