### PR TITLE
Use localStore for managing luggage & marquee state

### DIFF
--- a/src/lib/ui/ui.ts
+++ b/src/lib/ui/ui.ts
@@ -19,7 +19,7 @@ import type {Membership} from '$lib/vocab/membership/membership';
 import {createContextmenuStore, type ContextmenuStore} from '$lib/ui/contextmenu/contextmenu';
 import {initBrowser} from '$lib/ui/init';
 import {isHomeSpace} from '$lib/vocab/space/spaceHelpers';
-import {locallyStoredMap} from '$lib/ui/locallyStored';
+import {locallyStored, locallyStoredMap} from '$lib/ui/locallyStored';
 import type {Tie} from '$lib/vocab/tie/tie';
 
 if (browser) initBrowser();
@@ -228,8 +228,8 @@ export const toUi = (
 	const sourceTiesByDestEntityId: Mutable<Map<number, Mutable<Tie[]>>> = mutable(new Map());
 	const destTiesBySourceEntityId: Mutable<Map<number, Mutable<Tie[]>>> = mutable(new Map());
 
-	const expandMainNav = writable(!initialMobile);
-	const expandMarquee = writable(!initialMobile);
+	const expandMainNav = locallyStored(writable(!initialMobile), 'expandMainNav');
+	const expandMarquee = locallyStored(writable(!initialMobile), 'expandMarquee');
 
 	return {
 		// db data


### PR DESCRIPTION
This PR adds localStores around the luggage & marquee state stores in UI.

As an aside, I'm not sure if this is just a local dev thing, but there's some noticeable pop-in on the elements before collapse when saved as collapsed. Any thoughts?