### PR TITLE
tweak a loop for subjective readability

### DIFF
--- a/src/lib/vocab/entity/entityServices.ts
+++ b/src/lib/vocab/entity/entityServices.ts
@@ -120,7 +120,7 @@ export const DeleteEntitiesService: ServiceByName['DeleteEntities'] = {
 		}
 		deletedEntityIds.push(...params.entityIds);
 
-		// Loop until all orphans are deleted because deleting one entity may orphan others.
+		// Deleting one entity may orphan others, so loop until there are no more orphans.
 		while (true) {
 			const orphans = await repos.entity.findOrphanedEntities(); // eslint-disable-line no-await-in-loop
 			if (!orphans.ok) {

--- a/src/lib/vocab/entity/entityServices.ts
+++ b/src/lib/vocab/entity/entityServices.ts
@@ -120,6 +120,7 @@ export const DeleteEntitiesService: ServiceByName['DeleteEntities'] = {
 		}
 		deletedEntityIds.push(...params.entityIds);
 
+		// Loop until all orphans are deleted because deleting one entity may orphan others.
 		while (true) {
 			const orphans = await repos.entity.findOrphanedEntities(); // eslint-disable-line no-await-in-loop
 			if (!orphans.ok) {

--- a/src/lib/vocab/entity/entityServices.ts
+++ b/src/lib/vocab/entity/entityServices.ts
@@ -120,21 +120,19 @@ export const DeleteEntitiesService: ServiceByName['DeleteEntities'] = {
 		}
 		deletedEntityIds.push(...params.entityIds);
 
-		let noOrphans = false;
-		while (!noOrphans) {
+		while (true) {
 			const orphans = await repos.entity.findOrphanedEntities(); // eslint-disable-line no-await-in-loop
 			if (!orphans.ok) {
 				return {ok: false, status: 500, message: 'failed to find orphans'};
 			}
 			if (orphans.value.length === 0) {
-				noOrphans = true;
-			} else {
-				const deletedOrphans = await repos.entity.deleteByIds(orphans.value); // eslint-disable-line no-await-in-loop
-				if (!deletedOrphans.ok) {
-					return {ok: false, status: 500, message: 'failed to delete orphans'};
-				}
-				deletedEntityIds.push(...orphans.value);
+				break;
 			}
+			const deletedOrphans = await repos.entity.deleteByIds(orphans.value); // eslint-disable-line no-await-in-loop
+			if (!deletedOrphans.ok) {
+				return {ok: false, status: 500, message: 'failed to delete orphans'};
+			}
+			deletedEntityIds.push(...orphans.value);
 		}
 
 		return {ok: true, status: 200, value: {deletedEntityIds}};


### PR DESCRIPTION
Feel free to reject, this is a no-op that rewrites a loop to be more readable IMO but it's subjective. My reasoning is that it doesn't need to track a state var, and doesn't need the `if` nesting. The `while (true) {` pattern doesn't always work but I usually prefer it when possible.