### PR TITLE
fix edit space button in devmode

### DIFF
--- a/src/lib/ui/Marquee.svelte
+++ b/src/lib/ui/Marquee.svelte
@@ -5,12 +5,10 @@
 	import type {Community} from '$lib/vocab/community/community';
 	import MemberItem from '$lib/ui/MemberItem.svelte';
 	import MarqueeNav from '$lib/ui/MarqueeNav.svelte';
-	import SpaceEditor from '$lib/ui/SpaceEditor.svelte';
 	import {getApp} from '$lib/ui/app';
 	import SocketConnectionControls from '$lib/ui/SocketConnectionControls.svelte';
 
 	const {
-		dispatch,
 		ui: {expandMarquee, personasByCommunityId},
 		socket,
 		devmode,
@@ -40,13 +38,6 @@
 				<li><a href="/docs">/docs</a></li>
 			</ul>
 		</section>
-		{#if $space}
-			<section>
-				<button on:click={() => dispatch.OpenDialog({Component: SpaceEditor, props: {space}})}
-					>Edit Space</button
-				>
-			</section>
-		{/if}
 		<section>
 			<SocketConnectionControls {socket} />
 		</section>


### PR DESCRIPTION
This "edit space" button that appeared in the marquee in devmode was bugged because we don't have typesafety on our dialog components (I think I can see a way to implement it, main thing is how to generate types from a Svelte component).

Rather than fixing the bug, I'm removing the button because this predated contextmenus.