### PR TITLE
rename post name to title

### DIFF
--- a/src/lib/ui/EntityInput.svelte
+++ b/src/lib/ui/EntityInput.svelte
@@ -73,7 +73,7 @@
 	<h1>New {entityName}</h1>
 	<form>
 		<input
-			placeholder="> name"
+			placeholder="> title"
 			bind:this={nameEl}
 			bind:value={name}
 			use:autofocus


### PR DESCRIPTION
(never mind, closing this for now, `name` makes sense for a generic `EntityInput`)

The user-facing concept for board `post.name` is probably `title`? Seems ok to keep `content`.

However since this is an `EntityInput`, `name` is probably more correct. Maybe we need to separate `BoardPostInput` and `TodoInput`?