### PR TITLE
change contextmenu hotkeys and add hotkey to toggle main menu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@feltcoop/felt": "^0.33.0",
+        "@feltcoop/felt": "^0.34.0",
         "@feltcoop/svelte-gettable-stores": "^0.2.0",
         "@polka/send-type": "^0.5.2",
         "@ryanatkn/json-schema-to-typescript": "^11.1.2",
@@ -130,9 +130,9 @@
       }
     },
     "node_modules/@feltcoop/felt": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@feltcoop/felt/-/felt-0.33.0.tgz",
-      "integrity": "sha512-NMJkdDCpj6Wm/2c/szdwaVicuzLMaoXAdmP8S1/hovQ8hYETiFk6gPDC7KjfgUJtIZ/Qhb8GBiscARjJ1ikQhQ==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@feltcoop/felt/-/felt-0.34.0.tgz",
+      "integrity": "sha512-bxTv7tAdr5ngLmfL72+xhaBP+TN6A9BD9Lcc6E/ZLRhCrlueaH8kgu2EDVim5cvuAtwcNuCVnPaLcmk3UUe81A==",
       "dependencies": {
         "@lukeed/uuid": "^2.0.0"
       },
@@ -2971,9 +2971,9 @@
       "requires": {}
     },
     "@feltcoop/felt": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@feltcoop/felt/-/felt-0.33.0.tgz",
-      "integrity": "sha512-NMJkdDCpj6Wm/2c/szdwaVicuzLMaoXAdmP8S1/hovQ8hYETiFk6gPDC7KjfgUJtIZ/Qhb8GBiscARjJ1ikQhQ==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@feltcoop/felt/-/felt-0.34.0.tgz",
+      "integrity": "sha512-bxTv7tAdr5ngLmfL72+xhaBP+TN6A9BD9Lcc6E/ZLRhCrlueaH8kgu2EDVim5cvuAtwcNuCVnPaLcmk3UUe81A==",
       "requires": {
         "@lukeed/uuid": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "typescript": "^4.6.3"
   },
   "dependencies": {
-    "@feltcoop/felt": "^0.33.0",
+    "@feltcoop/felt": "^0.34.0",
     "@feltcoop/svelte-gettable-stores": "^0.2.0",
     "@polka/send-type": "^0.5.2",
     "@ryanatkn/json-schema-to-typescript": "^11.1.2",

--- a/src/lib/ui/contextmenu/Contextmenu.svelte
+++ b/src/lib/ui/contextmenu/Contextmenu.svelte
@@ -37,7 +37,7 @@
 	const onWindowKeydown = async (e: KeyboardEvent) => {
 		if (!open) {
 			// TODO extract this so it can be used with a global hotkey system
-			if (e.key === '`' && e.ctrlKey && e.shiftKey && !isEditable(e.target)) {
+			if (e.key === '~' && !e.ctrlKey && !isEditable(e.target)) {
 				const el = document.elementFromPoint(mousePageX, mousePageY) as HTMLElement;
 				if (!el) return;
 				swallow(e);

--- a/src/lib/ui/contextmenu/Contextmenu.svelte
+++ b/src/lib/ui/contextmenu/Contextmenu.svelte
@@ -36,7 +36,7 @@
 
 	const onWindowKeydown = async (e: KeyboardEvent) => {
 		if (!open) {
-			// TODO extract this or make it a prop (maybe include `export const openContextmenu = (x: number, y: number) => ...`)
+			// TODO extract this so it can be used with a global hotkey system
 			if (e.key === '`' && e.ctrlKey && e.shiftKey && !isEditable(e.target)) {
 				const el = document.elementFromPoint(mousePageX, mousePageY) as HTMLElement;
 				if (!el) return;

--- a/src/lib/ui/contextmenu/Contextmenu.svelte
+++ b/src/lib/ui/contextmenu/Contextmenu.svelte
@@ -36,7 +36,8 @@
 
 	const onWindowKeydown = async (e: KeyboardEvent) => {
 		if (!open) {
-			if ((e.key === ' ' || e.key === 'Enter') && !isEditable(e.target)) {
+			// TODO extract this or make it a prop (maybe include `export const openContextmenu = (x: number, y: number) => ...`)
+			if (e.key === '`' && e.ctrlKey && e.shiftKey && !isEditable(e.target)) {
 				const el = document.elementFromPoint(mousePageX, mousePageY) as HTMLElement;
 				if (!el) return;
 				swallow(e);

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -104,7 +104,7 @@
 
 	// TODO `ShortcutKeys` or `Hotkeys` component with some interface
 	const onWindowKeydown = async (e: KeyboardEvent) => {
-		if (e.key === '`' && !isEditable(e.target)) {
+		if (e.key === '`' && !e.ctrlKey && !isEditable(e.target)) {
 			swallow(e);
 			dispatch.ToggleMainNav();
 		}

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -102,7 +102,7 @@
 	let clientHeight: number;
 	$: $layout = {width: clientWidth, height: clientHeight}; // TODO event? `UpdateLayout`?
 
-	// TODO BLOCK `ShortcutKeys` or `Hotkeys` component with some interface
+	// TODO `ShortcutKeys` or `Hotkeys` component with some interface
 	const onWindowKeydown = async (e: KeyboardEvent) => {
 		if (e.key === '`') {
 			swallow(e);

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -8,6 +8,7 @@
 	import {browser} from '$app/env';
 	import Dialogs from '@feltcoop/felt/ui/dialog/Dialogs.svelte';
 	import {Logger} from '@feltcoop/felt/util/log.js';
+	import {isEditable, swallow} from '@feltcoop/felt/util/dom.js';
 
 	import {toSocketStore} from '$lib/ui/socket';
 	import Luggage from '$lib/ui/Luggage.svelte';
@@ -100,6 +101,14 @@
 	let clientWidth: number;
 	let clientHeight: number;
 	$: $layout = {width: clientWidth, height: clientHeight}; // TODO event? `UpdateLayout`?
+
+	// TODO BLOCK `ShortcutKeys` or `Hotkeys` component with some interface
+	const onWindowKeydown = async (e: KeyboardEvent) => {
+		if (e.key === '`') {
+			swallow(e);
+			dispatch.ToggleMainNav();
+		}
+	};
 </script>
 
 <svelte:body
@@ -111,6 +120,8 @@
 <svelte:head>
 	<link rel="shortcut icon" href="/favicon.png" />
 </svelte:head>
+
+<svelte:window on:keydown|capture={onWindowKeydown} />
 
 <SocketConnection {socket} url={WEBSOCKET_URL} />
 

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -8,7 +8,7 @@
 	import {browser} from '$app/env';
 	import Dialogs from '@feltcoop/felt/ui/dialog/Dialogs.svelte';
 	import {Logger} from '@feltcoop/felt/util/log.js';
-	import {isEditable, swallow} from '@feltcoop/felt/util/dom.js';
+	import {swallow} from '@feltcoop/felt/util/dom.js';
 
 	import {toSocketStore} from '$lib/ui/socket';
 	import Luggage from '$lib/ui/Luggage.svelte';

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -8,7 +8,7 @@
 	import {browser} from '$app/env';
 	import Dialogs from '@feltcoop/felt/ui/dialog/Dialogs.svelte';
 	import {Logger} from '@feltcoop/felt/util/log.js';
-	import {swallow} from '@feltcoop/felt/util/dom.js';
+	import {isEditable, swallow} from '@feltcoop/felt/util/dom.js';
 
 	import {toSocketStore} from '$lib/ui/socket';
 	import Luggage from '$lib/ui/Luggage.svelte';
@@ -104,7 +104,7 @@
 
 	// TODO `ShortcutKeys` or `Hotkeys` component with some interface
 	const onWindowKeydown = async (e: KeyboardEvent) => {
-		if (e.key === '`') {
+		if (e.key === '`' && !isEditable(e.target)) {
 			swallow(e);
 			dispatch.ToggleMainNav();
 		}


### PR DESCRIPTION
Changes the contextmenu opener key to be `ctrl+shift+Backtick` for now. Also makes `Backtick` toggle the main nav.

todo

- [x] upgrade Felt with the devmode shortcut change: https://github.com/feltcoop/felt/pull/218


Future: create a `Hotkeys` component or similar