### PR TITLE
upgrade `@feltcoop/svelte-gettable-stores`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@feltcoop/felt": "^0.33.0",
-        "@feltcoop/svelte-gettable-stores": "^0.1.0",
+        "@feltcoop/svelte-gettable-stores": "^0.2.0",
         "@polka/send-type": "^0.5.2",
         "@ryanatkn/json-schema-to-typescript": "^11.1.2",
         "ajv": "^8.11.0",
@@ -184,9 +184,9 @@
       }
     },
     "node_modules/@feltcoop/svelte-gettable-stores": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@feltcoop/svelte-gettable-stores/-/svelte-gettable-stores-0.1.0.tgz",
-      "integrity": "sha512-RrLShzpH/PMQmCHUGcFWz6UfmecNjwhWQFBaS+NuvIK4TIkTGsKsTkFQ8I8pGbLClw6IRd+WYmzwLa9RV129UQ==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@feltcoop/svelte-gettable-stores/-/svelte-gettable-stores-0.2.0.tgz",
+      "integrity": "sha512-e8tQAkHJs3DSLP4O6RD5Ry2gcLKhgVCONqTR76SnpRB4bTHkvYHXVroe33QVxi171CXqGI3qUU1OYZg8ppL+ew==",
       "engines": {
         "node": ">= 16.6"
       }
@@ -3002,9 +3002,9 @@
       }
     },
     "@feltcoop/svelte-gettable-stores": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@feltcoop/svelte-gettable-stores/-/svelte-gettable-stores-0.1.0.tgz",
-      "integrity": "sha512-RrLShzpH/PMQmCHUGcFWz6UfmecNjwhWQFBaS+NuvIK4TIkTGsKsTkFQ8I8pGbLClw6IRd+WYmzwLa9RV129UQ=="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@feltcoop/svelte-gettable-stores/-/svelte-gettable-stores-0.2.0.tgz",
+      "integrity": "sha512-e8tQAkHJs3DSLP4O6RD5Ry2gcLKhgVCONqTR76SnpRB4bTHkvYHXVroe33QVxi171CXqGI3qUU1OYZg8ppL+ew=="
     },
     "@humanwhocodes/config-array": {
       "version": "0.9.3",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@feltcoop/felt": "^0.33.0",
-    "@feltcoop/svelte-gettable-stores": "^0.1.0",
+    "@feltcoop/svelte-gettable-stores": "^0.2.0",
     "@polka/send-type": "^0.5.2",
     "@ryanatkn/json-schema-to-typescript": "^11.1.2",
     "ajv": "^8.11.0",


### PR DESCRIPTION
I simplified the implementation of `@feltcoop/svelte-gettable-stores` quite a bit here: https://github.com/feltcoop/svelte-gettable-stores/pull/1

this upgrades the dep