### PR TITLE
First pass on query & orphan cleanup

### DIFF
--- a/src/lib/app/contextmenu/EntityContextmenu.svelte
+++ b/src/lib/app/contextmenu/EntityContextmenu.svelte
@@ -35,7 +35,7 @@
 				Erase Entity
 			</ContextmenuEntry>
 		{/if}
-		<ContextmenuEntry action={() => dispatch.DeleteEntities({entity_ids: [$entity.entity_id]})}>
+		<ContextmenuEntry action={() => dispatch.DeleteEntities({entityIds: [$entity.entity_id]})}>
 			Delete Entity
 		</ContextmenuEntry>
 	</svelte:fragment>

--- a/src/lib/app/eventTypes.ts
+++ b/src/lib/app/eventTypes.ts
@@ -353,7 +353,9 @@ export type EraseEntitiesResponseResult = ApiResult<EraseEntitiesResponse>;
 export interface DeleteEntitiesParams {
 	entity_ids: number[];
 }
-export type DeleteEntitiesResponse = null;
+export interface DeleteEntitiesResponse {
+	removed_entity_ids: number[];
+}
 export type DeleteEntitiesResponseResult = ApiResult<DeleteEntitiesResponse>;
 
 export interface CreateTieParams {

--- a/src/lib/app/eventTypes.ts
+++ b/src/lib/app/eventTypes.ts
@@ -294,7 +294,10 @@ export type UpdateSpaceResponseResult = ApiResult<UpdateSpaceResponse>;
 export interface DeleteSpaceParams {
 	space_id: number;
 }
-export type DeleteSpaceResponse = null;
+export interface DeleteSpaceResponse {
+	removed_entity_ids: number[];
+	[k: string]: unknown;
+}
 export type DeleteSpaceResponseResult = ApiResult<DeleteSpaceResponse>;
 
 export interface CreateEntityParams {

--- a/src/lib/app/eventTypes.ts
+++ b/src/lib/app/eventTypes.ts
@@ -296,7 +296,6 @@ export interface DeleteSpaceParams {
 }
 export interface DeleteSpaceResponse {
 	removed_entity_ids: number[];
-	[k: string]: unknown;
 }
 export type DeleteSpaceResponseResult = ApiResult<DeleteSpaceResponse>;
 

--- a/src/lib/app/eventTypes.ts
+++ b/src/lib/app/eventTypes.ts
@@ -295,7 +295,7 @@ export interface DeleteSpaceParams {
 	space_id: number;
 }
 export interface DeleteSpaceResponse {
-	removed_entity_ids: number[];
+	deletedEntityIds: number[];
 }
 export type DeleteSpaceResponseResult = ApiResult<DeleteSpaceResponse>;
 
@@ -353,10 +353,10 @@ export interface EraseEntitiesResponse {
 export type EraseEntitiesResponseResult = ApiResult<EraseEntitiesResponse>;
 
 export interface DeleteEntitiesParams {
-	entity_ids: number[];
+	entityIds: number[];
 }
 export interface DeleteEntitiesResponse {
-	removed_entity_ids: number[];
+	deletedEntityIds: number[];
 }
 export type DeleteEntitiesResponseResult = ApiResult<DeleteEntitiesResponse>;
 

--- a/src/lib/server/servicesIntegration.test.ts
+++ b/src/lib/server/servicesIntegration.test.ts
@@ -129,18 +129,17 @@ test_servicesIntegration('services integration test', async ({db, random}) => {
 	// TODO delete entities here
 
 	// delete spaces except the home space
-	await Promise.all(
-		filteredSpaces
-			.filter((s) => !isHomeSpace(s))
-			.map(async (space) =>
-				unwrap(
-					await DeleteSpaceService.perform({
-						params: {space_id: space.space_id},
-						...serviceRequest,
-					}),
-				),
-			),
-	);
+	for (const space of filteredSpaces) {
+		if (!isHomeSpace(space)) {
+			unwrap(
+				// eslint-disable-next-line no-await-in-loop
+				await DeleteSpaceService.perform({
+					params: {space_id: space.space_id},
+					...serviceRequest,
+				}),
+			);
+		}
+	}
 	assert.is(unwrap(await db.repos.space.filterByCommunity(community.community_id)).length, 1);
 
 	// delete membership

--- a/src/lib/ui/EntityEditor.svelte
+++ b/src/lib/ui/EntityEditor.svelte
@@ -38,7 +38,7 @@
 	let deletePending = false;
 	const deleteEntity = async () => {
 		deletePending = true;
-		await dispatch.DeleteEntities({entity_ids: [$entity.entity_id]});
+		await dispatch.DeleteEntities({entityIds: [$entity.entity_id]});
 		deletePending = false;
 		done?.();
 	};

--- a/src/lib/ui/view/Todo.svelte
+++ b/src/lib/ui/view/Todo.svelte
@@ -70,8 +70,8 @@
 			return acc;
 		}, [] as Array<Readable<Entity>>);
 		if (!items?.length) return;
-		const entity_ids = items.map((i) => i.get().entity_id);
-		await dispatch.DeleteEntities({entity_ids});
+		const entityIds = items.map((i) => i.get().entity_id);
+		await dispatch.DeleteEntities({entityIds});
 		await dispatch.UpdateEntity({
 			data: null,
 			entity_id: $space.directory_id,

--- a/src/lib/util/randomEventParams.ts
+++ b/src/lib/util/randomEventParams.ts
@@ -121,7 +121,7 @@ export const randomEventParams: RandomEventParams = {
 		const entity1 = await random.entity(persona, account, community, space?.directory_id);
 		const entity2 = await random.entity(persona, account, community, space?.directory_id);
 		return {
-			entity_ids: [entity1.entity.entity_id, entity2.entity.entity_id],
+			entityIds: [entity1.entity.entity_id, entity2.entity.entity_id],
 		};
 	},
 	CreateTie: async (random, {account, persona, community, space} = {}) => {

--- a/src/lib/vocab/entity/EntityRepo.ts
+++ b/src/lib/vocab/entity/EntityRepo.ts
@@ -76,6 +76,7 @@ export class EntityRepo extends PostgresRepo {
 			DELETE FROM entities WHERE entity_id IN ${this.db.sql(entity_ids)}
 		`;
 		if (!data.count) return NOT_OK;
+		if (data.count !== entity_ids.length) return NOT_OK;
 		return OK;
 	}
 

--- a/src/lib/vocab/entity/EntityRepo.ts
+++ b/src/lib/vocab/entity/EntityRepo.ts
@@ -78,4 +78,15 @@ export class EntityRepo extends PostgresRepo {
 		if (!data.count) return NOT_OK;
 		return OK;
 	}
+
+	//This function finds all non-directory entities with no ties pointing to them & returns an array of their ids
+	async findOrphanedEntities(): Promise<Result<{value: number[]}>> {
+		const data = await this.db.sql<Entity[]>`
+			SELECT entity_id FROM entities e
+			LEFT JOIN ties t
+			ON e.entity_id = t.dest_id
+			WHERE e.data->>'space_id' IS NULL AND t.dest_id IS NULL;
+		`;
+		return {ok: true, value: data.flatMap((e) => e.entity_id)};
+	}
 }

--- a/src/lib/vocab/entity/entityEvents.ts
+++ b/src/lib/vocab/entity/entityEvents.ts
@@ -181,18 +181,18 @@ export const DeleteEntities: ServiceEventInfo = {
 		$id: '/schemas/DeleteEntitiesParams.json',
 		type: 'object',
 		properties: {
-			entity_ids: {type: 'array', items: {type: 'number'}},
+			entityIds: {type: 'array', items: {type: 'number'}},
 		},
-		required: ['entity_ids'],
+		required: ['entityIds'],
 		additionalProperties: false,
 	},
 	response: {
 		$id: '/schemas/DeleteEntitiesResponse.json',
 		type: 'object',
 		properties: {
-			removed_entity_ids: {type: 'array', items: {type: 'number'}},
+			deletedEntityIds: {type: 'array', items: {type: 'number'}},
 		},
-		required: ['removed_entity_ids'],
+		required: ['deletedEntityIds'],
 		additionalProperties: false,
 	},
 	returns: 'Promise<DeleteEntitiesResponseResult>',

--- a/src/lib/vocab/entity/entityEvents.ts
+++ b/src/lib/vocab/entity/entityEvents.ts
@@ -188,7 +188,12 @@ export const DeleteEntities: ServiceEventInfo = {
 	},
 	response: {
 		$id: '/schemas/DeleteEntitiesResponse.json',
-		type: 'null',
+		type: 'object',
+		properties: {
+			removed_entity_ids: {type: 'array', items: {type: 'number'}},
+		},
+		required: ['removed_entity_ids'],
+		additionalProperties: false,
 	},
 	returns: 'Promise<DeleteEntitiesResponseResult>',
 	route: {

--- a/src/lib/vocab/entity/entityMutations.ts
+++ b/src/lib/vocab/entity/entityMutations.ts
@@ -38,19 +38,21 @@ export const EraseEntities: Mutations['EraseEntities'] = async ({invoke, ui}) =>
 	return result;
 };
 
-export const DeleteEntities: Mutations['DeleteEntities'] = async ({invoke, params, ui}) => {
+export const DeleteEntities: Mutations['DeleteEntities'] = async ({invoke, ui}) => {
 	const result = await invoke();
 	if (!result.ok) return result;
-	const {entity_ids} = params;
-	for (const entity_id of entity_ids) {
+	const {removed_entity_ids} = result.value;
+	for (const entity_id of removed_entity_ids) {
 		deleteEntity(ui, entity_id);
 	}
 
 	//TODO extract all this to a helper sibling like updateEntityCaches
 	for (const spaceEntities of ui.entitiesBySourceId.values()) {
 		// TODO this is very inefficient
-		if (spaceEntities.get().find((e) => entity_ids.includes(e.get().entity_id))) {
-			spaceEntities.update(($s) => $s.filter(($e) => !entity_ids.includes($e.get().entity_id)));
+		if (spaceEntities.get().find((e) => removed_entity_ids.includes(e.get().entity_id))) {
+			spaceEntities.update(($s) =>
+				$s.filter(($e) => !removed_entity_ids.includes($e.get().entity_id)),
+			);
 		}
 	}
 

--- a/src/lib/vocab/entity/entityMutations.ts
+++ b/src/lib/vocab/entity/entityMutations.ts
@@ -41,17 +41,17 @@ export const EraseEntities: Mutations['EraseEntities'] = async ({invoke, ui}) =>
 export const DeleteEntities: Mutations['DeleteEntities'] = async ({invoke, ui}) => {
 	const result = await invoke();
 	if (!result.ok) return result;
-	const {removed_entity_ids} = result.value;
-	for (const entity_id of removed_entity_ids) {
+	const {deletedEntityIds} = result.value;
+	for (const entity_id of deletedEntityIds) {
 		deleteEntity(ui, entity_id);
 	}
 
 	//TODO extract all this to a helper sibling like updateEntityCaches
 	for (const spaceEntities of ui.entitiesBySourceId.values()) {
 		// TODO this is very inefficient
-		if (spaceEntities.get().find((e) => removed_entity_ids.includes(e.get().entity_id))) {
+		if (spaceEntities.get().find((e) => deletedEntityIds.includes(e.get().entity_id))) {
 			spaceEntities.update(($s) =>
-				$s.filter(($e) => !removed_entity_ids.includes($e.get().entity_id)),
+				$s.filter(($e) => !deletedEntityIds.includes($e.get().entity_id)),
 			);
 		}
 	}

--- a/src/lib/vocab/entity/entityServices.test.ts
+++ b/src/lib/vocab/entity/entityServices.test.ts
@@ -6,7 +6,10 @@ import {setupDb, teardownDb, type TestDbContext} from '$lib/util/testDbHelpers';
 import type {TestAppContext} from '$lib/util/testAppHelpers';
 import type {NoteEntityData} from '$lib/vocab/entity/entityData';
 import {toServiceRequest} from '$lib/util/testHelpers';
-import {ReadEntitiesPaginatedService} from '$lib/vocab/entity/entityServices';
+import {
+	ReadEntitiesPaginatedService,
+	DeleteEntitiesService,
+} from '$lib/vocab/entity/entityServices';
 import {DEFAULT_PAGE_SIZE} from '$lib/server/constants';
 import {validateSchema} from '$lib/util/ajv';
 
@@ -129,6 +132,41 @@ test_entityServices('assert default as max pageSize', async ({random}) => {
 
 	const validateParams = validateSchema(ReadEntitiesPaginatedService.event.params);
 	assert.ok(!validateParams({source_id: space.directory_id, pageSize: DEFAULT_PAGE_SIZE + 1}));
+});
+
+test_entityServices('deleting entities and cleaning orphans', async ({random, db}) => {
+	const {space, persona, account, community} = await random.space();
+	const serviceRequest = toServiceRequest(account.account_id, db);
+	//generate a collection with 3 notes
+	const {entity: list} = await random.entity(persona, account, community, space.directory_id, {
+		data: {type: 'Collection', name: `grocery list`},
+	});
+	const {entity: todo1} = await random.entity(persona, account, community, space.directory_id, {
+		source_id: list.entity_id,
+		data: {type: 'Note', content: `eggs`},
+	});
+	const {entity: todo2} = await random.entity(persona, account, community, space.directory_id, {
+		source_id: list.entity_id,
+		data: {type: 'Note', content: `bread`},
+	});
+	const {entity: todo3} = await random.entity(persona, account, community, space.directory_id, {
+		source_id: list.entity_id,
+		data: {type: 'Note', content: `milk`},
+	});
+	//delete the collection
+	const result = unwrap(
+		await DeleteEntitiesService.perform({
+			params: {
+				entity_ids: [list.entity_id],
+			},
+			...serviceRequest,
+		}),
+	);
+	//confirm all four entity ids come back
+	assert.ok(result.removed_entity_ids.includes(list.entity_id));
+	assert.ok(result.removed_entity_ids.includes(todo1.entity_id));
+	assert.ok(result.removed_entity_ids.includes(todo2.entity_id));
+	assert.ok(result.removed_entity_ids.includes(todo3.entity_id));
 });
 
 test_entityServices.run();

--- a/src/lib/vocab/entity/entityServices.test.ts
+++ b/src/lib/vocab/entity/entityServices.test.ts
@@ -157,16 +157,17 @@ test_entityServices('deleting entities and cleaning orphans', async ({random, db
 	const result = unwrap(
 		await DeleteEntitiesService.perform({
 			params: {
-				entity_ids: [list.entity_id],
+				entityIds: [list.entity_id],
 			},
 			...serviceRequest,
 		}),
 	);
 	//confirm all four entity ids come back
-	assert.ok(result.removed_entity_ids.includes(list.entity_id));
-	assert.ok(result.removed_entity_ids.includes(todo1.entity_id));
-	assert.ok(result.removed_entity_ids.includes(todo2.entity_id));
-	assert.ok(result.removed_entity_ids.includes(todo3.entity_id));
+	assert.equal(result.deletedEntityIds.length, 4);
+	assert.ok(result.deletedEntityIds.includes(list.entity_id));
+	assert.ok(result.deletedEntityIds.includes(todo1.entity_id));
+	assert.ok(result.deletedEntityIds.includes(todo2.entity_id));
+	assert.ok(result.deletedEntityIds.includes(todo3.entity_id));
 });
 
 test_entityServices.run();

--- a/src/lib/vocab/entity/entityServices.ts
+++ b/src/lib/vocab/entity/entityServices.ts
@@ -113,12 +113,12 @@ export const EraseEntitiesService: ServiceByName['EraseEntities'] = {
 export const DeleteEntitiesService: ServiceByName['DeleteEntities'] = {
 	event: DeleteEntities,
 	perform: async ({repos, params}) => {
-		const removed_entity_ids: number[] = [];
-		const result = await repos.entity.deleteByIds(params.entity_ids);
+		const deletedEntityIds: number[] = [];
+		const result = await repos.entity.deleteByIds(params.entityIds);
 		if (!result.ok) {
 			return {ok: false, status: 500, message: 'failed to delete entity'};
 		}
-		removed_entity_ids.push(...params.entity_ids);
+		deletedEntityIds.push(...params.entityIds);
 
 		let noOrphans = false;
 		while (!noOrphans) {
@@ -129,14 +129,14 @@ export const DeleteEntitiesService: ServiceByName['DeleteEntities'] = {
 			if (orphans.value.length === 0) {
 				noOrphans = true;
 			} else {
-				const removedOrphans = await repos.entity.deleteByIds(orphans.value); // eslint-disable-line no-await-in-loop
-				if (!removedOrphans.ok) {
-					return {ok: false, status: 500, message: 'failed to cleanup orphans'};
+				const deletedOrphans = await repos.entity.deleteByIds(orphans.value); // eslint-disable-line no-await-in-loop
+				if (!deletedOrphans.ok) {
+					return {ok: false, status: 500, message: 'failed to delete orphans'};
 				}
-				removed_entity_ids.push(...orphans.value);
+				deletedEntityIds.push(...orphans.value);
 			}
 		}
 
-		return {ok: true, status: 200, value: {removed_entity_ids}};
+		return {ok: true, status: 200, value: {deletedEntityIds}};
 	},
 };

--- a/src/lib/vocab/membership/membershipServices.ts
+++ b/src/lib/vocab/membership/membershipServices.ts
@@ -90,7 +90,7 @@ const cleanOrphanCommunities = async (community_id: number, repos: Database['rep
 		log.trace('[membershipServices] no memberships found, cleaning up', community_id);
 		const cleanupResult = await repos.community.deleteById(community_id);
 		if (cleanupResult.ok) {
-			log.trace('[membershipServices] orphan community successfully removed', community_id);
+			log.trace('[membershipServices] orphan community successfully deleted', community_id);
 		} else {
 			log.trace('[membershipServices] issue deleting orphaned community', community_id);
 		}

--- a/src/lib/vocab/space/spaceEvents.ts
+++ b/src/lib/vocab/space/spaceEvents.ts
@@ -143,6 +143,7 @@ export const DeleteSpace: ServiceEventInfo = {
 			removed_entity_ids: {type: 'array', items: {type: 'number'}},
 		},
 		required: ['removed_entity_ids'],
+		additionalProperties: false,
 	},
 	returns: 'Promise<DeleteSpaceResponseResult>',
 	route: {

--- a/src/lib/vocab/space/spaceEvents.ts
+++ b/src/lib/vocab/space/spaceEvents.ts
@@ -139,7 +139,10 @@ export const DeleteSpace: ServiceEventInfo = {
 	},
 	response: {
 		$id: '/schemas/DeleteSpaceResponse.json',
-		type: 'null',
+		properties: {
+			removed_entity_ids: {type: 'array', items: {type: 'number'}},
+		},
+		required: ['removed_entity_ids'],
 	},
 	returns: 'Promise<DeleteSpaceResponseResult>',
 	route: {

--- a/src/lib/vocab/space/spaceEvents.ts
+++ b/src/lib/vocab/space/spaceEvents.ts
@@ -140,9 +140,9 @@ export const DeleteSpace: ServiceEventInfo = {
 	response: {
 		$id: '/schemas/DeleteSpaceResponse.json',
 		properties: {
-			removed_entity_ids: {type: 'array', items: {type: 'number'}},
+			deletedEntityIds: {type: 'array', items: {type: 'number'}},
 		},
-		required: ['removed_entity_ids'],
+		required: ['deletedEntityIds'],
 		additionalProperties: false,
 	},
 	returns: 'Promise<DeleteSpaceResponseResult>',

--- a/src/lib/vocab/space/spaceMutations.ts
+++ b/src/lib/vocab/space/spaceMutations.ts
@@ -36,6 +36,7 @@ export const DeleteSpace: Mutations['DeleteSpace'] = async ({params, invoke, ui}
 	const space = spaceById.get(space_id)!;
 	const $space = space.get();
 	const {community_id} = $space;
+	const {removed_entity_ids} = result.value;
 
 	// If the deleted space is selected, select the home space as a fallback.
 	if (space_id === spaceIdSelectionByCommunityId.get().value.get(community_id)) {
@@ -56,7 +57,9 @@ export const DeleteSpace: Mutations['DeleteSpace'] = async ({params, invoke, ui}
 
 	spaceById.delete(space_id);
 	spaces.mutate(($spaces) => $spaces.splice($spaces.indexOf(space), 1));
-	deleteEntity(ui, $space.directory_id);
+	for (const entity_id of removed_entity_ids) {
+		deleteEntity(ui, entity_id);
+	}
 
 	return result;
 };

--- a/src/lib/vocab/space/spaceMutations.ts
+++ b/src/lib/vocab/space/spaceMutations.ts
@@ -36,7 +36,7 @@ export const DeleteSpace: Mutations['DeleteSpace'] = async ({params, invoke, ui}
 	const space = spaceById.get(space_id)!;
 	const $space = space.get();
 	const {community_id} = $space;
-	const {removed_entity_ids} = result.value;
+	const {deletedEntityIds} = result.value;
 
 	// If the deleted space is selected, select the home space as a fallback.
 	if (space_id === spaceIdSelectionByCommunityId.get().value.get(community_id)) {
@@ -57,7 +57,7 @@ export const DeleteSpace: Mutations['DeleteSpace'] = async ({params, invoke, ui}
 
 	spaceById.delete(space_id);
 	spaces.mutate(($spaces) => $spaces.splice($spaces.indexOf(space), 1));
-	for (const entity_id of removed_entity_ids) {
+	for (const entity_id of deletedEntityIds) {
 		deleteEntity(ui, entity_id);
 	}
 

--- a/src/lib/vocab/space/spaceServices.ts
+++ b/src/lib/vocab/space/spaceServices.ts
@@ -18,6 +18,7 @@ import type {ErrorResponse} from '$lib/util/error';
 import {toDefaultSpaces} from '$lib/vocab/space/defaultSpaces';
 import type {DirectoryEntityData} from '../entity/entityData';
 import type {Entity} from '$lib/vocab/entity/entity';
+import {DeleteEntitiesService} from '$lib/vocab/entity/entityServices';
 
 const log = new Logger(gray('[') + blue('spaceServices') + gray(']'));
 
@@ -138,9 +139,10 @@ export const UpdateSpaceService: ServiceByName['UpdateSpace'] = {
 //deletes a single space
 export const DeleteSpaceService: ServiceByName['DeleteSpace'] = {
 	event: DeleteSpace,
-	perform: async ({repos, params}) => {
+	perform: async (serviceRequest) => {
+		const {repos, params} = serviceRequest;
 		log.trace('[DeleteSpace] deleting space with id:', params.space_id);
-
+		const removed_entity_ids: number[] = [];
 		// Check that the space can be deleted.
 		const findSpaceResult = await repos.space.findById(params.space_id);
 		if (!findSpaceResult.ok) {
@@ -157,7 +159,24 @@ export const DeleteSpaceService: ServiceByName['DeleteSpace'] = {
 			log.trace('[DeleteSpace] error removing space: ', params.space_id);
 			return {ok: false, status: 500, message: 'failed to delete space'};
 		}
-		return {ok: true, status: 200, value: null};
+
+		removed_entity_ids.push(space.directory_id);
+		const orphanedEntities = await DeleteEntitiesService.perform({
+			...serviceRequest,
+			params: {entity_ids: [space.directory_id]},
+		});
+
+		if (!orphanedEntities.ok) {
+			log.trace('[DeleteSpace] error cleaning up space entities: ', params.space_id);
+			return {
+				ok: false,
+				status: 500,
+				message: `failed to clean up space entities; ${orphanedEntities.message}`,
+			};
+		}
+		removed_entity_ids.push(...orphanedEntities.value.removed_entity_ids);
+
+		return {ok: true, status: 200, value: {removed_entity_ids}};
 	},
 };
 

--- a/src/lib/vocab/space/spaceServices.ts
+++ b/src/lib/vocab/space/spaceServices.ts
@@ -142,7 +142,7 @@ export const DeleteSpaceService: ServiceByName['DeleteSpace'] = {
 	perform: async (serviceRequest) => {
 		const {repos, params} = serviceRequest;
 		log.trace('[DeleteSpace] deleting space with id:', params.space_id);
-		const removed_entity_ids: number[] = [];
+		const deletedEntityIds: number[] = [];
 		// Check that the space can be deleted.
 		const findSpaceResult = await repos.space.findById(params.space_id);
 		if (!findSpaceResult.ok) {
@@ -160,10 +160,10 @@ export const DeleteSpaceService: ServiceByName['DeleteSpace'] = {
 			return {ok: false, status: 500, message: 'failed to delete space'};
 		}
 
-		removed_entity_ids.push(space.directory_id);
+		deletedEntityIds.push(space.directory_id);
 		const orphanedEntities = await DeleteEntitiesService.perform({
 			...serviceRequest,
-			params: {entity_ids: [space.directory_id]},
+			params: {entityIds: [space.directory_id]},
 		});
 
 		if (!orphanedEntities.ok) {
@@ -174,9 +174,9 @@ export const DeleteSpaceService: ServiceByName['DeleteSpace'] = {
 				message: `failed to clean up space entities; ${orphanedEntities.message}`,
 			};
 		}
-		removed_entity_ids.push(...orphanedEntities.value.removed_entity_ids);
+		deletedEntityIds.push(...orphanedEntities.value.deletedEntityIds);
 
-		return {ok: true, status: 200, value: {removed_entity_ids}};
+		return {ok: true, status: 200, value: {deletedEntityIds}};
 	},
 };
 


### PR DESCRIPTION
This PR adds a query to find any orphaned entities & then makes a call to delete them when deleting other entities.

Additional work:
- [x] figure out the async in loop issue
- [x] add tests
- [x] check in on directories when space gets deleted
- [x] add all deleted entities to result set for client side event culling
- [x] add check to deleteEntitiesById to compare # input with # deleted, throw error if mismatch