### PR TITLE
tweak freshness indicator style

### DIFF
--- a/src/lib/ui/CommunityNavItem.svelte
+++ b/src/lib/ui/CommunityNavItem.svelte
@@ -62,6 +62,7 @@
 		display: block;
 		/* TODO better way to have active state? this makes the community nav wider than the luggage button! */
 		padding: var(--spacing_xs);
+		padding-left: calc(var(--indicator_size) + var(--indicator_padding) * 2);
 		text-decoration: none;
 		position: relative;
 	}

--- a/src/lib/ui/CommunityNavItem.svelte
+++ b/src/lib/ui/CommunityNavItem.svelte
@@ -62,7 +62,7 @@
 		display: block;
 		/* TODO better way to have active state? this makes the community nav wider than the luggage button! */
 		padding: var(--spacing_xs);
-		padding-left: calc(var(--indicator_size) + var(--indicator_padding) * 2);
+		padding-left: calc(var(--freshness_indicator_size) + var(--freshness_indicator_padding) * 2);
 		text-decoration: none;
 		position: relative;
 	}

--- a/src/lib/ui/FreshnessIndicator.svelte
+++ b/src/lib/ui/FreshnessIndicator.svelte
@@ -10,7 +10,7 @@
 	.freshness-indicator {
 		width: var(--indicator_size);
 		height: var(--indicator_size);
-		background-color: #fff;
+		background-color: white;
 		border-radius: 50%;
 	}
 	.freshness-indicator-wrapper {

--- a/src/lib/ui/FreshnessIndicator.svelte
+++ b/src/lib/ui/FreshnessIndicator.svelte
@@ -8,14 +8,14 @@
 
 <style>
 	.freshness-indicator {
-		width: var(--indicator_size);
-		height: var(--indicator_size);
+		width: var(--freshness_indicator_size);
+		height: var(--freshness_indicator_size);
 		background-color: white;
 		border-radius: 50%;
 	}
 	.freshness-indicator-wrapper {
 		position: absolute;
-		left: var(--indicator_padding);
+		left: var(--freshness_indicator_padding);
 		top: 0;
 		height: 100%;
 		display: flex;

--- a/src/lib/ui/FreshnessIndicator.svelte
+++ b/src/lib/ui/FreshnessIndicator.svelte
@@ -8,14 +8,14 @@
 
 <style>
 	.freshness-indicator {
-		width: 12px;
-		height: 12px;
-		background-color: white;
+		width: var(--indicator_size);
+		height: var(--indicator_size);
+		background-color: #fff;
 		border-radius: 50%;
 	}
 	.freshness-indicator-wrapper {
 		position: absolute;
-		left: 0;
+		left: var(--indicator_padding);
 		top: 0;
 		height: 100%;
 		display: flex;

--- a/src/lib/ui/SpaceNavItem.svelte
+++ b/src/lib/ui/SpaceNavItem.svelte
@@ -52,6 +52,6 @@
 		display: flex;
 		align-items: center;
 		text-decoration: none;
-		padding-left: calc(var(--indicator_size) + var(--indicator_padding) * 2);
+		padding-left: calc(var(--freshness_indicator_size) + var(--freshness_indicator_padding) * 2);
 	}
 </style>

--- a/src/lib/ui/SpaceNavItem.svelte
+++ b/src/lib/ui/SpaceNavItem.svelte
@@ -52,5 +52,6 @@
 		display: flex;
 		align-items: center;
 		text-decoration: none;
+		padding-left: calc(var(--indicator_size) + var(--indicator_padding) * 2);
 	}
 </style>

--- a/src/lib/ui/style.css
+++ b/src/lib/ui/style.css
@@ -6,8 +6,8 @@
 	--luggage_size: calc(var(--icon_size_md) + var(--spacing_xs) * 2);
 	--navbar_size: calc(var(--icon_size_sm) + var(--spacing_xs) * 2);
 	--contextmenu_width: 360px;
-	--indicator_size: 7px;
-	--indicator_padding: 3px;
+	--freshness_indicator_size: 7px;
+	--freshness_indicator_padding: 3px;
 }
 
 html {

--- a/src/lib/ui/style.css
+++ b/src/lib/ui/style.css
@@ -6,6 +6,8 @@
 	--luggage_size: calc(var(--icon_size_md) + var(--spacing_xs) * 2);
 	--navbar_size: calc(var(--icon_size_sm) + var(--spacing_xs) * 2);
 	--contextmenu_width: 360px;
+	--indicator_size: 7px;
+	--indicator_padding: 3px;
 }
 
 html {


### PR DESCRIPTION
Adds some padding around the freshness indicator. Not sure about this, I'm not expecting to merge, just implementing so we can think about it. The main downside of this is that the community buttons are no longer square, and though we could improve things by adding right padding to the community icons, wasting the space doesn't seem good either.

Might need to think laterally instead of going down this path of indicating freshness.