### PR TITLE
improve property editor buttons

### DIFF
--- a/src/lib/ui/PropertyEditor.svelte
+++ b/src/lib/ui/PropertyEditor.svelte
@@ -86,16 +86,7 @@
 	<pre>{currentSerialized}</pre>
 </div>
 {#if editing}
-	{#if changed}
-		<div class="buttons">
-			<button type="button" on:click={reset}> reset </button>
-			<PendingButton on:click={save} {pending} disabled={pending || !!errorMessage}>
-				save
-			</PendingButton>
-		</div>
-	{:else}
-		<button type="button" on:click={stopEditing}>cancel</button>
-	{/if}
+	<button type="button" on:click={stopEditing}>cancel</button>
 	<textarea
 		placeholder="> value"
 		bind:this={fieldValueEl}
@@ -104,6 +95,14 @@
 		disabled={pending}
 		on:keydown={onKeydown}
 	/>
+	{#if changed}
+		<div class="buttons">
+			<button type="button" on:click={reset}> reset </button>
+			<PendingButton on:click={save} {pending} disabled={pending || !!errorMessage}>
+				save
+			</PendingButton>
+		</div>
+	{/if}
 	{#if errorMessage}
 		<Message status="error">{errorMessage}</Message>
 	{:else if changed}
@@ -124,5 +123,9 @@
 	}
 	.preview {
 		overflow: auto;
+	}
+	textarea {
+		/* TODO customize this for different values */
+		height: 120px;
 	}
 </style>

--- a/src/lib/ui/style.css
+++ b/src/lib/ui/style.css
@@ -48,7 +48,9 @@ main {
 .buttons {
 	width: 100%;
 	display: flex;
-	justify-content: space-between;
+}
+.buttons > * {
+	flex: 1;
 }
 
 /* TODO upstream? */


### PR DESCRIPTION
Changes the property editor buttons to always show "cancel" or "edit", and then displays "reset" and "save" below instead of replacing "cancel" when there are changes. Also makes the buttons fill the space and makes the textarea a bit taller for now.