### PR TITLE
add a subtle click animation to the luggage

### DIFF
--- a/src/lib/ui/Luggage.svelte
+++ b/src/lib/ui/Luggage.svelte
@@ -10,7 +10,7 @@
 		aria-label="toggle luggage"
 		on:click={() => dispatch.ToggleMainNav()}
 	>
-		☰
+		<span>☰</span>
 	</button>
 </div>
 
@@ -25,5 +25,8 @@
 	button {
 		height: var(--navbar_size);
 		border-radius: 0;
+	}
+	button:active span {
+		transform: scale3d(1.16, 1.16, 1.16);
 	}
 </style>


### PR DESCRIPTION
Makes the luggage contents scale up slightly when the button is `:active` (clicking or pressing the spacebar). Doesn't add a transition animation or hover state (because the button already has its own), is very minimal, might be something we extract into a helper class.